### PR TITLE
refactor: prettified fiat on-ramp a bit

### DIFF
--- a/ext/src/pages/Popup/Home.tsx
+++ b/ext/src/pages/Popup/Home.tsx
@@ -6,6 +6,7 @@ import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
+import { fiatOnRamp } from '@shared/models/fiat-on-ramp';
 import { getDecimalsByNetwork, getIsTestnet, getKnowMoreUrl, getTickerByNetwork } from '@shared/models/network-getters';
 import { capitalizeFirstLetter, formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
 import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_BREEZ, NETWORK_BREEZTESTNET, Networks } from '@shared/types/networks';
@@ -94,13 +95,13 @@ const Home: React.FC = () => {
       ) : null}
       <h1>
         <span id="home-balance">{balance ? formatBalance(balance, getDecimalsByNetwork(network), 8) : ''}</span> {getTickerByNetwork(network)}
-        {network === NETWORK_BITCOIN ? (
+        {fiatOnRamp?.[network]?.canBuyWithFiat ? (
           <span style={{ paddingLeft: '15px' }}>
             <Button
               onClick={() => {
                 BackgroundCaller.getAddress(network, accountNumber).then((addressResponse) => {
                   if (addressResponse) {
-                    window.open(`https://layerztec.github.io/website/onramp/?address=${addressResponse}`, '_blank');
+                    window.open(`https://layerztec.github.io/website/onramp/?address=${addressResponse}&network=${network}`, '_blank');
                   }
                 });
               }}

--- a/mobile/app/Onramp.tsx
+++ b/mobile/app/Onramp.tsx
@@ -1,14 +1,16 @@
+import { Networks } from '@shared/types/networks';
 import { useLocalSearchParams } from 'expo-router';
 import React from 'react';
 import WebView from 'react-native-webview';
 
 export type OnrampProps = {
   address: string; // bitcoin address to receive coins to
+  network: Networks;
 };
 
 const Onramp: React.FC = () => {
   const params = useLocalSearchParams<OnrampProps>();
-  const { address } = params;
+  const { address, network } = params;
 
   // @see https://docs.onramper.com/docs/integrating-in-webviews
   return (
@@ -16,7 +18,7 @@ const Onramp: React.FC = () => {
       originWhitelist={['https://*', 'http://*', 'about:blank', 'about:srcdoc']}
       allowsInlineMediaPlayback={true}
       style={{ flex: 1 }}
-      source={{ uri: `https://layerztec.github.io/website/onramp/?address=${address}` }}
+      source={{ uri: `https://layerztec.github.io/website/onramp/?address=${address}&network=${network}` }}
     />
   );
 };

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -19,6 +19,7 @@ import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_BR
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
 import { OnrampProps } from '@/app/Onramp';
 import BreezTokensView from '@/components/BreezTokensView';
+import { fiatOnRamp } from '@shared/models/fiat-on-ramp';
 
 export default function IndexScreen() {
   const { network, setNetwork } = useContext(NetworkContext);
@@ -95,6 +96,7 @@ export default function IndexScreen() {
         pathname: '/Onramp',
         params: {
           address,
+          network,
         } as OnrampProps,
       });
     });
@@ -170,7 +172,7 @@ export default function IndexScreen() {
                 <ThemedText style={styles.buttonText}>Send</ThemedText>
               </TouchableOpacity>
 
-              {network === NETWORK_BITCOIN ? (
+              {fiatOnRamp?.[network]?.canBuyWithFiat ? (
                 <TouchableOpacity style={[styles.button]} onPress={goToBuyBitcoin}>
                   <ThemedText style={styles.buttonText}> $ Buy </ThemedText>
                 </TouchableOpacity>

--- a/shared/models/fiat-on-ramp.ts
+++ b/shared/models/fiat-on-ramp.ts
@@ -1,0 +1,8 @@
+import { NETWORK_BITCOIN } from '../types/networks';
+import { BuySupportMap } from '../types/fiat-on-ramp';
+
+export const fiatOnRamp: Partial<BuySupportMap> = {
+  [NETWORK_BITCOIN]: {
+    canBuyWithFiat: true,
+  },
+};

--- a/shared/types/fiat-on-ramp.ts
+++ b/shared/types/fiat-on-ramp.ts
@@ -1,0 +1,8 @@
+import { Networks } from './networks';
+
+export interface CoinBuySupport {
+  canBuyWithFiat: boolean;
+  // partner: FiatOnRampPartner;
+}
+
+export type BuySupportMap = Record<Networks, CoinBuySupport>;


### PR DESCRIPTION
doing some preparations for future, in case we will have many onramp providers, and when you can buy with fiat straight to l2s we support (like rbtc)

also, will try to use this code as a basis for future swaps support and configuration (there might be different swap providers for different pairs)