### PR TITLE
feat: unified lightning-receive on ext (rel #135)

### DIFF
--- a/ext/src/pages/Popup/DesignSystem.tsx
+++ b/ext/src/pages/Popup/DesignSystem.tsx
@@ -21,6 +21,176 @@ export const SelectFeeSlider: React.FC<
   );
 };
 
+// ActionPopupButton Component
+export const ActionPopupButton: React.FC<{
+  children: React.ReactNode;
+  actions: Array<{ label: string; onClick: () => void }>;
+  disabled?: boolean;
+}> = ({ children, actions, disabled }) => {
+  const [showPopup, setShowPopup] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [popupPosition, setPopupPosition] = useState({ x: 0, y: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const handleClick = (event: React.MouseEvent) => {
+    if (disabled) return;
+    event.stopPropagation();
+
+    if (buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setPopupPosition({
+        x: rect.left,
+        y: rect.top - 150,
+      });
+    }
+    setShowPopup(true);
+    setProgress(0);
+
+    // Start progress for default button (first action)
+    intervalRef.current = setInterval(() => {
+      setProgress((prevProgress) => {
+        if (prevProgress < 100) {
+          return prevProgress + (100 * 10) / 3000; // 3 seconds = 3000ms
+        }
+        clearInterval(intervalRef.current!);
+        // Trigger default action when progress reaches 100%
+        actions[0]?.onClick();
+        setShowPopup(false);
+        return 100;
+      });
+    }, 10);
+  };
+
+  const handleActionClick = (action: () => void) => {
+    // Clear the progress interval
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    // Trigger the clicked action
+    action();
+    setShowPopup(false);
+    setProgress(0);
+  };
+
+  const handleClose = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    setShowPopup(false);
+    setProgress(0);
+  };
+
+  // Close popup when clicking outside
+  useEffect(() => {
+    if (showPopup) {
+      const handleClickOutside = (event: MouseEvent) => {
+        const target = event.target as Element;
+        if (!target.closest('[data-popup-container]')) {
+          handleClose();
+        }
+      };
+
+      // Use setTimeout to avoid immediate closure
+      setTimeout(() => {
+        document.addEventListener('click', handleClickOutside);
+      }, 100);
+
+      return () => document.removeEventListener('click', handleClickOutside);
+    }
+  }, [showPopup]);
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block', zIndex: 1 }}>
+      <button
+        ref={buttonRef}
+        onClick={handleClick}
+        disabled={disabled}
+        style={{
+          backgroundColor: '#282c34',
+          color: 'white',
+          border: '1px solid white',
+          padding: '10px 20px',
+          borderRadius: '5px',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          fontSize: '20px',
+          transition: 'background-color 0.3s',
+          opacity: disabled ? 0.5 : 1,
+          display: 'inline-flex',
+          alignItems: 'center',
+          whiteSpace: 'nowrap',
+          margin: '0 5px 5px 0',
+        }}
+      >
+        {children}
+      </button>
+
+      {showPopup && (
+        <div
+          data-popup-container
+          style={{
+            position: 'fixed',
+            top: popupPosition.y,
+            left: popupPosition.x,
+            backgroundColor: 'white',
+            border: '1px solid #ccc',
+            borderRadius: '8px',
+            padding: '10px',
+            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+            zIndex: 1000,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+            minWidth: '200px',
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {actions.map((action, index) => (
+            <button
+              key={index}
+              onClick={() => handleActionClick(action.onClick)}
+              style={{
+                backgroundColor: '#282c34',
+                color: 'white',
+                border: '1px solid white',
+                padding: '10px 20px',
+                borderRadius: '5px',
+                cursor: 'pointer',
+                fontSize: '16px',
+                transition: 'background-color 0.3s',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                width: '100%',
+                position: 'relative',
+                ...(index === 0 && {
+                  // Default button (first action) has progress bar
+                  overflow: 'hidden',
+                }),
+              }}
+            >
+              {index === 0 && progress > 0 && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    bottom: 0,
+                    left: 0,
+                    width: `${progress}%`,
+                    height: '5px',
+                    backgroundColor: 'white',
+                    transition: 'width 0.1s linear',
+                  }}
+                />
+              )}
+              <span style={{ zIndex: 1, position: 'relative' }}>{action.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
 // Switch Component
 export const Switch = <T extends string>({ items, activeItem, onItemClick }: { items: T[]; activeItem: T; onItemClick: (item: T) => void }) => {
   return (
@@ -639,6 +809,19 @@ export default function DesignSystem() {
         <h2>Toggle Switch</h2>
         <div style={{ marginBottom: '20px' }}>
           <ToggleSwitch checked={toggleValue} onChange={(e) => setToggleValue(e.target.checked)} />
+        </div>
+
+        <h2>Action Popup Button</h2>
+        <div style={{ marginBottom: '20px' }}>
+          <ActionPopupButton
+            actions={[
+              { label: 'Default Action', onClick: () => alert('Default action triggered!') },
+              { label: 'Secondary Action', onClick: () => alert('Secondary action triggered!') },
+              { label: 'Cancel', onClick: () => alert('Cancel action triggered!') },
+            ]}
+          >
+            Show Actions
+          </ActionPopupButton>
         </div>
       </Card>
     </div>

--- a/ext/src/pages/Popup/Home.tsx
+++ b/ext/src/pages/Popup/Home.tsx
@@ -18,9 +18,10 @@ import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIGHTNING, NETWORK_LIGHT
 import { BackgroundCaller } from '../../modules/background-caller';
 import PartnersView from './components/PartnersView';
 import TokensView from './components/TokensView';
-import { Button, Switch } from './DesignSystem';
+import { ActionPopupButton, Button, Switch } from './DesignSystem';
 import LiquidTokensView from './components/LiquidTokensView';
 import SwapInterfaceView from './components/SwapInterfaceView';
+import { ReceiveLightningProps } from './ReceiveLightning';
 
 const Home: React.FC = () => {
   const navigate = useNavigate();
@@ -46,14 +47,7 @@ const Home: React.FC = () => {
   }, [network]);
 
   const handleReceive = () => {
-    switch (network) {
-      case NETWORK_LIGHTNING:
-      case NETWORK_LIGHTNINGTESTNET:
-        navigate('/receive-lightning');
-        break;
-      default:
-        navigate('/receive');
-    }
+    navigate('/receive');
   };
 
   const handleSend = () => {
@@ -76,6 +70,38 @@ const Home: React.FC = () => {
       default:
         navigate('/send-evm');
     }
+  };
+
+  const handleReceiveLightningOnSpark = () => {
+    if (network === NETWORK_LIGHTNINGTESTNET) {
+      alert('Spark has no testnet');
+      return;
+    }
+    const state: ReceiveLightningProps = { network: NETWORK_SPARK };
+    navigate('/receive-lightning', { state });
+  };
+
+  const handleReceiveLightningOnLiquid = () => {
+    let chosenNetwork: typeof NETWORK_LIQUIDTESTNET | typeof NETWORK_LIQUID = NETWORK_LIQUID; // default - mainnet
+
+    if (network === NETWORK_LIGHTNINGTESTNET) {
+      chosenNetwork = NETWORK_LIQUIDTESTNET;
+    }
+
+    const state: ReceiveLightningProps = { network: chosenNetwork };
+    navigate('/receive-lightning', { state });
+  };
+
+  const handleBuyClick = () => {
+    BackgroundCaller.getAddress(network, accountNumber).then((addressResponse) => {
+      if (addressResponse) {
+        window.open(`https://layerztec.github.io/website/onramp/?address=${addressResponse}&network=${network}`, '_blank');
+      }
+    });
+  };
+
+  const handleSwapClick = () => {
+    setShowSwapInterface(true);
   };
 
   return (
@@ -112,15 +138,7 @@ const Home: React.FC = () => {
         <span id="home-balance">{balance ? formatBalance(balance, getDecimalsByNetwork(network), 8) : ''}</span> {getTickerByNetwork(network)}
         {fiatOnRamp?.[network]?.canBuyWithFiat ? (
           <span style={{ paddingLeft: '15px' }}>
-            <Button
-              onClick={() => {
-                BackgroundCaller.getAddress(network, accountNumber).then((addressResponse) => {
-                  if (addressResponse) {
-                    window.open(`https://layerztec.github.io/website/onramp/?address=${addressResponse}&network=${network}`, '_blank');
-                  }
-                });
-              }}
-            >
+            <Button onClick={handleBuyClick}>
               <ShoppingCartIcon /> Buy
             </Button>
           </span>
@@ -148,17 +166,33 @@ const Home: React.FC = () => {
         <SendIcon />
         Send
       </Button>
-      <Button onClick={handleReceive}>
-        <ArrowDownRightIcon />
-        Receive
-      </Button>
+
+      {network === NETWORK_LIGHTNING || network === NETWORK_LIGHTNINGTESTNET ? (
+        <ActionPopupButton
+          actions={[
+            {
+              label: 'Receive on Spark',
+              onClick: handleReceiveLightningOnSpark,
+            },
+            {
+              label: 'Receive on Liquid',
+              onClick: handleReceiveLightningOnLiquid,
+            },
+            { label: 'Cancel', onClick: () => {} },
+          ]}
+        >
+          <ArrowDownRightIcon />
+          Receive
+        </ActionPopupButton>
+      ) : (
+        <Button onClick={handleReceive}>
+          <ArrowDownRightIcon />
+          Receive
+        </Button>
+      )}
 
       {swapPairs.length > 0 ? (
-        <Button
-          onClick={() => {
-            setShowSwapInterface(true);
-          }}
-        >
+        <Button onClick={handleSwapClick}>
           <RefreshCwIcon /> Swap
         </Button>
       ) : null}

--- a/ext/src/pages/Popup/ReceiveLightning.tsx
+++ b/ext/src/pages/Popup/ReceiveLightning.tsx
@@ -1,29 +1,32 @@
-import { PrepareReceiveRequest, ReceivePaymentRequest } from '@breeztech/breez-sdk-liquid';
 import writeQR from '@paulmillr/qr';
 import BigNumber from 'bignumber.js';
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { ThemedText } from '../../components/ThemedText';
 
 import { BreezWallet, getBreezNetwork } from '@shared/class/wallets/breez-wallet';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
-import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
-import { formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_LIGHTNING, NETWORK_LIGHTNINGTESTNET } from '@shared/types/networks';
+import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-utils';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK, Networks } from '@shared/types/networks';
 import { StringNumber } from '@shared/types/string-number';
 import { BackgroundCaller } from '../../modules/background-caller';
-// import { getBreezNetwork } from '../../modules/breeze-adapter';
 import { AddressBubble, Input, WideButton } from './DesignSystem';
+import { SparkWallet } from '@shared/class/wallets/spark-wallet';
+
+export interface ReceiveLightningProps {
+  network: Networks;
+}
 
 const ReceiveLightning: React.FC = () => {
+  const location = useLocation();
+  const { network } = location.state as ReceiveLightningProps;
   const navigate = useNavigate();
   const [amount, setAmount] = useState<string>('');
   const [invoice, setInvoice] = useState<string>('');
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
-  const network = useContext(NetworkContext).network as typeof NETWORK_LIGHTNING | typeof NETWORK_LIGHTNINGTESTNET;
   const { accountNumber } = useContext(AccountNumberContext);
   const [imgSrc, setImgSrc] = useState('');
   const [oldBalance, setOldBalance] = useState<StringNumber>('');
@@ -31,7 +34,7 @@ const ReceiveLightning: React.FC = () => {
   const [limits, setLimits] = useState<{ min: number; max: number } | null>(null);
   const [isWalletInitialized, setIsWalletInitialized] = useState<boolean>(false);
   const [feesSat, setFeesSat] = useState<number | null>(null);
-  const breezWalletRef = useRef<BreezWallet | null>(null);
+  const walletRef = useRef<BreezWallet | SparkWallet | null>(null);
 
   const isNewBalanceGT = useCallback((): false | StringNumber => {
     if (Boolean(balance && oldBalance && new BigNumber(balance).gt(oldBalance))) {
@@ -68,17 +71,30 @@ const ReceiveLightning: React.FC = () => {
     }
   };
 
-  // Initialize the BreezWallet
+  // Initialize the wallet
   useEffect(() => {
     const initializeWallet = async () => {
       try {
-        const breezMnemonic = await BackgroundCaller.getSubMnemonic(accountNumber);
-        breezWalletRef.current = new BreezWallet(breezMnemonic, getBreezNetwork(network));
+        if (network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET) {
+          const subMnemonic = await BackgroundCaller.getSubMnemonic(accountNumber);
+          const bNetwork = getBreezNetwork(network);
+
+          walletRef.current = new BreezWallet(subMnemonic, bNetwork);
+        }
+
+        if (network === NETWORK_SPARK) {
+          const subMnemonic = await BackgroundCaller.getSubMnemonic(accountNumber);
+
+          walletRef.current = new SparkWallet();
+          walletRef.current.setSecret(subMnemonic);
+          await walletRef.current.init();
+        }
+
         setIsWalletInitialized(true);
 
         // Fetch limits after wallet is initialized
-        if (breezWalletRef.current) {
-          const limitsResponse = await breezWalletRef.current.fetchLightningLimits();
+        if (walletRef.current) {
+          const limitsResponse = await walletRef.current.fetchLightningLimits();
           setLimits({
             min: limitsResponse.receive.minSat,
             max: limitsResponse.receive.maxSat,
@@ -93,7 +109,7 @@ const ReceiveLightning: React.FC = () => {
     initializeWallet();
 
     return () => {
-      breezWalletRef.current = null;
+      walletRef.current = null;
       setIsWalletInitialized(false);
     };
   }, [network, accountNumber]);
@@ -119,7 +135,7 @@ const ReceiveLightning: React.FC = () => {
       return;
     }
 
-    if (!breezWalletRef.current || !isWalletInitialized) {
+    if (!walletRef.current || !isWalletInitialized) {
       setError('Wallet is not initialized yet. Please try again.');
       return;
     }
@@ -143,24 +159,11 @@ const ReceiveLightning: React.FC = () => {
         }
       }
 
-      // Step 1: Prepare receive payment to get fee information
-      const prepareRequest: PrepareReceiveRequest = {
-        paymentMethod: 'lightning',
-        amount: { type: 'bitcoin', payerAmountSat: amountSats },
-      };
+      const response = await walletRef.current.createLightningInvoice(amountSats, 'please pay');
 
-      const prepareResponse = await breezWalletRef.current.prepareReceivePayment(prepareRequest);
-      setFeesSat(prepareResponse.feesSat);
-
-      // Step 2: Generate the actual lightning invoice
-      const receiveRequest: ReceivePaymentRequest = {
-        prepareResponse: prepareResponse,
-        description: `Payment to ${getTickerByNetwork(network)} wallet`,
-      };
-
-      const receiveResponse = await breezWalletRef.current.receivePayment(receiveRequest);
-      setInvoice(receiveResponse.destination);
-      setImgSrc(qrGifDataUrl(receiveResponse.destination));
+      setFeesSat(response.serviceFeeSat);
+      setInvoice(response.invoice);
+      setImgSrc(qrGifDataUrl(response.invoice));
     } catch (err) {
       console.error('Failed to generate invoice:', err);
       setError('Failed to generate invoice. Please try again.');
@@ -191,7 +194,7 @@ const ReceiveLightning: React.FC = () => {
 
   return (
     <div style={{ position: 'relative' }}>
-      <ThemedText type="headline">Receive Lightning on {network.charAt(0).toUpperCase() + network.slice(1)}</ThemedText>
+      <ThemedText type="headline">Receive Lightning on {capitalizeFirstLetter(network)}</ThemedText>
 
       {!invoice ? (
         <>

--- a/shared/class/wallets/interface-lightning-wallet.ts
+++ b/shared/class/wallets/interface-lightning-wallet.ts
@@ -1,6 +1,17 @@
+export interface Limits {
+  minSat: number;
+  maxSat: number;
+  maxZeroConfSat: number;
+}
+
 export interface createLightningInvoiceResponse {
   invoice: string;
   serviceFeeSat: number;
+}
+
+export interface LightningPaymentLimitsResponse {
+  send: Limits;
+  receive: Limits;
 }
 
 export interface InterfaceLightningWallet {
@@ -11,4 +22,6 @@ export interface InterfaceLightningWallet {
   createLightningInvoice(amountSats: number, memo: string): Promise<createLightningInvoiceResponse>;
 
   isInvoicePaid(invoice: string): Promise<boolean>;
+
+  fetchLightningLimits(): Promise<LightningPaymentLimitsResponse>;
 }

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -1,6 +1,6 @@
 import { ArkWallet } from './ark-wallet';
 import { SparkWallet as SDK } from '@buildonspark/spark-sdk';
-import { createLightningInvoiceResponse, InterfaceLightningWallet } from './interface-lightning-wallet';
+import { createLightningInvoiceResponse, InterfaceLightningWallet, LightningPaymentLimitsResponse } from './interface-lightning-wallet';
 import bolt11 from 'bolt11';
 
 export interface ISparkAdapter {
@@ -115,5 +115,20 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
     if (lightningPaymentStatus?.status === 'TRANSFER_COMPLETED') return true;
 
     return false;
+  }
+
+  async fetchLightningLimits(): Promise<LightningPaymentLimitsResponse> {
+    return Promise.resolve({
+      send: {
+        maxSat: -1,
+        minSat: -1,
+        maxZeroConfSat: -1,
+      },
+      receive: {
+        maxZeroConfSat: 0,
+        minSat: 0,
+        maxSat: 100000000,
+      },
+    });
   }
 }


### PR DESCRIPTION
this is first PR to utilize unified lightning interface for classes of breez & spark.

* vibecoded an action button that shows tooltip where do you want to receive ln - on liquid or spark
* receive screen for lightning is now more or less wallet-agnostic and can work with provided wallet


TODO in next PRs: 

* [ ] teach lightning-receive screen to check specific invoice status instead of polling for whole balance (might leave polling for balance as a fallback)
* [ ] port changes to mobile
* [ ] 'Lightning' network should display multiple balances (liquid & spark atm)
* [ ] do the same for Send button - choose how to send, make the screen wallet-agnostic


<img width="793" height="533" alt="image" src="https://github.com/user-attachments/assets/5f3cb185-28b9-4a34-ba5a-1acc1f06117b" />
