### PR TITLE
feat: generic app settings

### DIFF
--- a/ext/src/pages/Popup/Home.tsx
+++ b/ext/src/pages/Popup/Home.tsx
@@ -11,8 +11,9 @@ import { getSwapPairs } from '@shared/models/swap-providers-list';
 import { getDecimalsByNetwork, getIsTestnet, getKnowMoreUrl, getTickerByNetwork } from '@shared/models/network-getters';
 import { capitalizeFirstLetter, formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
 import { SwapPair, SwapPlatform } from '@shared/types/swap';
+import { useAvailableNetworks } from '@shared/hooks/useAvailableNetworks';
+import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIGHTNING, NETWORK_LIGHTNINGTESTNET, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK } from '@shared/types/networks';
 
-import { getAvailableNetworks, NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIGHTNING, NETWORK_LIGHTNINGTESTNET, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK } from '@shared/types/networks';
 import { BackgroundCaller } from '../../modules/background-caller';
 import PartnersView from './components/PartnersView';
 import TokensView from './components/TokensView';
@@ -30,6 +31,7 @@ const Home: React.FC = () => {
   const { exchangeRate } = useExchangeRate(network, 'USD');
   const [swapPairs, setSwapPairs] = useState<SwapPair[]>([]);
   const [showSwapInterface, setShowSwapInterface] = useState<boolean>(false);
+  const availableNetworks = useAvailableNetworks();
 
   useEffect(() => {
     setIsTestnet(getIsTestnet(network));
@@ -76,7 +78,7 @@ const Home: React.FC = () => {
 
   return (
     <div>
-      <Switch items={getAvailableNetworks()} activeItem={network} onItemClick={setNetwork} />
+      <Switch items={availableNetworks} activeItem={network} onItemClick={setNetwork} />
       {getKnowMoreUrl(network) ? (
         <div style={{ textAlign: 'right' }}>
           <a

--- a/ext/src/pages/Popup/Popup.tsx
+++ b/ext/src/pages/Popup/Popup.tsx
@@ -10,6 +10,7 @@ import { Hello } from '@shared/class/hello';
 import { AccountNumberContextProvider } from '@shared/hooks/AccountNumberContext';
 import { EStep, InitializationContext, InitializationContextProvider } from '@shared/hooks/InitializationContext';
 import { NetworkContextProvider } from '@shared/hooks/NetworkContext';
+import { SettingsContextProvider } from '@shared/hooks/SettingsContext';
 import { LayerzStorage } from '../../class/layerz-storage';
 import { SwrCacheProvider } from '../../class/swr-cache-provider';
 import { AskPasswordContextProvider } from '../../hooks/AskPasswordContext';
@@ -121,11 +122,13 @@ const Popup: React.FC = () => {
           <AskMnemonicContextProvider>
             <ScanQrContextProvider>
               <InitializationContextProvider storage={LayerzStorage} backgroundCaller={BackgroundCaller}>
-                <AccountNumberContextProvider storage={LayerzStorage} backgroundCaller={BackgroundCaller}>
-                  <NetworkContextProvider storage={LayerzStorage} backgroundCaller={BackgroundCaller}>
-                    <AppContent />
-                  </NetworkContextProvider>
-                </AccountNumberContextProvider>
+                <SettingsContextProvider storage={LayerzStorage}>
+                  <AccountNumberContextProvider storage={LayerzStorage} backgroundCaller={BackgroundCaller}>
+                    <NetworkContextProvider storage={LayerzStorage} backgroundCaller={BackgroundCaller}>
+                      <AppContent />
+                    </NetworkContextProvider>
+                  </AccountNumberContextProvider>
+                </SettingsContextProvider>
               </InitializationContextProvider>
             </ScanQrContextProvider>
           </AskMnemonicContextProvider>

--- a/ext/src/pages/Popup/SettingsPage.tsx
+++ b/ext/src/pages/Popup/SettingsPage.tsx
@@ -2,6 +2,8 @@ import * as BlueElectrum from '@shared/blue_modules/BlueElectrum';
 import { HDSegwitBech32Wallet } from '@shared/class/wallets/hd-segwit-bech32-wallet';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { EStep, InitializationContext } from '@shared/hooks/InitializationContext';
+import { useSettings } from '@shared/hooks/useSettings';
+import { SETTINGS_CONFIG } from '@shared/hooks/SettingsContext';
 import React, { useContext } from 'react';
 import { useNavigate } from 'react-router';
 import { Csprng } from '../../class/rng';
@@ -16,6 +18,8 @@ const SettingsPage: React.FC = () => {
   const navigate = useNavigate();
   const { setStep } = useContext(InitializationContext);
   const { accountNumber, setAccountNumber } = useContext(AccountNumberContext);
+  const { settings, updateSetting } = useSettings();
+
   const assert = (condition: boolean, message: string) => {
     if (!condition) throw new Error('Assertion failed: ' + message);
   };
@@ -30,6 +34,14 @@ const SettingsPage: React.FC = () => {
   const setSelectedAccount = (value: string) => {
     console.log(typeof value, value);
     setAccountNumber(parseInt(value));
+  };
+
+  const handleSettingChange = async (key: string, value: string | boolean) => {
+    try {
+      await updateSetting(key as any, value);
+    } catch (error) {
+      console.error('Error updating setting:', error);
+    }
   };
 
   return (
@@ -47,6 +59,29 @@ const SettingsPage: React.FC = () => {
             <option value={4}>Pocket 4</option>
           </Select>
         </div>
+      </div>
+
+      {/* App Settings Section */}
+      <div style={{ textAlign: 'left', fontSize: '16px', marginBottom: '20px' }}>
+        {Object.keys(SETTINGS_CONFIG).map((key) => {
+          const config = SETTINGS_CONFIG[key as keyof typeof SETTINGS_CONFIG];
+          const currentValue = settings[key as keyof typeof SETTINGS_CONFIG];
+
+          return (
+            <div key={key} style={{ marginBottom: '15px' }}>
+              <ThemedText>{key.charAt(0).toUpperCase() + key.slice(1).replace(/([A-Z])/g, ' $1')}:</ThemedText>
+              <div style={{ marginTop: '5px' }}>
+                <Select id={`setting-${key}`} value={currentValue} onChange={(e) => handleSettingChange(key, e.target.value)}>
+                  {config.options.map((option: string) => (
+                    <option key={option} value={option}>
+                      {option === 'never' ? 'Never' : option === 'ON' ? 'On' : option === 'OFF' ? 'Off' : option.length === 2 ? option.toUpperCase() : option.charAt(0).toUpperCase() + option.slice(1)}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+            </div>
+          );
+        })}
       </div>
 
       <div style={{ fontSize: '12px' }}>

--- a/ext/src/tests/e2e/main.spec.ts
+++ b/ext/src/tests/e2e/main.spec.ts
@@ -69,6 +69,15 @@ test('can send coins to second account, and verify balance', async ({ page, exte
 
   await helperImportWallet(page, extensionId, process.env.TEST_MNEMONIC);
   await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  // Testnet is not visible by default
+  await expect(page.getByText(/Sepolia/)).not.toBeVisible();
+
+  // Enabling all testnets
+  await page.getByTestId('settings-button').click();
+  await page.selectOption('select[id="setting-showTestnets"]', 'ON');
+  await page.goto(`chrome-extension://${extensionId}/popup.html`); // Navigate back to home
+
   await page.getByText(/Sepolia/).click();
   await new Promise((resolve) => setTimeout(resolve, 5_000)); // sleep, waiting for balance to load on screen
 

--- a/shared/hooks/SettingsContext.tsx
+++ b/shared/hooks/SettingsContext.tsx
@@ -1,0 +1,123 @@
+import React, { createContext, ReactNode, useEffect, useState } from 'react';
+
+import { IStorage, STORAGE_KEY_SETTINGS } from '../types/IStorage';
+
+// Define all possible settings with their types, possible values, and defaults
+export const SETTINGS_CONFIG = {
+  /* 
+  // reserved for future use: 
+  language: {
+    options: ['en', 'es', 'fr', 'zh', 'ja'] as const,
+    default: 'en' as const,
+  }, */
+  showTestnets: {
+    options: ['ON', 'OFF'] as const,
+    default: 'OFF' as const,
+  },
+} as const;
+
+// Derive the AppSettings interface from the config
+export type AppSettings = {
+  [K in keyof typeof SETTINGS_CONFIG]: (typeof SETTINGS_CONFIG)[K] extends { options: readonly any[] } ? (typeof SETTINGS_CONFIG)[K]['options'][number] : (typeof SETTINGS_CONFIG)[K]['default'];
+};
+
+// Derive default settings from the config
+export const DEFAULT_SETTINGS: AppSettings = Object.fromEntries(Object.entries(SETTINGS_CONFIG).map(([key, config]) => [key, config.default])) as AppSettings;
+
+// Extract options for settings that have them
+export const SETTING_OPTIONS = Object.fromEntries(
+  Object.entries(SETTINGS_CONFIG)
+    .filter(([_, config]) => 'options' in config)
+    .map(([key, config]) => [key, (config as any).options])
+) as {
+  [K in keyof typeof SETTINGS_CONFIG]: (typeof SETTINGS_CONFIG)[K] extends { options: readonly any[] } ? (typeof SETTINGS_CONFIG)[K]['options'] : never;
+};
+
+interface ISettingsContext {
+  settings: AppSettings;
+  updateSetting: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => Promise<void>;
+  resetToDefaults: () => Promise<void>;
+  getSetting: <K extends keyof AppSettings>(key: K) => AppSettings[K];
+}
+
+export const SettingsContext = createContext<ISettingsContext>({
+  settings: DEFAULT_SETTINGS,
+  updateSetting: async () => {
+    throw new Error('SettingsContext.updateSetting(): This should never happen');
+  },
+  resetToDefaults: async () => {
+    throw new Error('SettingsContext.resetToDefaults(): This should never happen');
+  },
+  getSetting: () => {
+    throw new Error('SettingsContext.getSetting(): This should never happen');
+  },
+});
+
+interface SettingsContextProviderProps {
+  children: ReactNode;
+  storage: IStorage;
+}
+
+export const SettingsContextProvider: React.FC<SettingsContextProviderProps> = (props) => {
+  const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
+
+  // Load settings from storage on initialization
+  useEffect(() => {
+    (async () => {
+      try {
+        const storedSettings = await props.storage.getItem(STORAGE_KEY_SETTINGS);
+        if (storedSettings) {
+          const parsedSettings = JSON.parse(storedSettings);
+          // Merge with defaults to ensure all settings exist
+          const mergedSettings = { ...DEFAULT_SETTINGS, ...parsedSettings };
+          setSettings(mergedSettings);
+        } else {
+          // No settings stored, use defaults
+          setSettings(DEFAULT_SETTINGS);
+        }
+      } catch (error) {
+        console.error('Error loading settings, using defaults:', error);
+        setSettings(DEFAULT_SETTINGS);
+      }
+    })();
+  }, [props.storage]);
+
+  const updateSetting = async <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => {
+    const newSettings = { ...settings, [key]: value };
+    setSettings(newSettings);
+
+    // Store in storage
+    try {
+      await props.storage.setItem(STORAGE_KEY_SETTINGS, JSON.stringify(newSettings));
+    } catch (error) {
+      console.error('Error saving settings:', error);
+    }
+  };
+
+  const resetToDefaults = async () => {
+    setSettings(DEFAULT_SETTINGS);
+
+    try {
+      await props.storage.setItem(STORAGE_KEY_SETTINGS, JSON.stringify(DEFAULT_SETTINGS));
+    } catch (error) {
+      console.error('Error saving default settings:', error);
+    }
+  };
+
+  const getSetting = <K extends keyof AppSettings>(key: K): AppSettings[K] => {
+    return settings[key];
+  };
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        settings,
+        updateSetting,
+        resetToDefaults,
+        getSetting,
+      }}
+    >
+      {props.children}
+    </SettingsContext.Provider>
+  );
+};

--- a/shared/hooks/useAvailableNetworks.ts
+++ b/shared/hooks/useAvailableNetworks.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { getAvailableNetworks, Networks } from '../types/networks';
+import { getIsTestnet } from '../models/network-getters';
+import { useSetting } from './useSettings';
+
+/**
+ * Hook that returns available networks filtered by testnet settings
+ * Filters out testnet networks if showTestnets is set to 'OFF'
+ */
+export const useAvailableNetworks = (): Networks[] => {
+  const showTestnets = useSetting('showTestnets');
+
+  return useMemo(() => {
+    const allNetworks = getAvailableNetworks();
+
+    if (showTestnets === 'ON') {
+      return allNetworks;
+    }
+
+    // Filter out testnet networks when showTestnets is 'OFF'
+    return allNetworks.filter((network) => !getIsTestnet(network));
+  }, [showTestnets]);
+};

--- a/shared/hooks/useSettings.ts
+++ b/shared/hooks/useSettings.ts
@@ -1,0 +1,18 @@
+import { useContext } from 'react';
+import { SettingsContext, AppSettings } from './SettingsContext';
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsContextProvider');
+  }
+
+  return context;
+};
+
+// Type-safe hook for getting a specific setting
+export const useSetting = <K extends keyof AppSettings>(key: K): AppSettings[K] => {
+  const { getSetting } = useSettings();
+  return getSetting(key);
+};

--- a/shared/tests/unit-vi/codebase.test.ts
+++ b/shared/tests/unit-vi/codebase.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, it } from 'vitest';
 import assert from 'assert';
+import { SETTINGS_CONFIG } from '../../hooks/SettingsContext';
 
 describe('codebase', function () {
   /**
@@ -22,5 +23,14 @@ describe('codebase', function () {
 
     assert.strictEqual(extPrettierConfig, mobilePrettierConfig);
     assert.strictEqual(extPrettierConfig, sharedPrettierConfig);
+  });
+
+  it('all SETTINGS_CONFIG default values are among possible options', function () {
+    Object.entries(SETTINGS_CONFIG).forEach(([key, config]) => {
+      const defaultValue = config.default;
+      const options = config.options as readonly any[];
+
+      assert(options.includes(defaultValue), `Setting "${key}" has default value "${defaultValue}" which is not among the possible options: [${options.join(', ')}]`);
+    });
   });
 });

--- a/shared/types/IStorage.ts
+++ b/shared/types/IStorage.ts
@@ -7,6 +7,7 @@ export const STORAGE_KEY_WHITELIST = 'STORAGE_KEY_WHITELIST';
 export const STORAGE_KEY_ACCEPTED_TOS = 'STORAGE_KEY_ACCEPTED_TOS';
 export const STORAGE_KEY_SERIALIZED = 'STORAGE_KEY_SERIALIZED';
 export const STORAGE_KEY_SUB_MNEMONIC = 'STORAGE_KEY_SUB_MNEMONIC';
+export const STORAGE_KEY_SETTINGS = 'STORAGE_KEY_SETTINGS';
 
 export interface IStorage {
   setItem(key: string, value: string): Promise<void>;


### PR DESCRIPTION
in this PR i introduce a generic mechanism  to store all kind of settings in the app, such as language, currency, etc.

it is implemented as a context provider and has a dedicated hook `useSettings()`.

i added a first setting to show all testnets or not (default: do not show)

additional hook `useAvailableNetworks` is aware of  this setting and will not return testnet networks if testnets are disabled.

since its all hooks, its all reactive and updates instantly across the app.


the settings page itself renders all values from settings dynamically, so we can only edit `SETTINGS_CONFIG` to add new settings and UI will reflect this.


this PR adds this to `ext`  only, I will add this to `mobile` in a separate PR.


PS. whole code was vibecoded in cursor