### PR TITLE
feat: display correct cached pocket balance

### DIFF
--- a/ext/src/class/swr-cache-provider.ts
+++ b/ext/src/class/swr-cache-provider.ts
@@ -12,11 +12,11 @@ import { State } from 'swr/_internal';
  * @see https://swr.vercel.app/docs/advanced/cache
  */
 export class SwrCacheProvider implements Cache<any> {
-  private cachePrefix = 'cache-v3-';
+  private cachePrefix = 'cache-v4-';
 
   get(key: string): State<any> | undefined {
     try {
-      let value = localStorage.getItem(`${this.cachePrefix}${key}`);
+      let value = localStorage.getItem(key.startsWith(this.cachePrefix) ? key : `${this.cachePrefix}${key}`);
       if (value) {
         const data = JSON.parse(value);
         return { data };
@@ -39,6 +39,15 @@ export class SwrCacheProvider implements Cache<any> {
   }
 
   keys(): IterableIterator<string> {
-    return [].values();
+    const that = this;
+    function* generator() {
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith(that.cachePrefix)) {
+          yield key;
+        }
+      }
+    }
+    return generator();
   }
 }

--- a/ext/src/pages/Popup/Home.tsx
+++ b/ext/src/pages/Popup/Home.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
+import { useAccountBalance } from '@shared/hooks/useAccountBalance';
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
 import { fiatOnRamp } from '@shared/models/fiat-on-ramp';
 import { getSwapPairs } from '@shared/models/swap-providers-list';
@@ -32,6 +33,7 @@ const Home: React.FC = () => {
   const [swapPairs, setSwapPairs] = useState<SwapPair[]>([]);
   const [showSwapInterface, setShowSwapInterface] = useState<boolean>(false);
   const availableNetworks = useAvailableNetworks();
+  const { accountBalance } = useAccountBalance(accountNumber, availableNetworks);
 
   useEffect(() => {
     setIsTestnet(getIsTestnet(network));
@@ -127,6 +129,9 @@ const Home: React.FC = () => {
           <span style={{ fontSize: 14 }}>{balance && +balance > 0 && exchangeRate ? '$' + formatFiatBalance(balance, getDecimalsByNetwork(network), exchangeRate) : ''}</span>
         </div>
       </h1>
+      <h3>
+        <span id="pocket-balance">Pocket balance: {accountBalance ? formatBalance(accountBalance, getDecimalsByNetwork(NETWORK_BITCOIN), 8) : ''}</span> {getTickerByNetwork(NETWORK_BITCOIN)}
+      </h3>
 
       {showSwapInterface ? (
         <SwapInterfaceView />

--- a/mobile/app/home.tsx
+++ b/mobile/app/home.tsx
@@ -17,26 +17,14 @@ import { getNetworkGradient, getNetworkIcon } from '@shared/constants/Colors';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
+import { useAccountBalance } from '@shared/hooks/useAccountBalance';
+import { useAvailableNetworks } from '@shared/hooks/useAvailableNetworks';
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
 import { fiatOnRamp } from '@shared/models/fiat-on-ramp';
 import { getDecimalsByNetwork, getIsEVM, getIsTestnet, getTickerByNetwork } from '@shared/models/network-getters';
 import { getSwapPairs } from '@shared/models/swap-providers-list';
 import { formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
-import {
-  NETWORK_ARKMUTINYNET,
-  NETWORK_BITCOIN,
-  NETWORK_BOTANIX,
-  NETWORK_BOTANIXTESTNET,
-  NETWORK_CITREATESTNET,
-  NETWORK_LIGHTNING,
-  NETWORK_LIGHTNINGTESTNET,
-  NETWORK_LIQUID,
-  NETWORK_LIQUIDTESTNET,
-  NETWORK_ROOTSTOCK,
-  NETWORK_SEPOLIA,
-  NETWORK_SPARK,
-  NETWORK_STRATADEVNET,
-} from '@shared/types/networks';
+import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIGHTNING, NETWORK_LIGHTNINGTESTNET, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK } from '@shared/types/networks';
 import { SwapPair, SwapPlatform } from '@shared/types/swap';
 
 export default function HomeScreen() {
@@ -47,6 +35,8 @@ export default function HomeScreen() {
   const router = useRouter();
   const [swapPairs, setSwapPairs] = useState<SwapPair[]>([]);
   const [showSwapInterface, setShowSwapInterface] = useState<boolean>(false);
+  const availableNetworks = useAvailableNetworks();
+  const { accountBalance } = useAccountBalance(accountNumber, availableNetworks);
 
   useEffect(() => {
     setSwapPairs(getSwapPairs(network, SwapPlatform.MOBILE));
@@ -189,7 +179,7 @@ export default function HomeScreen() {
         <ThemedView style={styles.balanceContainer}>
           <ThemedText style={styles.balanceLabel}>Pocket Balance:</ThemedText>
           <ThemedText style={styles.balanceText} adjustsFontSizeToFit numberOfLines={1}>
-            {balance ? formatBalance(balance, getDecimalsByNetwork(network)) + ' ' + getTickerByNetwork(network) : '???'}
+            {accountBalance ? formatBalance(accountBalance, getDecimalsByNetwork(NETWORK_BITCOIN)) + ' ' + getTickerByNetwork(NETWORK_BITCOIN) : ''}
           </ThemedText>
           <ThemedText style={styles.balanceLabel} testID="LayerBalance">
             Layer Balance:

--- a/shared/hooks/useAccountBalance.ts
+++ b/shared/hooks/useAccountBalance.ts
@@ -1,0 +1,51 @@
+import { useSWRConfig } from 'swr';
+import { NETWORK_BITCOIN, NETWORK_LIGHTNING, Networks } from '../types/networks';
+import { getDecimalsByNetwork, getIsTestnet } from '../models/network-getters';
+import { StringNumber } from '../types/string-number';
+
+/**
+ * a bit hacky hook to get whole account balance from the SWR cache.
+ * accessing SWR cache is legit, through the official SWR api.
+ * as a sideeffect, we can also get _cached_ balance for a single network (that wont trigger network fetch)
+ *
+ * @param accountNumber - the account number
+ * @param availableNetworks - array of networks for which we want to get the balance (since user might
+ *                            disable showing some networks in the UI)
+ *
+ * @returns the account balance in **sats** (as a StringNumber), networks with higher denomination
+ *          will be truncated (aka precision dropped)
+ */
+export const useAccountBalance = (accountNumber: number, availableNetworks: Networks[]): { accountBalance: StringNumber } => {
+  const { cache } = useSWRConfig();
+
+  let sumSats = 0;
+
+  for (const key of cache.keys()) {
+    for (const network of availableNetworks) {
+      if (network === NETWORK_LIGHTNING) continue; // its an "aggregated" network, we don't need to count it
+
+      if (getIsTestnet(network)) continue; // we don't count testnet networks, they are worthless
+
+      if (key.includes(`balanceFetcher`) && key.includes(`accountNumber:${accountNumber}`) && key.includes(`network:"${network}"`)) {
+        const balance = cache.get(key);
+        let networkBalance = parseInt(balance?.data);
+        const defaultDecimals = getDecimalsByNetwork(NETWORK_BITCOIN);
+        const decimals = getDecimalsByNetwork(network);
+
+        if (decimals > defaultDecimals) {
+          // droping extra precision for networks that have more decimals than bitcoin,
+          // but still peg 1 to 1 with btc
+          networkBalance = Math.floor(networkBalance / 10 ** (decimals - defaultDecimals));
+        }
+
+        if (balance?.data && networkBalance) {
+          sumSats += networkBalance;
+        }
+      }
+    }
+  }
+
+  return {
+    accountBalance: String(sumSats),
+  };
+};


### PR DESCRIPTION
a bit hacky,  but it was surprisingly easy to make and it works surprisingly well (so far).
my pocket balances match exactly on mobile and ext, to the last sat

we can also use this to get _cached_ balance for  _specific network_:

```js
const cachedBalance = useAccountBalance(accounNum, [NETWORK_BITCOIN]);
```