### PR TITLE
refactor: separate scrypt config for different environments

### DIFF
--- a/ext/src/modules/background-message-controller.ts
+++ b/ext/src/modules/background-message-controller.ts
@@ -20,7 +20,7 @@ import {
 } from '@shared/types/IBackgroundCaller';
 
 import { getDeviceID } from '@shared/modules/device-id';
-import { decrypt, encrypt } from '@shared/modules/encryption';
+import { decrypt, encrypt } from '../modules/encryption';
 
 import { LayerzStorage } from '../class/layerz-storage';
 import { EvmWallet } from '@shared/class/evm-wallet';

--- a/ext/src/modules/encryption.ts
+++ b/ext/src/modules/encryption.ts
@@ -1,0 +1,12 @@
+import { decrypt as decryptRaw, encrypt as encryptRaw, IScryptConfig } from '@shared/modules/encryption';
+import { ICsprng } from '@shared/types/ICsprng';
+
+const extScryptConfig: IScryptConfig = { N: 2 ** 17, r: 8, p: 1, dkLen: 32 };
+
+export async function encrypt(csprng: ICsprng, plaintext: string, password: string, saltValue: string): Promise<string> {
+  return await encryptRaw(extScryptConfig, csprng, plaintext, password, saltValue);
+}
+
+export async function decrypt(encryptedData: string, password: string, saltValue: string): Promise<string> {
+  return await decryptRaw(extScryptConfig, encryptedData, password, saltValue);
+}

--- a/ext/src/pages/Popup/ActionComponents/SendTransaction.tsx
+++ b/ext/src/pages/Popup/ActionComponents/SendTransaction.tsx
@@ -9,7 +9,7 @@ import { BackgroundCaller } from '../../../modules/background-caller';
 import { Messenger } from '@shared/modules/messenger';
 import { Button, HodlButton, SelectFeeSlider } from '../DesignSystem';
 import assert from 'assert';
-import { decrypt } from '@shared/modules/encryption';
+import { decrypt } from '../../../modules/encryption';
 import { getDeviceID } from '@shared/modules/device-id';
 import { StringNumber } from '@shared/types/string-number';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';

--- a/ext/src/pages/Popup/SendArk.tsx
+++ b/ext/src/pages/Popup/SendArk.tsx
@@ -10,7 +10,7 @@ import BigNumber from 'bignumber.js';
 import assert from 'assert';
 import { AskPasswordContext } from '../../hooks/AskPasswordContext';
 import { useNavigate } from 'react-router-dom';
-import { decrypt } from '@shared/modules/encryption';
+import { decrypt } from '../../modules/encryption';
 import { getDeviceID } from '@shared/modules/device-id';
 import { ArkWallet } from '@shared/class/wallets/ark-wallet';
 import { formatBalance } from '@shared/modules/string-utils';

--- a/ext/src/pages/Popup/SendBtc.tsx
+++ b/ext/src/pages/Popup/SendBtc.tsx
@@ -17,7 +17,7 @@ import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { BackgroundCaller } from '../../modules/background-caller';
 import { getDeviceID } from '@shared/modules/device-id';
-import { decrypt } from '@shared/modules/encryption';
+import { decrypt } from '../../modules/encryption';
 import { Button, HodlButton, Input, Modal, RadioButton, WideButton } from './DesignSystem';
 import ClipboardBackdoor from './components/ClipboardBackdoor';
 import { formatBalance } from '@shared/modules/string-utils';

--- a/ext/src/pages/Popup/SendEvm.tsx
+++ b/ext/src/pages/Popup/SendEvm.tsx
@@ -14,7 +14,7 @@ import { StringNumber } from '@shared/types/string-number';
 import { AskPasswordContext } from '../../hooks/AskPasswordContext';
 import { useNavigate } from 'react-router-dom';
 import { TransactionSuccessProps } from './TransactionSuccessEvm';
-import { decrypt } from '@shared/modules/encryption';
+import { decrypt } from '../../modules/encryption';
 import { getDeviceID } from '@shared/modules/device-id';
 import { formatBalance } from '@shared/modules/string-utils';
 import { ScanQrContext } from '../../hooks/ScanQrContext';

--- a/ext/src/pages/Popup/SendTokenEvm.tsx
+++ b/ext/src/pages/Popup/SendTokenEvm.tsx
@@ -14,7 +14,7 @@ import { StringNumber } from '@shared/types/string-number';
 import { AskPasswordContext } from '../../hooks/AskPasswordContext';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { TransactionSuccessProps } from './TransactionSuccessEvm';
-import { decrypt } from '@shared/modules/encryption';
+import { decrypt } from '../../modules/encryption';
 import { getDeviceID } from '@shared/modules/device-id';
 import { getTokenList } from '@shared/models/token-list';
 import { useTokenBalance } from '@shared/hooks/useTokenBalance';

--- a/ext/src/pages/Popup/SettingsPage.tsx
+++ b/ext/src/pages/Popup/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { decrypt, encrypt } from '@shared/modules/encryption';
+import { decrypt, encrypt } from '../../modules/encryption';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { Button, Select } from './DesignSystem';
 import * as BlueElectrum from '@shared/blue_modules/BlueElectrum';

--- a/mobile/app/SendArk.tsx
+++ b/mobile/app/SendArk.tsx
@@ -14,7 +14,7 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { getDeviceID } from '@shared/modules/device-id';
-import { decrypt } from '@shared/modules/encryption';
+import { decrypt } from '../src/modules/encryption';
 import { formatBalance } from '@shared/modules/string-utils';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
 import assert from 'assert';

--- a/mobile/app/SendBtc.tsx
+++ b/mobile/app/SendBtc.tsx
@@ -16,7 +16,7 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { getDeviceID } from '@shared/modules/device-id';
-import { decrypt } from '@shared/modules/encryption';
+import { decrypt } from '../src/modules/encryption';
 import { formatBalance } from '@shared/modules/string-utils';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
 import assert from 'assert';

--- a/mobile/app/SendEvm.tsx
+++ b/mobile/app/SendEvm.tsx
@@ -20,7 +20,7 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { getDeviceID } from '@shared/modules/device-id';
-import { decrypt } from '@shared/modules/encryption';
+import { decrypt } from '../src/modules/encryption';
 import { formatBalance } from '@shared/modules/string-utils';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
 import { NETWORK_BITCOIN } from '@shared/types/networks';

--- a/mobile/app/SendTokenEvm.tsx
+++ b/mobile/app/SendTokenEvm.tsx
@@ -23,7 +23,7 @@ import { useTokenBalance } from '@shared/hooks/useTokenBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { getTokenList } from '@shared/models/token-list';
 import { getDeviceID } from '@shared/modules/device-id';
-import { decrypt } from '@shared/modules/encryption';
+import { decrypt } from '../src/modules/encryption';
 import { formatBalance } from '@shared/modules/string-utils';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
 import { Networks } from '@shared/types/networks';

--- a/mobile/app/selftest.tsx
+++ b/mobile/app/selftest.tsx
@@ -3,7 +3,7 @@ import { Button, View } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import { EvmWallet } from '@shared/class/evm-wallet';
 import { HDSegwitBech32Wallet } from '@shared/class/wallets/hd-segwit-bech32-wallet';
-import { decrypt, encrypt } from '@shared/modules/encryption';
+import { decrypt, encrypt } from '../src/modules/encryption';
 import assert from 'assert';
 import { useState } from 'react';
 

--- a/mobile/src/modules/background-executor.ts
+++ b/mobile/src/modules/background-executor.ts
@@ -6,7 +6,7 @@ import { ArkWallet } from '@shared/class/wallets/ark-wallet';
 import { HDSegwitBech32Wallet } from '@shared/class/wallets/hd-segwit-bech32-wallet';
 import { WatchOnlyWallet } from '@shared/class/wallets/watch-only-wallet';
 import { getDeviceID } from '@shared/modules/device-id';
-import { encrypt } from '@shared/modules/encryption';
+import { encrypt } from '../modules/encryption';
 import {
   CreateMnemonicResponse,
   EncryptMnemonicResponse,

--- a/mobile/src/modules/encryption.ts
+++ b/mobile/src/modules/encryption.ts
@@ -1,0 +1,12 @@
+import { decrypt as decryptRaw, encrypt as encryptRaw, IScryptConfig } from '@shared/modules/encryption';
+import { ICsprng } from '@shared/types/ICsprng';
+
+const mobileScryptConfig: IScryptConfig = { N: 2 ** 11, r: 8, p: 1, dkLen: 32 };
+
+export async function encrypt(csprng: ICsprng, plaintext: string, password: string, saltValue: string): Promise<string> {
+  return await encryptRaw(mobileScryptConfig, csprng, plaintext, password, saltValue);
+}
+
+export async function decrypt(encryptedData: string, password: string, saltValue: string): Promise<string> {
+  return await decryptRaw(mobileScryptConfig, encryptedData, password, saltValue);
+}

--- a/shared/modules/encryption.ts
+++ b/shared/modules/encryption.ts
@@ -6,13 +6,23 @@ import * as aes from 'browserify-cipher';
 const createCipheriv = aes.createCipheriv;
 const createDecipheriv = aes.createDecipheriv;
 
-// cant use higher values, it becomes too slow in our pure-js environment
-const scryptConfig = { N: 2 ** 11, r: 8, p: 1, dkLen: 32 };
+export interface IScryptConfig {
+  N: number;    // CPU/memory cost parameter
+  r: number;    // Block size parameter
+  p: number;    // Parallelization parameter
+  dkLen: number; // Desired key length in bytes
+}
 
 /**
  * @see https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
  */
-export async function encrypt(csprng: ICsprng, plaintext: string, password: string, saltValue: string): Promise<string> {
+export async function encrypt(
+  scryptConfig: IScryptConfig,
+  csprng: ICsprng,
+  plaintext: string,
+  password: string,
+  saltValue: string,
+): Promise<string> {
   const derivedKey = (await scryptAsync(normalizeString(password), saltValue, scryptConfig)) as Uint8Array;
   const initializationVector = await csprng.randomBytes(16);
   const encryptionCipher = createCipheriv('aes-256-gcm', derivedKey, initializationVector, { authTagLength: 16 });
@@ -25,8 +35,12 @@ export async function encrypt(csprng: ICsprng, plaintext: string, password: stri
   return [uint8ArrayToHex(initializationVector), authenticationTag.toString('hex'), ciphertextHex].join(':');
 }
 
-
-export async function decrypt(encryptedData: string, password: string, saltValue: string): Promise<string> {
+export async function decrypt(
+  scryptConfig: IScryptConfig,
+  encryptedData: string,
+  password: string,
+  saltValue: string
+): Promise<string> {
   let initializationVectorHex: string, authenticationTagHex: string, ciphertextHex: string;
 
   // Parse cryptogram string in format <InitializationVector>:<AuthenticationTag>:<Ciphertext>

--- a/shared/tests/unit-vi/encryption.test.ts
+++ b/shared/tests/unit-vi/encryption.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from 'vitest';
 import { ICsprng } from '../../types/ICsprng';
-import { decrypt, encrypt } from '../../modules/encryption';
+import { decrypt, encrypt, IScryptConfig } from '../../modules/encryption';
 const assert = require('assert');
+
+const scryptConfig: IScryptConfig = { N: 2 ** 10, r: 8, p: 1, dkLen: 32 };
 
 describe('unit - encryption', function () {
   it('encrypts and decrypts', async function () {
@@ -9,8 +11,8 @@ describe('unit - encryption', function () {
       randomBytes: async (length: number) => new Uint8Array(length).fill(0)
     };
     const data2encrypt = 'really long data string bla bla really long data string bla bla really long data string bla bla';
-    const crypted = await encrypt(rng, data2encrypt, 'password', '53B63311-D2D5-4C62-9F7F-28F25447B825');
-    const decrypted = await decrypt(crypted, 'password', '53B63311-D2D5-4C62-9F7F-28F25447B825');
+    const crypted = await encrypt(scryptConfig, rng, data2encrypt, 'password', '53B63311-D2D5-4C62-9F7F-28F25447B825');
+    const decrypted = await decrypt(scryptConfig, crypted, 'password', '53B63311-D2D5-4C62-9F7F-28F25447B825');
 
     assert.ok(crypted);
     assert.ok(decrypted);
@@ -19,7 +21,7 @@ describe('unit - encryption', function () {
 
     let decryptedWithBadPassword;
     try {
-      decryptedWithBadPassword = await decrypt(crypted, 'passwordBad', '53B63311-D2D5-4C62-9F7F-28F25447B825');
+      decryptedWithBadPassword = await decrypt(scryptConfig, crypted, 'passwordBad', '53B63311-D2D5-4C62-9F7F-28F25447B825');
     } catch (e) {}
     assert.ok(!decryptedWithBadPassword);
   });


### PR DESCRIPTION
i was thinking about making some different configs or constants for different environments, but in the end opted in for the dumbest approach. the reason for this is that its bulletproof, easy to audit, hard to break, and it will never ever change in the app in production