### PR TITLE
feat: buy bitcoin button

### DIFF
--- a/ext/src/pages/Popup/components/Home.tsx
+++ b/ext/src/pages/Popup/components/Home.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownRightIcon, SendIcon, Info } from 'lucide-react';
+import { ArrowDownRightIcon, SendIcon, Info, ShoppingCartIcon } from 'lucide-react';
 import React, { useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DEFAULT_NETWORK } from '@shared/config';
@@ -65,6 +65,21 @@ const Home: React.FC = () => {
       ) : null}
       <h1>
         <span id="home-balance">{balance ? formatBalance(balance, getDecimalsByNetwork(network), 8) : ''}</span> {getTickerByNetwork(network)}
+        {network === NETWORK_BITCOIN ? (
+          <span style={{ paddingLeft: '15px' }}>
+            <Button
+              onClick={() => {
+                BackgroundCaller.getAddress(network, accountNumber).then((addressResponse) => {
+                  if (addressResponse) {
+                    window.open(`https://layerztec.github.io/website/onramp/?address=${addressResponse}`, '_blank');
+                  }
+                });
+              }}
+            >
+              <ShoppingCartIcon /> Buy
+            </Button>
+          </span>
+        ) : null}
         <div style={{ width: '100%', marginBottom: '15px' }}>
           <span style={{ fontSize: 14 }}>{balance && +balance > 0 && exchangeRate ? '$' + (+formatBalance(balance, getDecimalsByNetwork(network), 8) * exchangeRate).toPrecision(2) : ''}</span>
         </div>

--- a/mobile/app/Onramp.tsx
+++ b/mobile/app/Onramp.tsx
@@ -1,0 +1,24 @@
+import { useLocalSearchParams } from 'expo-router';
+import React from 'react';
+import WebView from 'react-native-webview';
+
+export type OnrampProps = {
+  address: string; // bitcoin address to receive coins to
+};
+
+const Onramp: React.FC = () => {
+  const params = useLocalSearchParams<OnrampProps>();
+  const { address } = params;
+
+  // @see https://docs.onramper.com/docs/integrating-in-webviews
+  return (
+    <WebView
+      originWhitelist={['https://*', 'http://*', 'about:blank', 'about:srcdoc']}
+      allowsInlineMediaPlayback={true}
+      style={{ flex: 1 }}
+      source={{ uri: `https://layerztec.github.io/website/onramp/?address=${address}` }}
+    />
+  );
+};
+
+export default Onramp;

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -83,6 +83,7 @@ export default function RootLayout() {
                   <Stack.Screen name="onboarding/create-wallet" options={{ headerShown: false }} />
                   <Stack.Screen name="selftest" options={{ title: 'Self Test' }} />
                   <Stack.Screen name="SendArk" options={{ title: 'Send ARK' }} />
+                  <Stack.Screen name="Onramp" options={{ headerShown: true }} />
                   <Stack.Screen name="+not-found" options={{ title: 'Not Found' }} />
                 </Stack>
                 <StatusBar style="auto" />

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -17,6 +17,7 @@ import { getDecimalsByNetwork, getIsTestnet, getTickerByNetwork } from '@shared/
 import { formatBalance } from '@shared/modules/string-utils';
 import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUIDTESTNET, NETWORK_LIQUID } from '@shared/types/networks';
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
+import { OnrampProps } from '@/app/Onramp';
 
 export default function IndexScreen() {
   const { network, setNetwork } = useContext(NetworkContext);
@@ -75,6 +76,19 @@ export default function IndexScreen() {
       default:
         router.push('/SendEvm');
     }
+  };
+
+  const goToBuyBitcoin = () => {
+    BackgroundExecutor.getAddress(network, accountNumber).then((address) => {
+      router.push('/Onramp');
+
+      router.replace({
+        pathname: '/Onramp',
+        params: {
+          address,
+        } as OnrampProps,
+      });
+    });
   };
 
   return (
@@ -147,6 +161,12 @@ export default function IndexScreen() {
             <TouchableOpacity style={[styles.button, styles.sendButton]} onPress={goToSend}>
               <ThemedText style={styles.buttonText}>Send</ThemedText>
             </TouchableOpacity>
+
+            {network === NETWORK_BITCOIN ? (
+              <TouchableOpacity style={[styles.button]} onPress={goToBuyBitcoin}>
+                <ThemedText style={styles.buttonText}> $ Buy </ThemedText>
+              </TouchableOpacity>
+            ) : null}
           </ThemedView>
         </ThemedView>
       </ThemedView>


### PR DESCRIPTION
added BUY BITCOIN button. placement is temporary, till we get the proper design. displayed only when BTC mainchain is selected.

button leads to our own webpage, that actualy implements redirect to a service provider - this makes it really easy to adjust stuff later (like, add provider selection logic based on platform & geo) without re-releasing binaries.

on ext it straight leads to our redirect, where on mobile it displays it in webview (so user is not leaving the app).

we pass `address` so it is prefilled where user wants to deliver bought coins, but i need to test it and it might need further work - documentation mentions that such argument passed needs the URI params to be signed so the url is not tampered with by a 3rd party along the way.

not yet tested, but we can test after we merge - if any fixes are necessary they are most likely need to be done on the side of redirect  (https://github.com/layerztec/website/tree/master/onramp)

production api key is already used on the redirect.

also, onramper widget can be styled (we can pass our own colors), we need to do that once we style our own design 

cc @Relborg737 

![image](https://github.com/user-attachments/assets/0013490d-7789-4943-b362-c1ee99209309)

![image](https://github.com/user-attachments/assets/00870c5f-e45e-416c-a2cf-a7c5413eec08)

