### PR TITLE
feat: sanitize and validate mnemonic

### DIFF
--- a/ext/src/pages/Popup/Home.tsx
+++ b/ext/src/pages/Popup/Home.tsx
@@ -12,17 +12,7 @@ import { getDecimalsByNetwork, getIsTestnet, getKnowMoreUrl, getTickerByNetwork 
 import { capitalizeFirstLetter, formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
 import { SwapPair, SwapPlatform } from '@shared/types/swap';
 
-import {
-  getAvailableNetworks,
-  NETWORK_ARKMUTINYNET,
-  NETWORK_BITCOIN,
-  NETWORK_LIGHTNING,
-  NETWORK_LIGHTNINGTESTNET,
-  NETWORK_LIQUID,
-  NETWORK_LIQUIDTESTNET,
-  NETWORK_SPARK,
-  Networks,
-} from '@shared/types/networks';
+import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIGHTNING, NETWORK_LIGHTNINGTESTNET, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK } from '@shared/types/networks';
 import { BackgroundCaller } from '../../modules/background-caller';
 import PartnersView from './components/PartnersView';
 import TokensView from './components/TokensView';

--- a/ext/src/pages/Popup/OnboardingImportWallet.tsx
+++ b/ext/src/pages/Popup/OnboardingImportWallet.tsx
@@ -4,6 +4,7 @@ import React, { useContext, useState } from 'react';
 
 import { useScanQR } from '../../hooks/ScanQrContext';
 import { BackgroundCaller } from '../../modules/background-caller';
+import { sanitizeAndValidateMnemonic } from '@shared/modules/wallet-utils';
 import { Button, TextArea } from './DesignSystem';
 
 export default function OnboardingImport() {
@@ -18,6 +19,14 @@ export default function OnboardingImport() {
   };
 
   const handleSaveMnemonicSeed = async () => {
+    // Validate and sanitize the mnemonic first
+    try {
+      sanitizeAndValidateMnemonic(value);
+    } catch (error: any) {
+      setError(error.message);
+      return;
+    }
+
     const response = await BackgroundCaller.saveMnemonic(value);
 
     if (!response) {

--- a/mobile/app/onboarding/import-wallet.tsx
+++ b/mobile/app/onboarding/import-wallet.tsx
@@ -2,11 +2,12 @@ import { useRouter } from 'expo-router';
 import React, { useContext, useState } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ScanQrContext } from '@/src/hooks/ScanQrContext';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { sanitizeAndValidateMnemonic } from '@shared/modules/wallet-utils';
 
 export default function ImportWalletScreen() {
   const { scanQr } = useContext(ScanQrContext);
@@ -26,7 +27,15 @@ export default function ImportWalletScreen() {
 
     try {
       await new Promise((resolve) => setTimeout(resolve, 200)); // propagate ui
-      const response = await BackgroundExecutor.saveMnemonic(mnemonic.trim());
+
+      try {
+        sanitizeAndValidateMnemonic(mnemonic);
+      } catch (validationError) {
+        setError('Invalid mnemonic seed');
+        return;
+      }
+
+      const response = await BackgroundExecutor.saveMnemonic(mnemonic);
 
       if (!response) {
         setError('Invalid mnemonic seed');

--- a/shared/modules/wallet-utils.ts
+++ b/shared/modules/wallet-utils.ts
@@ -114,3 +114,19 @@ export async function lazyInitWallet(network: SupportedWalletNetworks, accountNu
   await saveWalletState(storage, wallet, network, accountNumber);
   return wallet;
 }
+
+export const sanitizeAndValidateMnemonic = (mnemonic: string): string => {
+  // Remove extra spaces and newlines
+  const sanitizedMnemonic = mnemonic.replace(/\s+/g, ' ').trim().toLocaleLowerCase();
+
+  // Validate mnemonic length
+  const words = sanitizedMnemonic.split(' ');
+  if (words.length < 12 || words.length > 24) {
+    throw new Error('Invalid mnemonic length. It should be 12 to 24 words.');
+  }
+
+  // Check if we can import it
+  BIP85.fromMnemonic(sanitizedMnemonic);
+
+  return sanitizedMnemonic;
+};


### PR DESCRIPTION
We have a case where bip39 accepts mnemonic as valid, but bip85 throws an error.
And because we are using different libraries for different wallets, I've added new function to do basic mnemonic satize and check it against bip85 before we pass it to wallets.

Another issue i'm fixing is saving STORAGE_KEY_MNEMONIC too early, when we don't have all the sub-mnemonic generated