### PR TITLE
fix: engineering notation for fiat balance display

### DIFF
--- a/ext/src/pages/Popup/components/Home.tsx
+++ b/ext/src/pages/Popup/components/Home.tsx
@@ -11,7 +11,7 @@ import { Button, Switch } from '../DesignSystem';
 import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_BREEZ, NETWORK_BREEZTESTNET, NETWORK_LIQUIDTESTNET, Networks } from '@shared/types/networks';
 import TokensView from './TokensView';
 import PartnersView from './PartnersView';
-import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-utils';
+import { capitalizeFirstLetter, formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
 
 const Home: React.FC = () => {
@@ -92,7 +92,7 @@ const Home: React.FC = () => {
           </span>
         ) : null}
         <div style={{ width: '100%', marginBottom: '15px' }}>
-          <span style={{ fontSize: 14 }}>{balance && +balance > 0 && exchangeRate ? '$' + (+formatBalance(balance, getDecimalsByNetwork(network), 8) * exchangeRate).toPrecision(2) : ''}</span>
+          <span style={{ fontSize: 14 }}>{balance && +balance > 0 && exchangeRate ? '$' + formatFiatBalance(balance, getDecimalsByNetwork(network), exchangeRate) : ''}</span>
         </div>
       </h1>
       <PartnersView />

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -15,7 +15,7 @@ import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getIsTestnet, getTickerByNetwork } from '@shared/models/network-getters';
-import { formatBalance } from '@shared/modules/string-utils';
+import { formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
 import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUIDTESTNET, NETWORK_LIQUID, NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
 import { OnrampProps } from '@/app/Onramp';
@@ -153,7 +153,7 @@ export default function IndexScreen() {
           {balance ? formatBalance(balance, getDecimalsByNetwork(network)) + ' ' + getTickerByNetwork(network) : '???'}
         </ThemedText>
         <ThemedText adjustsFontSizeToFit numberOfLines={1}>
-          {balance && +balance > 0 && exchangeRate ? '$' + (+formatBalance(balance, getDecimalsByNetwork(network), 8) * exchangeRate).toPrecision(2) : ''}
+          {balance && +balance > 0 && exchangeRate ? '$' + formatFiatBalance(balance, getDecimalsByNetwork(network), exchangeRate) : ''}
         </ThemedText>
       </ThemedView>
 

--- a/shared/modules/string-utils.ts
+++ b/shared/modules/string-utils.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { StringNumber } from '../types/string-number';
 import { ICsprng } from '../types/ICsprng';
-import { uint8ArrayToHex } from '../modules/uint8array-extras';
+import { uint8ArrayToHex } from './uint8array-extras';
 
 export function capitalizeFirstLetter(input: string): string {
   return input.replace(/^./, (match) => match.toUpperCase());
@@ -60,4 +60,8 @@ export function formatBalance(balance: StringNumber, decimals: number, decimalPl
     .dividedBy(new BigNumber(10).pow(decimals))
     .toFixed(decimalPlaces)
     .replace(/\.?0+$/, '');
+}
+
+export function formatFiatBalance(balance: StringNumber, decimals: number, exchangeRate: number): string {
+  return new BigNumber(balance).dividedBy(new BigNumber(10).pow(decimals)).multipliedBy(exchangeRate).toFixed(2);
 }

--- a/shared/tests/unit-vi/string-utils.test.ts
+++ b/shared/tests/unit-vi/string-utils.test.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import { test } from 'vitest';
 import { getDecimalsByNetwork } from '../../models/network-getters';
-import { capitalizeFirstLetter, formatBalance } from '../../modules/string-utils';
-import { NETWORK_BITCOIN } from '../../types/networks';
+import { capitalizeFirstLetter, formatBalance, formatFiatBalance } from '../../modules/string-utils';
+import { NETWORK_BITCOIN, NETWORK_ROOTSTOCK } from '../../types/networks';
 
 test('capitalizeFirstLetter', () => {
   assert.strictEqual(capitalizeFirstLetter('hello world'), 'Hello world');
@@ -16,4 +16,8 @@ test('formatBalance', () => {
   assert.strictEqual(formatBalance('123456789', getDecimalsByNetwork(NETWORK_BITCOIN), 8), '1.23456789');
   assert.strictEqual(formatBalance('123456789', getDecimalsByNetwork(NETWORK_BITCOIN), 2), '1.23');
   assert.strictEqual(formatBalance('123456789', getDecimalsByNetwork(NETWORK_BITCOIN), 4), '1.2346'); // rounding up
+});
+
+test('formatFiatBalance', () => {
+  assert.strictEqual(formatFiatBalance('1011138556590607', getDecimalsByNetwork(NETWORK_ROOTSTOCK), 105338.6), '106.51');
 });


### PR DESCRIPTION
fixing this:

![image](https://github.com/user-attachments/assets/0e9c25c3-bc1a-483a-833f-9db6e5704468)
