### PR TITLE
fix: selecting proper swap provider respecting current platform

### DIFF
--- a/ext/src/pages/Popup/components/SwapInterfaceView.tsx
+++ b/ext/src/pages/Popup/components/SwapInterfaceView.tsx
@@ -40,7 +40,7 @@ const SwapInterfaceView: React.FC = () => {
     assert(new BigNumber(balance).gte(satValue), 'Not enough balance');
 
     const swapProviders = getSwapProvidersList(network);
-    const provider = swapProviders.find((p) => p.getSupportedPairs().some((pair) => pair.from === network && pair.to === targetNetwork));
+    const provider = swapProviders.find((p) => p.getSupportedPairs().some((pair) => pair.from === network && pair.to === targetNetwork && pair.platform === SwapPlatform.EXT));
 
     assert(provider, 'No provider found for the selected networks');
 

--- a/mobile/components/SwapInterfaceView.tsx
+++ b/mobile/components/SwapInterfaceView.tsx
@@ -41,7 +41,7 @@ const SwapInterfaceView: React.FC = () => {
     assert(new BigNumber(balance).gte(satValue), 'Not enough balance');
 
     const providers = getSwapProvidersList(network);
-    const provider = providers.find((p) => p.getSupportedPairs().some((pair) => pair.from === network && pair.to === targetNetwork));
+    const provider = providers.find((p) => p.getSupportedPairs().some((pair) => pair.from === network && pair.to === targetNetwork && pair.platform === SwapPlatform.MOBILE));
 
     assert(provider, 'internal error: no provider found for the selected networks');
 


### PR DESCRIPTION
i missed that check, so currently on mobile it can use only-ext swap provider