### PR TITLE
refactor: background caller types

### DIFF
--- a/ext/src/modules/background-caller.ts
+++ b/ext/src/modules/background-caller.ts
@@ -1,28 +1,6 @@
 import { Messenger } from '@shared/modules/messenger';
-import {
-  CreateMnemonicResponse,
-  EncryptMnemonicRequest,
-  EncryptMnemonicResponse,
-  GetBtcBalanceRequest,
-  GetBtcBalanceResponse,
-  GetBtcSendDataRequest,
-  GetBtcSendDataResponse,
-  GetLiquidBalanceResponse,
-  GetLiquidSendDataRequest,
-  GetLiquidSendDataResponse,
-  IBackgroundCaller,
-  LogRequest,
-  MessageType,
-  ProcessRPCRequest,
-  SaveMnemonicRequest,
-  SaveMnemonicResponse,
-  SignPersonalMessageRequest,
-  SignPersonalMessageResponse,
-  SignTypedDataRequest,
-  SignTypedDataResponse,
-} from '@shared/types/IBackgroundCaller';
+import { GetBtcSendDataResponse, GetLiquidSendDataResponse, IBackgroundCaller, MessageType } from '@shared/types/IBackgroundCaller';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
-import { Networks } from '@shared/types/networks';
 import { LayerzStorage } from '../class/layerz-storage';
 import { SecureStorage } from '../class/secure-storage';
 
@@ -34,60 +12,45 @@ const STORAGE_KEY_ACCEPTED_TOS = 'STORAGE_KEY_ACCEPTED_TOS';
  * in an isolated context for security. Communication is handled via the `Messenger` service
  */
 export const BackgroundCaller: IBackgroundCaller = {
-  async getAddress(network: Networks, accountNumber: number): Promise<string> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.GET_ADDRESS,
-      network,
-      accountNumber,
-    });
+  async getAddress(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.GET_ADDRESS, params);
   },
 
-  async acceptTermsOfService(): Promise<void> {
+  async acceptTermsOfService() {
     await LayerzStorage.setItem(STORAGE_KEY_ACCEPTED_TOS, 'true');
   },
 
-  async hasAcceptedTermsOfService(): Promise<boolean> {
+  async hasAcceptedTermsOfService() {
     return !!(await LayerzStorage.getItem(STORAGE_KEY_ACCEPTED_TOS));
   },
 
-  async hasMnemonic(): Promise<boolean> {
+  async hasMnemonic() {
     const mnemonic = await SecureStorage.getItem(STORAGE_KEY_MNEMONIC);
     return !!mnemonic;
   },
 
-  async hasEncryptedMnemonic(): Promise<boolean> {
+  async hasEncryptedMnemonic() {
     const mnemonic = await SecureStorage.getItem(STORAGE_KEY_MNEMONIC);
     return !!mnemonic && mnemonic.startsWith(ENCRYPTED_PREFIX);
   },
 
-  async saveMnemonic(mnemonic: string): Promise<SaveMnemonicResponse> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.SAVE_MNEMONIC,
-      mnemonic,
-    } as SaveMnemonicRequest);
+  async saveMnemonic(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.SAVE_MNEMONIC, params);
   },
 
-  async createMnemonic(): Promise<CreateMnemonicResponse> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.CREATE_MNEMONIC,
-    });
+  async createMnemonic(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.CREATE_MNEMONIC, params);
   },
 
-  async encryptMnemonic(password: string): Promise<EncryptMnemonicResponse> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.ENCRYPT_MNEMONIC,
-      password,
-    } as EncryptMnemonicRequest);
+  async encryptMnemonic(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.ENCRYPT_MNEMONIC, params);
   },
 
-  async getBtcBalance(accountNumber: number): Promise<GetBtcBalanceResponse> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.GET_BTC_BALANCE,
-      accountNumber,
-    } as GetBtcBalanceRequest);
+  async getBtcBalance(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.GET_BTC_BALANCE, params);
   },
 
-  async whitelistDapp(dapp: string): Promise<void> {
+  async whitelistDapp(dapp) {
     let whitelist: string[] = [];
     try {
       whitelist = JSON.parse(await LayerzStorage.getItem(STORAGE_KEY_WHITELIST));
@@ -100,11 +63,11 @@ export const BackgroundCaller: IBackgroundCaller = {
     } catch (_) {}
   },
 
-  async unwhitelistDapp(dapp: string): Promise<void> {
+  async unwhitelistDapp(dapp: string) {
     alert('Implement me'); // todo
   },
 
-  async getWhitelist(): Promise<string[]> {
+  async getWhitelist() {
     try {
       return JSON.parse(await LayerzStorage.getItem(STORAGE_KEY_WHITELIST)) || [];
     } catch (_) {
@@ -112,61 +75,31 @@ export const BackgroundCaller: IBackgroundCaller = {
     }
   },
 
-  async log(data: string): Promise<void> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.LOG,
-      data,
-    } as LogRequest);
+  async log(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.LOG, params);
   },
 
-  async signPersonalMessage(message: string | Uint8Array, accountNumber: number, password: string): Promise<SignPersonalMessageResponse> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.SIGN_PERSONAL_MESSAGE,
-      accountNumber,
-      message,
-      password,
-    } as SignPersonalMessageRequest);
+  async signPersonalMessage(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.SIGN_PERSONAL_MESSAGE, params);
   },
 
-  async signTypedData(message: any, accountNumber: number, password: string): Promise<SignTypedDataResponse> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.SIGN_TYPED_DATA,
-      accountNumber,
-      message,
-      password,
-    } as SignTypedDataRequest);
+  async signTypedData(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.SIGN_TYPED_DATA, params);
   },
 
-  async openPopup(method: string, params: any, id: number, from: string): Promise<void> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.OPEN_POPUP,
-      method,
-      params,
-      id,
-      from,
-    } as ProcessRPCRequest);
+  async openPopup(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.OPEN_POPUP, params);
   },
 
-  async getBtcSendData(accountNumber: number): Promise<GetBtcSendDataResponse> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.GET_BTC_SEND_DATA,
-      accountNumber,
-    } as GetBtcSendDataRequest);
+  async getBtcSendData(...params): Promise<GetBtcSendDataResponse> {
+    return await Messenger.sendGenericMessageToBackground(MessageType.GET_BTC_SEND_DATA, params);
   },
 
-  async getLiquidBalance(network: Networks, accountNumber: number): Promise<GetLiquidBalanceResponse> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.GET_LIQUID_BALANCE,
-      network,
-      accountNumber,
-    } as GetBtcBalanceRequest);
+  async getLiquidBalance(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.GET_LIQUID_BALANCE, params);
   },
 
-  async getLiquidSendData(network: Networks, accountNumber: number): Promise<GetLiquidSendDataResponse> {
-    return await Messenger.sendGenericMessageToBackground({
-      type: MessageType.GET_LIQUID_SEND_DATA,
-      network,
-      accountNumber,
-    } as GetLiquidSendDataRequest);
+  async getLiquidSendData(...params): Promise<GetLiquidSendDataResponse> {
+    return await Messenger.sendGenericMessageToBackground(MessageType.GET_LIQUID_SEND_DATA, params);
   },
 };

--- a/ext/src/pages/Popup/OnboardingImportWallet.tsx
+++ b/ext/src/pages/Popup/OnboardingImportWallet.tsx
@@ -16,7 +16,7 @@ export default function OnboardingImport() {
   const handleSaveMnemonicSeed = async () => {
     const response = await BackgroundCaller.saveMnemonic(value);
 
-    if (!response.success) {
+    if (!response) {
       setError('Invalid mnemonic seed');
       return;
     } else {

--- a/ext/src/tests/unit-vi/background-message-controller.test.ts
+++ b/ext/src/tests/unit-vi/background-message-controller.test.ts
@@ -1,9 +1,9 @@
 import assert from 'assert';
-import { vi, afterEach, test, expect } from 'vitest';
-
+import { afterEach, expect, test, vi } from 'vitest';
+import { MessageType } from '@shared/types/IBackgroundCaller';
 import { BackgroundCaller } from '../../modules/background-caller';
-import { MessageType, ProcessRPCRequest, SaveMnemonicRequest, SaveMnemonicResponse } from '@shared/types/IBackgroundCaller';
 import { handleMessage } from '../../modules/background-message-controller';
+
 import CreateData = chrome.windows.CreateData;
 
 vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -29,16 +29,17 @@ test('BackgroundMessageController can handle messages SAVE_MNEMONIC', async () =
   const response2 = handleMessage(
     {
       type: MessageType.SAVE_MNEMONIC,
-      mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-    } as SaveMnemonicRequest,
+      params: ['abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'],
+    },
     {},
-    (response: SaveMnemonicResponse) => {
-      assert.strictEqual(response.success, true);
+    (response) => {
+      assert.strictEqual(response, true);
       handleMessageDone = true;
     }
   );
 
   while (!handleMessageDone) {
+    console.info('checking', handleMessageDone);
     await new Promise((resolve) => setTimeout(resolve, 500)); // sleep to allow callback to fire
   }
 
@@ -111,14 +112,20 @@ test('BackgroundMessageController can handle message OPEN_POPUP', async () => {
   handleMessage(
     {
       type: MessageType.OPEN_POPUP,
-      method: 'personal_sign',
-      params: ['0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765', '0xF5e61719675B46848572249b65DC6d9D83E7180A', 'Example password'],
-      id: 111,
-      from: 'metamask.github.io',
-    } as ProcessRPCRequest,
+      params: [
+        // method
+        'personal_sign',
+        // params
+        ['0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765', '0xF5e61719675B46848572249b65DC6d9D83E7180A', 'Example password'],
+        // id
+        111,
+        // from
+        'metamask.github.io',
+      ],
+    },
     // @ts-ignore not implementing full `Tab` type spec, need only `id`
     { tab: { id: 666 } },
-    (response) => {
+    () => {
       callbackCalled = true;
     }
   );

--- a/mobile/app/onboarding/import-wallet.tsx
+++ b/mobile/app/onboarding/import-wallet.tsx
@@ -23,7 +23,7 @@ export default function ImportWalletScreen() {
       await new Promise((resolve) => setTimeout(resolve, 200)); // propagate ui
       const response = await BackgroundExecutor.saveMnemonic(mnemonic.trim());
 
-      if (!response.success) {
+      if (!response) {
         setError('Invalid mnemonic seed');
       } else {
         router.replace('/onboarding/create-password');

--- a/shared/modules/messenger.ts
+++ b/shared/modules/messenger.ts
@@ -1,4 +1,5 @@
 import { Eip1193CustomEventCallback, Eip1193CustomEventResponse } from '../types/eip1193-custom-event';
+import { MessageTypeMap } from '../types/IBackgroundCaller';
 
 /**
  * Simple wrapper around few methods that shoot events. Mostly related to EIP-1193 and integrationwith EVM Dapps.
@@ -43,10 +44,11 @@ export const Messenger = {
     );
   },
 
-  async sendGenericMessageToBackground(message: any): Promise<any> {
+  sendGenericMessageToBackground<T extends keyof MessageTypeMap>(type: T, params: MessageTypeMap[T]['params']): Promise<MessageTypeMap[T]['response']> {
     return new Promise((resolve, reject) => {
       try {
-        chrome.runtime.sendMessage(message, async function (response) {
+        const message = { type, params };
+        chrome.runtime.sendMessage(message, (response) => {
           if (response?.error) {
             reject(new Error(response.message));
           } else {

--- a/shared/types/IBackgroundCaller.ts
+++ b/shared/types/IBackgroundCaller.ts
@@ -19,60 +19,95 @@ export enum MessageType {
   GET_LIQUID_SEND_DATA,
 }
 
-export interface SaveMnemonicResponse {
-  success: boolean;
-}
+// Message types for background script communication
+export type MessageTypeMap = {
+  [MessageType.GET_ADDRESS]: {
+    params: GetAddressParams;
+    response: GetAddressResponse;
+  };
+  [MessageType.SAVE_MNEMONIC]: {
+    params: SaveMnemonicParams;
+    response: SaveMnemonicResponse;
+  };
+  [MessageType.CREATE_MNEMONIC]: {
+    params: [];
+    response: CreateMnemonicResponse;
+  };
+  [MessageType.ENCRYPT_MNEMONIC]: {
+    params: EncryptMnemonicRequest;
+    response: EncryptMnemonicResponse;
+  };
+  [MessageType.GET_BTC_BALANCE]: {
+    params: GetBtcBalanceRequest;
+    response: GetBtcBalanceResponse;
+  };
+  [MessageType.LOG]: {
+    params: LogRequest;
+    response: void;
+  };
+  [MessageType.SIGN_PERSONAL_MESSAGE]: {
+    params: SignPersonalMessageRequest;
+    response: SignPersonalMessageResponse;
+  };
+  [MessageType.SIGN_TYPED_DATA]: {
+    params: SignTypedDataRequest;
+    response: SignTypedDataResponse;
+  };
+  [MessageType.OPEN_POPUP]: {
+    params: OpenPopupRequest;
+    response: void;
+  };
+  [MessageType.GET_BTC_SEND_DATA]: {
+    params: GetBtcSendDataRequest;
+    response: GetBtcSendDataResponse;
+  };
+  [MessageType.GET_LIQUID_BALANCE]: {
+    params: GetLiquidBalanceRequest;
+    response: GetLiquidBalanceResponse;
+  };
+  [MessageType.GET_LIQUID_SEND_DATA]: {
+    params: GetLiquidSendDataRequest;
+    response: GetLiquidSendDataResponse;
+  };
+};
 
-export interface GetBtcBalanceResponse {
-  confirmed: number;
-  unconfirmed: number;
-}
+export type GetAddressParams = [network: Networks, accountNumber: number];
+export type GetAddressResponse = string;
 
-export interface CreateMnemonicResponse {
-  mnemonic: string;
-}
+export type SaveMnemonicParams = [mnemonic: string];
+export type SaveMnemonicResponse = boolean;
 
-export interface EncryptMnemonicResponse {
-  success: boolean;
-  message?: string;
-}
+export type CreateMnemonicResponse = { mnemonic: string };
 
-export interface SignPersonalMessageResponse {
-  bytes: string;
-  success: boolean;
-  message?: string;
-}
+export type EncryptMnemonicRequest = [password: string];
+export type EncryptMnemonicResponse = { success: boolean; message?: string };
 
-export interface SignTypedDataResponse {
-  bytes: string;
-  success: boolean;
-  message?: string;
-}
+export type GetBtcBalanceRequest = [accountNumber: number];
+export type GetBtcBalanceResponse = { confirmed: number; unconfirmed: number };
 
-// Request interfaces
-export interface SaveMnemonicRequest {
-  mnemonic: string;
-}
+export type LogRequest = [data: string];
 
-export interface LogRequest {
-  data: string;
-}
+export type SignPersonalMessageRequest = [message: string | Uint8Array, accountNumber: number, password: string];
+export type SignPersonalMessageResponse = { bytes: string; success: boolean; message?: string };
 
-export interface SignPersonalMessageRequest {
-  message: string | Uint8Array;
-  password: string;
-  accountNumber: number;
-}
+export type SignTypedDataRequest = [message: any, accountNumber: number, password: string];
+export type SignTypedDataResponse = { bytes: string; success: boolean; message?: string };
 
-export interface SignTypedDataRequest {
-  message: any;
-  password: string;
-  accountNumber: number;
-}
+export type OpenPopupRequest = [method: string, params: any, id: number, from: string];
 
-export interface GetBtcBalanceRequest {
-  accountNumber: number;
-}
+export type GetBtcSendDataRequest = [accountNumber: number];
+export type GetBtcSendDataResponse = { utxos: CreateTransactionUtxo[]; changeAddress: string };
+
+export type GetLiquidBalanceRequest = [network: Networks, accountNumber: number];
+export type GetLiquidBalanceResponse = { [key: string]: number };
+
+export type GetLiquidSendDataRequest = [network: Networks, accountNumber: number];
+export type GetLiquidSendDataResponse = {
+  utxos: UnblindedOutput[];
+  txDetails: LiquidWallet['txDetails'];
+  outpointBlindingData: LiquidWallet['outpointBlindingData'];
+  scriptsDetails: LiquidWallet['scriptsDetails'];
+};
 
 export interface ProcessRPCRequest {
   method: string;
@@ -81,65 +116,24 @@ export interface ProcessRPCRequest {
   from: string;
 }
 
-export interface EncryptMnemonicRequest {
-  password: string;
-}
-
-export interface GetAddressRequest {
-  network: Networks;
-  accountNumber: number;
-}
-
-export type GetAddressResponse = string;
-
-export interface GetBtcSendDataRequest {
-  accountNumber: number;
-}
-
-export type GetBtcSendDataResponse = {
-  utxos: CreateTransactionUtxo[];
-  changeAddress: string;
-};
-
-export interface GetLiquidBalanceRequest {
-  network: Networks;
-  accountNumber: number;
-}
-
-export interface GetLiquidBalanceResponse {
-  [key: string]: number;
-}
-
-export interface GetLiquidSendDataRequest {
-  network: Networks;
-  accountNumber: number;
-}
-
-export type GetLiquidSendDataResponse = {
-  utxos: UnblindedOutput[];
-  txDetails: LiquidWallet['txDetails'];
-  outpointBlindingData: LiquidWallet['outpointBlindingData'];
-  scriptsDetails: LiquidWallet['scriptsDetails'];
-};
-
 export interface IBackgroundCaller {
-  getAddress(network: Networks, accountNumber: number): Promise<string>;
+  getAddress(...params: GetAddressParams): Promise<GetAddressResponse>;
   acceptTermsOfService(): Promise<void>;
   hasAcceptedTermsOfService(): Promise<boolean>;
   hasMnemonic(): Promise<boolean>;
   hasEncryptedMnemonic(): Promise<boolean>;
-  saveMnemonic(mnemonic: string): Promise<SaveMnemonicResponse>;
+  saveMnemonic(...params: SaveMnemonicParams): Promise<SaveMnemonicResponse>;
   createMnemonic(): Promise<CreateMnemonicResponse>;
-  encryptMnemonic(password: string): Promise<EncryptMnemonicResponse>;
-  getBtcBalance(accountNumber: number): Promise<GetBtcBalanceResponse>;
+  encryptMnemonic(...params: EncryptMnemonicRequest): Promise<EncryptMnemonicResponse>;
+  getBtcBalance(...params: GetBtcBalanceRequest): Promise<GetBtcBalanceResponse>;
   whitelistDapp(dapp: string): Promise<void>;
   unwhitelistDapp(dapp: string): Promise<void>;
   getWhitelist(): Promise<string[]>;
-  log(data: string): Promise<void>;
-  signPersonalMessage(message: string | Uint8Array, accountNumber: number, password: string): Promise<SignPersonalMessageResponse>;
-  signTypedData(message: any, accountNumber: number, password: string): Promise<SignTypedDataResponse>;
-  openPopup(method: string, params: any, id: number, from: string): Promise<void>;
-  getBtcSendData(accountNumber: number): Promise<GetBtcSendDataResponse>;
-  getLiquidBalance(network: Networks, accountNumber: number): Promise<GetLiquidBalanceResponse>;
-  getLiquidSendData(network: Networks, accountNumber: number): Promise<GetLiquidSendDataResponse>;
+  log(...params: LogRequest): Promise<void>;
+  signPersonalMessage(...params: SignPersonalMessageRequest): Promise<SignPersonalMessageResponse>;
+  signTypedData(...params: SignTypedDataRequest): Promise<SignTypedDataResponse>;
+  openPopup(...params: OpenPopupRequest): Promise<void>;
+  getBtcSendData(...params: GetBtcSendDataRequest): Promise<GetBtcSendDataResponse>;
+  getLiquidBalance(...params: GetLiquidBalanceRequest): Promise<GetLiquidBalanceResponse>;
+  getLiquidSendData(...params: GetLiquidSendDataRequest): Promise<GetLiquidSendDataResponse>;
 }


### PR DESCRIPTION
It started as an attempt to remove code like
```ts
    return await Messenger.sendGenericMessageToBackground({
      type: MessageType.SAVE_MNEMONIC,
      mnemonic,
    } as SaveMnemonicRequest);
```
As a result I've created MessageTypeMap that helped me typed all background calls
