### PR TITLE
refactor: rename breez to liquid

### DIFF
--- a/ext/src/modules/background-message-controller.ts
+++ b/ext/src/modules/background-message-controller.ts
@@ -6,7 +6,7 @@ import { getDeviceID } from '@shared/modules/device-id';
 import { lazyInitWallet, saveArkAddresses, saveBitcoinXpubs, saveSubMnemonics, saveWalletState } from '@shared/modules/wallet-utils';
 import { IBackgroundCaller, MessageType, MessageTypeMap, OpenPopupRequest, ProcessRPCRequest } from '@shared/types/IBackgroundCaller';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_ARK_ADDRESS, STORAGE_KEY_EVM_XPUB, STORAGE_KEY_MNEMONIC, STORAGE_KEY_SUB_MNEMONIC } from '@shared/types/IStorage';
-import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 import { Csprng } from '../../src/class/rng';
 import { LayerzStorage } from '../class/layerz-storage';
 import { SecureStorage } from '../class/secure-storage';
@@ -74,7 +74,7 @@ export const BackgroundExtensionExecutor: Pick<IBackgroundCaller, TMethods> = {
     } else if (network === NETWORK_ARKMUTINYNET) {
       const address = await LayerzStorage.getItem(STORAGE_KEY_ARK_ADDRESS + accountNumber);
       return address;
-    } else if (network === NETWORK_BREEZ || network === NETWORK_BREEZTESTNET) {
+    } else if (network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET) {
       const mnemonic = await SecureStorage.getItem(STORAGE_KEY_SUB_MNEMONIC + accountNumber);
       const wallet = new BreezWallet(mnemonic, getBreezNetwork(network));
       const address = wallet.getAddressLiquid();

--- a/ext/src/modules/breeze-adapter.ts
+++ b/ext/src/modules/breeze-adapter.ts
@@ -1,6 +1,6 @@
 import init, { BindingLiquidSdk, connect, defaultConfig, PrepareReceiveRequest, ReceivePaymentRequest, PrepareSendRequest, SendPaymentRequest } from '@breeztech/breez-sdk-liquid';
 import { BreezConnection, IBreezAdapter, assetMetadata } from '@shared/class/wallets/breez-wallet';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 
 const API_KEY = process.env.EXPO_PUBLIC_BREEZ_API_KEY;
 
@@ -95,10 +95,10 @@ class BreezAdapter implements IBreezAdapter {
 }
 
 // Map our app network to Breez LiquidNetwork type
-export const getBreezNetwork = (network: typeof NETWORK_BREEZ | typeof NETWORK_BREEZTESTNET) => {
-  if (network === NETWORK_BREEZ) {
+export const getBreezNetwork = (network: typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET) => {
+  if (network === NETWORK_LIQUID) {
     return 'mainnet';
-  } else if (network === NETWORK_BREEZTESTNET) {
+  } else if (network === NETWORK_LIQUIDTESTNET) {
     return 'testnet';
   } else {
     throw new Error(`Unsupported Breez network: ${network}`);

--- a/ext/src/pages/Popup/Home.tsx
+++ b/ext/src/pages/Popup/Home.tsx
@@ -12,12 +12,12 @@ import { getDecimalsByNetwork, getIsTestnet, getKnowMoreUrl, getTickerByNetwork 
 import { capitalizeFirstLetter, formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
 import { SwapPair } from '@shared/types/swap';
 
-import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_BREEZ, NETWORK_BREEZTESTNET, Networks } from '@shared/types/networks';
+import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, Networks } from '@shared/types/networks';
 import { BackgroundCaller } from '../../modules/background-caller';
 import PartnersView from './components/PartnersView';
 import TokensView from './components/TokensView';
 import { Button, Switch } from './DesignSystem';
-import BreezTokensView from './components/BreezTokensView';
+import LiquidTokensView from './components/LiquidTokensView';
 import SwapInterfaceView from './components/SwapInterfaceView';
 
 const Home: React.FC = () => {
@@ -43,9 +43,9 @@ const Home: React.FC = () => {
 
   const handleReceive = () => {
     switch (network) {
-      case NETWORK_BREEZ:
-      case NETWORK_BREEZTESTNET:
-        navigate('/receive-breez');
+      case NETWORK_LIQUID:
+      case NETWORK_LIQUIDTESTNET:
+        navigate('/receive-liquid');
         break;
       default:
         navigate('/receive');
@@ -60,9 +60,9 @@ const Home: React.FC = () => {
       case NETWORK_ARKMUTINYNET:
         navigate('/send-ark');
         break;
-      case NETWORK_BREEZ:
-      case NETWORK_BREEZTESTNET:
-        navigate('/send-breez');
+      case NETWORK_LIQUID:
+      case NETWORK_LIQUIDTESTNET:
+        navigate('/send-liquid');
         break;
       default:
         navigate('/send-evm');
@@ -132,7 +132,7 @@ const Home: React.FC = () => {
       ) : (
         <div>
           <PartnersView />
-          {network === NETWORK_BREEZ || network === NETWORK_BREEZTESTNET ? <BreezTokensView /> : <TokensView />}
+          {network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET ? <LiquidTokensView /> : <TokensView />}
         </div>
       )}
 

--- a/ext/src/pages/Popup/Popup.tsx
+++ b/ext/src/pages/Popup/Popup.tsx
@@ -77,9 +77,9 @@ const AppContent: React.FC = () => {
             <Route path="/test" element={<TestPage />} />
             <Route path="/home" element={<Home />} />
             <Route path="/receive" element={<Receive />} />
-            <Route path="/receive-breez" element={<ReceiveBreez />} />
+            <Route path="/receive-liquid" element={<ReceiveBreez />} />
             <Route path="/receive-lightning" element={<ReceiveLightning />} />
-            <Route path="/send-breez" element={<SendBreez />} />
+            <Route path="/send-liquid" element={<SendBreez />} />
             <Route path="/send-liquid" element={<SendLiquid />} />
             <Route path="/send-evm" element={<SendEvm />} />
             <Route path="/send-ark" element={<SendArk />} />

--- a/ext/src/pages/Popup/ReceiveLightning.tsx
+++ b/ext/src/pages/Popup/ReceiveLightning.tsx
@@ -11,7 +11,7 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 import { StringNumber } from '@shared/types/string-number';
 import { BackgroundCaller } from '../../modules/background-caller';
 import { getBreezNetwork } from '../../modules/breeze-adapter';
@@ -23,7 +23,7 @@ const ReceiveLightning: React.FC = () => {
   const [invoice, setInvoice] = useState<string>('');
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
-  const network = useContext(NetworkContext).network as typeof NETWORK_BREEZ | typeof NETWORK_BREEZTESTNET;
+  const network = useContext(NetworkContext).network as typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET;
   const { accountNumber } = useContext(AccountNumberContext);
   const [imgSrc, setImgSrc] = useState('');
   const [oldBalance, setOldBalance] = useState<StringNumber>('');

--- a/ext/src/pages/Popup/SendLightning.tsx
+++ b/ext/src/pages/Popup/SendLightning.tsx
@@ -9,7 +9,7 @@ import { BreezWallet } from '@shared/class/wallets/breez-wallet';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 import { AskMnemonicContext } from '../../hooks/AskMnemonicContext';
 import { useScanQR } from '../../hooks/ScanQrContext';
 import { BackgroundCaller } from '../../modules/background-caller';
@@ -26,7 +26,7 @@ const SendLightning: React.FC = () => {
   const [preparedResponse, setPreparedResponse] = useState<PrepareSendResponse | null>(null);
   const [feeSats, setFeeSats] = useState<number | null>(null);
   const [amountToSend, setAmountToSend] = useState<string>('');
-  const network = useContext(NetworkContext).network as typeof NETWORK_BREEZ | typeof NETWORK_BREEZTESTNET;
+  const network = useContext(NetworkContext).network as typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET;
   const { accountNumber } = useContext(AccountNumberContext);
   const breezWallet = useRef<BreezWallet | null>(null);
 

--- a/ext/src/pages/Popup/SendLiquid.tsx
+++ b/ext/src/pages/Popup/SendLiquid.tsx
@@ -7,7 +7,7 @@ import { BreezWallet, LBTC_ASSET_IDS } from '@shared/class/wallets/breez-wallet'
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 import { AskMnemonicContext } from '../../hooks/AskMnemonicContext';
 import { useScanQR } from '../../hooks/ScanQrContext';
 import { BackgroundCaller } from '../../modules/background-caller';
@@ -18,7 +18,7 @@ const SendLiquid: React.FC = () => {
   const scanQr = useScanQR();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const network = useContext(NetworkContext).network as typeof NETWORK_BREEZ | typeof NETWORK_BREEZTESTNET;
+  const network = useContext(NetworkContext).network as typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET;
   const { accountNumber } = useContext(AccountNumberContext);
   const { askMnemonic } = useContext(AskMnemonicContext);
 
@@ -36,7 +36,7 @@ const SendLiquid: React.FC = () => {
     const paramAssetId = searchParams.get('assetId');
     if (paramAssetId) {
       return paramAssetId;
-    } else if (network === NETWORK_BREEZ) {
+    } else if (network === NETWORK_LIQUID) {
       return LBTC_ASSET_IDS.mainnet;
     } else {
       return LBTC_ASSET_IDS.testnet;

--- a/ext/src/pages/Popup/components/LiquidTokensView.tsx
+++ b/ext/src/pages/Popup/components/LiquidTokensView.tsx
@@ -6,13 +6,13 @@ import { useNavigate } from 'react-router';
 import { BreezWallet, LBTC_ASSET_IDS } from '@shared/class/wallets/breez-wallet';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 import { BackgroundCaller } from '../../../modules/background-caller';
 import { getBreezNetwork } from '../../../modules/breeze-adapter';
 
-const BreezTokensView: React.FC = () => {
+const LiquidTokensView: React.FC = () => {
   const navigate = useNavigate();
-  const network = useContext(NetworkContext).network as typeof NETWORK_BREEZ | typeof NETWORK_BREEZTESTNET;
+  const network = useContext(NetworkContext).network as typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET;
   const { accountNumber } = useContext(AccountNumberContext);
   const [assetBalances, setAssetBalances] = useState<AssetBalance[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
@@ -126,4 +126,4 @@ const BreezTokensView: React.FC = () => {
   );
 };
 
-export default BreezTokensView;
+export default LiquidTokensView;

--- a/mobile/app/ReceiveLightning.tsx
+++ b/mobile/app/ReceiveLightning.tsx
@@ -17,12 +17,12 @@ import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 import { StringNumber } from '@shared/types/string-number';
 
 export default function ReceiveLightningScreen() {
   const router = useRouter();
-  const network = useContext(NetworkContext).network as typeof NETWORK_BREEZ | typeof NETWORK_BREEZTESTNET;
+  const network = useContext(NetworkContext).network as typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET;
   const { accountNumber } = useContext(AccountNumberContext);
   const [amount, setAmount] = useState<string>('');
   const [invoice, setInvoice] = useState<string>('');

--- a/mobile/app/SendLightning.tsx
+++ b/mobile/app/SendLightning.tsx
@@ -18,7 +18,7 @@ import { BreezWallet } from '@shared/class/wallets/breez-wallet';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 
 const SendLightning = () => {
   const { scanQr } = useContext(ScanQrContext);
@@ -32,7 +32,7 @@ const SendLightning = () => {
   const [preparedResponse, setPreparedResponse] = useState<PrepareSendResponse | null>(null);
   const [feeSats, setFeeSats] = useState<number | null>(null);
   const [amountToSend, setAmountToSend] = useState<string>('');
-  const network = useContext(NetworkContext).network as typeof NETWORK_BREEZ | typeof NETWORK_BREEZTESTNET;
+  const network = useContext(NetworkContext).network as typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET;
   const { accountNumber } = useContext(AccountNumberContext);
   const breezWallet = useRef<BreezWallet | null>(null);
 

--- a/mobile/app/SendLiquid.tsx
+++ b/mobile/app/SendLiquid.tsx
@@ -16,7 +16,7 @@ import { BreezWallet, LBTC_ASSET_IDS } from '@shared/class/wallets/breez-wallet'
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 
 export type SendLiquidParams = {
   assetId?: string; // Optional asset ID - if not provided, use L-BTC
@@ -26,7 +26,7 @@ const SendLiquid = () => {
   const router = useRouter();
   const params = useLocalSearchParams<SendLiquidParams>();
 
-  const network = useContext(NetworkContext).network as typeof NETWORK_BREEZ | typeof NETWORK_BREEZTESTNET;
+  const network = useContext(NetworkContext).network as typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET;
   const { accountNumber } = useContext(AccountNumberContext);
   const { scanQr } = useContext(ScanQrContext);
   const { askMnemonic } = useContext(AskMnemonicContext);
@@ -48,7 +48,7 @@ const SendLiquid = () => {
   const assetId = useMemo(() => {
     if (params.assetId) {
       return params.assetId;
-    } else if (network === NETWORK_BREEZ) {
+    } else if (network === NETWORK_LIQUID) {
       return LBTC_ASSET_IDS.mainnet;
     } else {
       return LBTC_ASSET_IDS.testnet;

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -17,11 +17,11 @@ import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getIsTestnet, getTickerByNetwork } from '@shared/models/network-getters';
 import { getSwapPairs } from '@shared/models/swap-providers-list';
 import { formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
-import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 import { SwapPair } from '@shared/types/swap';
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
 import { OnrampProps } from '@/app/Onramp';
-import BreezTokensView from '@/components/BreezTokensView';
+import LiquidTokensView from '@/components/LiquidTokensView';
 import { fiatOnRamp } from '@shared/models/fiat-on-ramp';
 
 export default function IndexScreen() {
@@ -72,7 +72,7 @@ export default function IndexScreen() {
   };
 
   const goToReceive = () => {
-    if (network === NETWORK_BREEZ || network === NETWORK_BREEZTESTNET) {
+    if (network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET) {
       router.push('/ReceiveBreez');
       return;
     }
@@ -88,8 +88,8 @@ export default function IndexScreen() {
       case NETWORK_ARKMUTINYNET:
         router.push('/SendArk');
         break;
-      case NETWORK_BREEZ:
-      case NETWORK_BREEZTESTNET:
+      case NETWORK_LIQUID:
+      case NETWORK_LIQUIDTESTNET:
         router.push('/SendBreez');
         break;
       default:
@@ -168,7 +168,7 @@ export default function IndexScreen() {
           </ThemedText>
         </ThemedView>
 
-        {showSwapInterface ? <SwapInterfaceView /> : <ThemedView>{network === NETWORK_BREEZ || network === NETWORK_BREEZTESTNET ? <BreezTokensView /> : <TokensView />}</ThemedView>}
+        {showSwapInterface ? <SwapInterfaceView /> : <ThemedView>{network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET ? <LiquidTokensView /> : <TokensView />}</ThemedView>}
 
         <ThemedView style={styles.contentContainer}>
           <ThemedView style={styles.buttonContainer}>

--- a/mobile/components/LiquidTokensView.tsx
+++ b/mobile/components/LiquidTokensView.tsx
@@ -11,9 +11,9 @@ import { getBreezNetwork } from '@/src/modules/breeze-adapter';
 import { BreezWallet, LBTC_ASSET_IDS } from '@shared/class/wallets/breez-wallet';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 
-const BreezTokensView: React.FC = () => {
+const LiquidTokensView: React.FC = () => {
   const router = useRouter();
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
@@ -23,7 +23,7 @@ const BreezTokensView: React.FC = () => {
   useEffect(() => {
     const fetchBreezAssetBalances = async () => {
       setAssetBalances([]);
-      if (network !== NETWORK_BREEZ && network !== NETWORK_BREEZTESTNET) {
+      if (network !== NETWORK_LIQUID && network !== NETWORK_LIQUIDTESTNET) {
         setLoading(false);
         return;
       }
@@ -96,7 +96,7 @@ const BreezTokensView: React.FC = () => {
   );
 };
 
-export default BreezTokensView;
+export default LiquidTokensView;
 
 const styles = StyleSheet.create({
   container: {

--- a/mobile/src/modules/background-executor.ts
+++ b/mobile/src/modules/background-executor.ts
@@ -15,7 +15,7 @@ import {
   STORAGE_KEY_SUB_MNEMONIC,
   STORAGE_KEY_WHITELIST,
 } from '@shared/types/IStorage';
-import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 import { LayerzStorage } from '../class/layerz-storage';
 import { Csprng } from '../class/rng';
 import { encrypt } from '../modules/encryption';
@@ -49,7 +49,7 @@ export const BackgroundExecutor: IBackgroundCaller = {
     } else if (network === NETWORK_ARKMUTINYNET) {
       const address = await LayerzStorage.getItem(STORAGE_KEY_ARK_ADDRESS + accountNumber);
       return address;
-    } else if (network === NETWORK_BREEZ || network === NETWORK_BREEZTESTNET) {
+    } else if (network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET) {
       const mnemonic = await SecureStorage.getItem(STORAGE_KEY_SUB_MNEMONIC + accountNumber);
       const wallet = new BreezWallet(mnemonic, getBreezNetwork(network));
       const address = wallet.getAddressLiquid();

--- a/mobile/src/modules/breeze-adapter.ts
+++ b/mobile/src/modules/breeze-adapter.ts
@@ -3,7 +3,7 @@ import * as RNAPI from '@breeztech/react-native-breez-sdk-liquid';
 import * as Crypto from 'expo-crypto';
 
 import { BreezConnection, IBreezAdapter, assetMetadata } from '@shared/class/wallets/breez-wallet';
-import { NETWORK_BREEZ, NETWORK_BREEZTESTNET } from '@shared/types/networks';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
 
 const API_KEY = process.env.EXPO_PUBLIC_BREEZ_API_KEY;
 
@@ -204,10 +204,10 @@ class BreezAdapter implements IBreezAdapter {
 }
 
 // Map our app network to Breez LiquidNetwork type
-export const getBreezNetwork = (network: typeof NETWORK_BREEZ | typeof NETWORK_BREEZTESTNET) => {
-  if (network === NETWORK_BREEZ) {
+export const getBreezNetwork = (network: typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET) => {
+  if (network === NETWORK_LIQUID) {
     return RNAPI.LiquidNetwork.MAINNET;
-  } else if (network === NETWORK_BREEZTESTNET) {
+  } else if (network === NETWORK_LIQUIDTESTNET) {
     return RNAPI.LiquidNetwork.TESTNET;
   } else {
     throw new Error(`Unsupported Breez network: ${network}`);

--- a/shared/hooks/useBalance.ts
+++ b/shared/hooks/useBalance.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import useSWR from 'swr';
 
-import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_BREEZ, NETWORK_BREEZTESTNET, Networks } from '../types/networks';
+import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, Networks } from '../types/networks';
 import { StringNumber } from '../types/string-number';
 import { IBackgroundCaller } from '../types/IBackgroundCaller';
 import { getRpcProvider } from '../models/network-getters';
@@ -28,9 +28,9 @@ export const balanceFetcher = async (arg: balanceFetcherArg): Promise<StringNumb
     return (balance.confirmed + balance.unconfirmed).toString(10);
   }
 
-  if (network === NETWORK_BREEZ || network === NETWORK_BREEZTESTNET) {
+  if (network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET) {
     const mnemonic = await backgroundCaller.getSubMnemonic(accountNumber);
-    const bNetwork = network === NETWORK_BREEZ ? 'mainnet' : 'testnet';
+    const bNetwork = network === NETWORK_LIQUID ? 'mainnet' : 'testnet';
     const bw = new BreezWallet(mnemonic, bNetwork);
     const balance = await bw.getBalance();
     return balance.toString(10);

--- a/shared/models/all-network-infos.ts
+++ b/shared/models/all-network-infos.ts
@@ -3,8 +3,8 @@ import {
   NETWORK_ARKMUTINYNET,
   NETWORK_BITCOIN,
   NETWORK_BOTANIXTESTNET,
-  NETWORK_BREEZ,
-  NETWORK_BREEZTESTNET,
+  NETWORK_LIQUID,
+  NETWORK_LIQUIDTESTNET,
   NETWORK_CITREATESTNET,
   NETWORK_ROOTSTOCK,
   NETWORK_SEPOLIA,
@@ -72,7 +72,7 @@ export const AllNetworkInfos: Record<Networks, NetworkInfo> = {
     knowMoreUrl: 'https://arklabs.to/',
     isTestnet: true,
   },
-  [NETWORK_BREEZ]: {
+  [NETWORK_LIQUID]: {
     chainId: 11,
     ticker: 'L-BTC',
     rpcUrl: '',
@@ -80,7 +80,7 @@ export const AllNetworkInfos: Record<Networks, NetworkInfo> = {
     decimals: 8,
     knowMoreUrl: 'https://breez.technology/',
   },
-  [NETWORK_BREEZTESTNET]: {
+  [NETWORK_LIQUIDTESTNET]: {
     chainId: 12,
     ticker: 'tL-BTC',
     rpcUrl: '',

--- a/shared/models/swap-provider-boltz.ts
+++ b/shared/models/swap-provider-boltz.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { SwapPair, SwapProvider } from '../types/swap';
-import { NETWORK_BITCOIN, NETWORK_BREEZ, NETWORK_ROOTSTOCK, Networks } from '@shared/types/networks';
+import { NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_ROOTSTOCK, Networks } from '@shared/types/networks';
 import BigNumber from 'bignumber.js';
 
 /**
@@ -13,8 +13,8 @@ export class SwapProviderBoltz implements SwapProvider {
     return [
       { from: NETWORK_BITCOIN, to: NETWORK_ROOTSTOCK },
       { from: NETWORK_ROOTSTOCK, to: NETWORK_BITCOIN },
-      { from: NETWORK_BITCOIN, to: NETWORK_BREEZ },
-      { from: NETWORK_BREEZ, to: NETWORK_BITCOIN },
+      { from: NETWORK_BITCOIN, to: NETWORK_LIQUID },
+      { from: NETWORK_LIQUID, to: NETWORK_BITCOIN },
     ];
   }
 
@@ -28,7 +28,7 @@ export class SwapProviderBoltz implements SwapProvider {
       case NETWORK_BITCOIN:
         sendAsset = 'BTC';
         break;
-      case NETWORK_BREEZ:
+      case NETWORK_LIQUID:
         sendAsset = 'L-BTC';
         break;
       case NETWORK_ROOTSTOCK:
@@ -51,7 +51,7 @@ export class SwapProviderBoltz implements SwapProvider {
         await new Promise((resolve) => setTimeout(resolve, 500)); // sleep to propagate
         break;
 
-      case NETWORK_BREEZ:
+      case NETWORK_LIQUID:
         receiveAsset = 'L-BTC';
         break;
       default:

--- a/shared/tests/unit-vi/swap.test.ts
+++ b/shared/tests/unit-vi/swap.test.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { test } from 'vitest';
 import { SwapProviderBoltz } from '../../models/swap-provider-boltz';
-import { NETWORK_BITCOIN, NETWORK_BOTANIXTESTNET, NETWORK_BREEZTESTNET, NETWORK_ROOTSTOCK } from '../../types/networks';
+import { NETWORK_BITCOIN, NETWORK_BOTANIXTESTNET, NETWORK_LIQUIDTESTNET, NETWORK_ROOTSTOCK } from '../../types/networks';
 import { getSwapPairs, getSwapProvidersList } from '../../models/swap-providers-list';
 
 test('throws on incorrect swap pair', async () => {
@@ -9,12 +9,12 @@ test('throws on incorrect swap pair', async () => {
 
   let errMsg = '';
   try {
-    await swapper.swap(NETWORK_BREEZTESTNET, () => {}, NETWORK_BOTANIXTESTNET, 1, '0x123');
+    await swapper.swap(NETWORK_LIQUIDTESTNET, () => {}, NETWORK_BOTANIXTESTNET, 1, '0x123');
   } catch (error: any) {
     errMsg = error.message;
   }
 
-  assert.strictEqual(errMsg, 'Swap pair breeztest->botanix not supported by Boltz');
+  assert.strictEqual(errMsg, 'Swap pair liquidtest->botanix not supported by Boltz');
 });
 
 test('accepts correct swap pair', async () => {
@@ -28,7 +28,7 @@ test('getSwapPartnersList()', async () => {
   let providers = getSwapProvidersList(NETWORK_BITCOIN);
   assert.ok(providers.length > 0); // there are providers that swap from bitcoin
 
-  providers = getSwapProvidersList(NETWORK_BREEZTESTNET);
+  providers = getSwapProvidersList(NETWORK_LIQUIDTESTNET);
   assert.ok(providers.length === 0); // there are no providers that swap from testnet
 });
 
@@ -38,7 +38,7 @@ test('getSwapPairs() returns correct pairs', () => {
   assert.ok(bitcoinPairs.every((pair) => pair.from === NETWORK_BITCOIN)); // all pairs are from bitcoin
   assert.ok(bitcoinPairs.some((pair) => pair.to === NETWORK_ROOTSTOCK)); // at least one pair swaps to rootstock
 
-  const testnetPairs = getSwapPairs(NETWORK_BREEZTESTNET);
+  const testnetPairs = getSwapPairs(NETWORK_LIQUIDTESTNET);
   assert.strictEqual(testnetPairs.length, 0); // testnet has no swap pairs
 
   // Check for duplicate pairs

--- a/shared/types/networks.ts
+++ b/shared/types/networks.ts
@@ -5,8 +5,8 @@ export const NETWORK_BOTANIXTESTNET = 'botanix' as const;
 export const NETWORK_STRATADEVNET = 'strata' as const;
 export const NETWORK_CITREATESTNET = 'citrea' as const;
 export const NETWORK_ARKMUTINYNET = 'ark' as const;
-export const NETWORK_BREEZ = 'breez' as const;
-export const NETWORK_BREEZTESTNET = 'breeztest' as const;
+export const NETWORK_LIQUID = 'liquid' as const;
+export const NETWORK_LIQUIDTESTNET = 'liquidtest' as const;
 
 const NetworksIterator = {
   BITCOIN: NETWORK_BITCOIN,
@@ -16,8 +16,8 @@ const NetworksIterator = {
   STRATADEVNET: NETWORK_STRATADEVNET,
   CITREATESTNET: NETWORK_CITREATESTNET,
   ARKMUTINYNET: NETWORK_ARKMUTINYNET,
-  BREEZ: NETWORK_BREEZ,
-  BREEZTESTNET: NETWORK_BREEZTESTNET,
+  LIQUID: NETWORK_LIQUID,
+  LIQIUDTESTNET: NETWORK_LIQUIDTESTNET,
 } as const;
 
 export type Networks = (typeof NetworksIterator)[keyof typeof NetworksIterator];


### PR DESCRIPTION
I don't think we need to rename BreezWallet, because it is both Liquid and Lightning
Also I did not rename SendBreez, ReceiveBreez - these will gone after we move Lightning to Networks