### PR TITLE
feat: unified lightning send

### DIFF
--- a/ext/src/pages/Popup/Home.tsx
+++ b/ext/src/pages/Popup/Home.tsx
@@ -22,6 +22,7 @@ import { ActionPopupButton, Button, Switch } from './DesignSystem';
 import LiquidTokensView from './components/LiquidTokensView';
 import SwapInterfaceView from './components/SwapInterfaceView';
 import { ReceiveLightningProps } from './ReceiveLightning';
+import { SendLightningProps } from './SendLightning';
 
 const Home: React.FC = () => {
   const navigate = useNavigate();
@@ -81,6 +82,15 @@ const Home: React.FC = () => {
     navigate('/receive-lightning', { state });
   };
 
+  const handleSendLightningOnSpark = () => {
+    if (network === NETWORK_LIGHTNINGTESTNET) {
+      alert('Spark has no testnet');
+      return;
+    }
+    const state: SendLightningProps = { network: NETWORK_SPARK };
+    navigate('/send-lightning', { state });
+  };
+
   const handleReceiveLightningOnLiquid = () => {
     let chosenNetwork: typeof NETWORK_LIQUIDTESTNET | typeof NETWORK_LIQUID = NETWORK_LIQUID; // default - mainnet
 
@@ -90,6 +100,17 @@ const Home: React.FC = () => {
 
     const state: ReceiveLightningProps = { network: chosenNetwork };
     navigate('/receive-lightning', { state });
+  };
+
+  const handleSendLightningOnLiquid = () => {
+    let chosenNetwork: typeof NETWORK_LIQUIDTESTNET | typeof NETWORK_LIQUID = NETWORK_LIQUID; // default - mainnet
+
+    if (network === NETWORK_LIGHTNINGTESTNET) {
+      chosenNetwork = NETWORK_LIQUIDTESTNET;
+    }
+
+    const state: SendLightningProps = { network: chosenNetwork };
+    navigate('/send-lightning', { state });
   };
 
   const handleBuyClick = () => {
@@ -162,10 +183,30 @@ const Home: React.FC = () => {
 
       <br />
       <br />
-      <Button onClick={handleSend}>
-        <SendIcon />
-        Send
-      </Button>
+
+      {network === NETWORK_LIGHTNING || network === NETWORK_LIGHTNINGTESTNET ? (
+        <ActionPopupButton
+          actions={[
+            {
+              label: 'Send via Spark',
+              onClick: handleSendLightningOnSpark,
+            },
+            {
+              label: 'Send via Liquid',
+              onClick: handleSendLightningOnLiquid,
+            },
+            { label: 'Cancel', onClick: () => {} },
+          ]}
+        >
+          <SendIcon />
+          Send
+        </ActionPopupButton>
+      ) : (
+        <Button onClick={handleSend}>
+          <SendIcon />
+          Send
+        </Button>
+      )}
 
       {network === NETWORK_LIGHTNING || network === NETWORK_LIGHTNINGTESTNET ? (
         <ActionPopupButton

--- a/ext/src/pages/Popup/ReceiveLightning.tsx
+++ b/ext/src/pages/Popup/ReceiveLightning.tsx
@@ -1,19 +1,16 @@
 import writeQR from '@paulmillr/qr';
-import BigNumber from 'bignumber.js';
-import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { ThemedText } from '../../components/ThemedText';
 
-import { BreezWallet, getBreezNetwork } from '@shared/class/wallets/breez-wallet';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
-import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK, Networks } from '@shared/types/networks';
-import { StringNumber } from '@shared/types/string-number';
+import { Networks } from '@shared/types/networks';
 import { BackgroundCaller } from '../../modules/background-caller';
 import { AddressBubble, Input, WideButton } from './DesignSystem';
-import { SparkWallet } from '@shared/class/wallets/spark-wallet';
+import { WalletFactory } from '@shared/class/wallet-factory';
+import { TLightningWallet } from '@shared/types/TWallet';
 
 export interface ReceiveLightningProps {
   network: Networks;
@@ -29,28 +26,62 @@ const ReceiveLightning: React.FC = () => {
   const [error, setError] = useState<string>('');
   const { accountNumber } = useContext(AccountNumberContext);
   const [imgSrc, setImgSrc] = useState('');
-  const [oldBalance, setOldBalance] = useState<StringNumber>('');
-  const { balance } = useBalance(network, accountNumber, BackgroundCaller);
   const [limits, setLimits] = useState<{ min: number; max: number } | null>(null);
   const [isWalletInitialized, setIsWalletInitialized] = useState<boolean>(false);
   const [feesSat, setFeesSat] = useState<number | null>(null);
-  const walletRef = useRef<BreezWallet | SparkWallet | null>(null);
+  const walletRef = useRef<TLightningWallet | null>(null);
+  const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [isInvoicePaid, setIsInvoicePaid] = useState<boolean>(false);
 
-  const isNewBalanceGT = useCallback((): false | StringNumber => {
-    if (Boolean(balance && oldBalance && new BigNumber(balance).gt(oldBalance))) {
-      return new BigNumber(balance ?? '0').minus(oldBalance).toString(10);
-    }
-
-    return false;
-  }, [balance, oldBalance]);
-
+  // Polling effect for invoice payment status
   useEffect(() => {
-    if (!oldBalance && balance) {
-      // initial update
-      setOldBalance(balance);
+    if (!invoice || !walletRef.current) {
       return;
     }
-  }, [balance, isNewBalanceGT, oldBalance]);
+
+    const pollForPayment = async () => {
+      try {
+        const wallet = walletRef.current;
+        if (!wallet) return;
+
+        const isPaid = await wallet.isInvoicePaid(invoice);
+        if (isPaid) {
+          setIsInvoicePaid(true);
+          // Clear the interval when payment is detected
+          if (pollingIntervalRef.current) {
+            clearInterval(pollingIntervalRef.current);
+            pollingIntervalRef.current = null;
+          }
+        }
+      } catch (error) {
+        console.error('Error checking invoice payment status:', error);
+      }
+    };
+
+    // Start polling immediately
+    pollForPayment();
+
+    // Set up interval to poll every 5 seconds
+    pollingIntervalRef.current = setInterval(pollForPayment, 3_000);
+
+    // Cleanup function
+    return () => {
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current);
+        pollingIntervalRef.current = null;
+      }
+    };
+  }, [invoice]);
+
+  // Cleanup interval when component unmounts
+  useEffect(() => {
+    return () => {
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current);
+        pollingIntervalRef.current = null;
+      }
+    };
+  }, []);
 
   const qrGifDataUrl = (text: string) => {
     const gifBytes = writeQR(text, 'gif', {
@@ -75,21 +106,7 @@ const ReceiveLightning: React.FC = () => {
   useEffect(() => {
     const initializeWallet = async () => {
       try {
-        if (network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET) {
-          const subMnemonic = await BackgroundCaller.getSubMnemonic(accountNumber);
-          const bNetwork = getBreezNetwork(network);
-
-          walletRef.current = new BreezWallet(subMnemonic, bNetwork);
-        }
-
-        if (network === NETWORK_SPARK) {
-          const subMnemonic = await BackgroundCaller.getSubMnemonic(accountNumber);
-
-          walletRef.current = new SparkWallet();
-          walletRef.current.setSecret(subMnemonic);
-          await walletRef.current.init();
-        }
-
+        walletRef.current = await WalletFactory.getInstance().getLightningWallet(network, accountNumber, BackgroundCaller);
         setIsWalletInitialized(true);
 
         // Fetch limits after wallet is initialized
@@ -101,7 +118,7 @@ const ReceiveLightning: React.FC = () => {
           });
         }
       } catch (err) {
-        console.error('Failed to initialize Breez wallet:', err);
+        console.error('Failed to initialize wallet:', err);
         setError('Failed to initialize wallet. Please try again.');
       }
     };
@@ -172,7 +189,7 @@ const ReceiveLightning: React.FC = () => {
     }
   };
 
-  if (isNewBalanceGT()) {
+  if (isInvoicePaid) {
     return (
       <div style={{ position: 'relative' }}>
         <ThemedText type="headline">Receive Lightning on {network.charAt(0).toUpperCase() + network.slice(1)}</ThemedText>
@@ -181,7 +198,7 @@ const ReceiveLightning: React.FC = () => {
           <div style={{ color: '#4CAF50', fontSize: '48px', marginBottom: '20px' }}>✓</div>
           <h2 style={{ color: '#4CAF50', marginBottom: '15px' }}>
             <ThemedText type="headline">
-              Received: +{isNewBalanceGT() ? formatBalance(String(isNewBalanceGT()), getDecimalsByNetwork(network), 8) : ''} {getTickerByNetwork(network)}
+              Received: +{formatBalance(String(+amount - (feesSat || 0)), getDecimalsByNetwork(network), 8)} {getTickerByNetwork(network)}
             </ThemedText>
           </h2>
           <WideButton onClick={() => navigate('/')}>

--- a/ext/src/pages/Popup/SendLightning.tsx
+++ b/ext/src/pages/Popup/SendLightning.tsx
@@ -1,71 +1,88 @@
-import BigNumber from 'bignumber.js';
 import { Scan, ZapIcon } from 'lucide-react';
-import React, { useContext, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
 import { ThemedText } from '../../components/ThemedText';
-import { PrepareSendRequest, PrepareSendResponse, SendPaymentRequest } from '@breeztech/breez-sdk-liquid';
-
-import { BreezWallet, getBreezNetwork } from '@shared/class/wallets/breez-wallet';
+import * as bolt11 from 'bolt11';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
-import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET } from '@shared/types/networks';
+import { NETWORK_BITCOIN, Networks } from '@shared/types/networks';
 import { AskMnemonicContext } from '../../hooks/AskMnemonicContext';
 import { useScanQR } from '../../hooks/ScanQrContext';
 import { BackgroundCaller } from '../../modules/background-caller';
 import { Button, HodlButton, Input, WideButton } from './DesignSystem';
+import BigNumber from 'bignumber.js';
+import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
+import { WalletFactory } from '@shared/class/wallet-factory';
+import { TLightningWallet } from '@shared/types/TWallet';
+
+export interface SendLightningProps {
+  network: Networks;
+}
+
+const maxFeePercent = 1; // hardcoded at the moment. might give user option to adjust later
 
 const SendLightning: React.FC = () => {
+  const location = useLocation();
+  const { network } = location.state as SendLightningProps;
   const scanQr = useScanQR();
   const navigate = useNavigate();
   const { askMnemonic } = useContext(AskMnemonicContext);
   const [invoice, setInvoice] = useState<string>('');
   const [error, setError] = useState<string>('');
-  const [sendState, setSendState] = useState<'idle' | 'preparing' | 'prepared' | 'success'>('idle');
-  const [preparedResponse, setPreparedResponse] = useState<PrepareSendResponse | null>(null);
+  const [sendState, setSendState] = useState<'idle' | 'preparing' | 'prepared' | 'sending' | 'success'>('idle');
   const [feeSats, setFeeSats] = useState<number | null>(null);
   const [amountToSend, setAmountToSend] = useState<string>('');
-  const network = useContext(NetworkContext).network as typeof NETWORK_LIQUID | typeof NETWORK_LIQUIDTESTNET;
   const { accountNumber } = useContext(AccountNumberContext);
-  const breezWallet = useRef<BreezWallet | null>(null);
+  const walletRef = useRef<TLightningWallet | null>(null);
+
+  const onInvoiceInput = async (scanned: string) => {
+    setInvoice(scanned);
+    try {
+      const decoded = bolt11.decode(scanned.trim());
+      setAmountToSend(String(decoded.satoshis));
+
+      if (!decoded.satoshis) {
+        throw new Error('Could not determine payment amount from invoice');
+      }
+
+      const feeBN = new BigNumber(decoded.satoshis).dividedBy(100).multipliedBy(maxFeePercent).toNumber();
+      setFeeSats(Math.max(Math.round(feeBN), 1));
+      setError('');
+    } catch (error: any) {
+      setError(error.message);
+    }
+  };
 
   const handleQRScan = async () => {
     const scanned = await scanQr();
-    if (scanned) {
-      setInvoice(scanned);
+    if (scanned && scanned.trim()) {
+      await onInvoiceInput(scanned.trim());
     }
   };
+
+  // Initialize the wallet
+  useEffect(() => {
+    const initializeWallet = async () => {
+      try {
+        walletRef.current = await WalletFactory.getInstance().getLightningWallet(network, accountNumber, BackgroundCaller);
+      } catch (err) {
+        console.error('Failed to initialize wallet:', err);
+        setError('Failed to initialize wallet. Please try again.');
+      }
+    };
+
+    initializeWallet();
+
+    return () => {
+      walletRef.current = null;
+    };
+  }, [network, accountNumber]);
 
   const prepareTransaction = async () => {
     setSendState('preparing');
     setError('');
     try {
-      // Validate invoice
-      if (!invoice || invoice.trim() === '') {
-        throw new Error('Please enter a valid Lightning invoice');
-      }
-
-      const mnemonic = await BackgroundCaller.getSubMnemonic(accountNumber);
-      const wallet = new BreezWallet(mnemonic, getBreezNetwork(network));
-      breezWallet.current = wallet;
-
-      // Prepare the payment
-      const prepareSendRequest: PrepareSendRequest = {
-        destination: invoice.trim(),
-      };
-
-      const prepareResponse = await wallet.prepareSendPayment(prepareSendRequest);
-      setPreparedResponse(prepareResponse);
-      setFeeSats(prepareResponse.feesSat || 0);
-
-      // Extract amount information from the destination
-      if (prepareResponse.destination.type === 'bolt11' && prepareResponse.destination.invoice.amountMsat) {
-        const msat = new BigNumber(prepareResponse.destination.invoice.amountMsat);
-        const satAmount = msat.dividedBy(1000).integerValue(BigNumber.ROUND_FLOOR);
-        setAmountToSend(satAmount.toString());
-      } else {
-        throw new Error('Could not determine payment amount from invoice');
-      }
+      await askMnemonic(); // verify password
 
       setSendState('prepared');
     } catch (error: any) {
@@ -77,19 +94,22 @@ const SendLightning: React.FC = () => {
 
   const sendPayment = async () => {
     try {
-      if (!breezWallet.current || !preparedResponse) {
-        throw new Error('Transaction not properly prepared');
+      if (!walletRef.current) {
+        throw new Error('Internal error: wallet not initialized');
       }
 
-      await askMnemonic(); // verify password
-      const sendRequest: SendPaymentRequest = {
-        prepareResponse: preparedResponse,
-      };
+      setSendState('sending');
+      await new Promise((r) => setTimeout(r, 200)); // propagate
 
       // Send payment
-      const paymentResponse = await breezWallet.current.sendPayment(sendRequest);
-      console.log('Payment sent:', paymentResponse);
-      setSendState('success');
+      const paymentResponse = await walletRef.current.payLightningInvoice(invoice);
+
+      if (paymentResponse) {
+        setSendState('success');
+      } else {
+        setSendState('idle');
+        setError('Payment failed');
+      }
     } catch (error: any) {
       console.error('Send payment error:', error);
       setError(error.message);
@@ -98,7 +118,6 @@ const SendLightning: React.FC = () => {
 
   const handleCancel = () => {
     setSendState('idle');
-    setPreparedResponse(null);
   };
 
   if (sendState === 'success') {
@@ -129,7 +148,7 @@ const SendLightning: React.FC = () => {
             data-testid="lightning-invoice-input"
             type="text"
             placeholder="Enter the Lightning invoice"
-            onChange={(event) => setInvoice(event.target.value)}
+            onChange={(event) => onInvoiceInput(event.target.value)}
             value={invoice}
             style={{ flexGrow: 1, marginRight: '10px' }}
           />
@@ -164,19 +183,21 @@ const SendLightning: React.FC = () => {
           </div>
         )}
 
-        {sendState === 'preparing' ? <span>loading...</span> : null}
+        {sendState === 'preparing' || sendState === 'sending' ? <span>loading...</span> : null}
 
-        {sendState === 'prepared' && (
+        {invoice && amountToSend && (
           <div style={{ backgroundColor: '#f5f5f5', borderRadius: '8px', padding: '16px', marginBottom: '20px' }}>
             <h3 style={{ marginTop: 0, marginBottom: '15px' }}>Payment Details</h3>
             <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '8px' }}>
               <span>Amount:</span>
-              <strong>{amountToSend ? formatBalance(amountToSend, 8, 8) : ''} sats</strong>
+              <strong>
+                {amountToSend ? formatBalance(amountToSend, getDecimalsByNetwork(NETWORK_BITCOIN)) : ''} {getTickerByNetwork(network)}
+              </strong>
             </div>
             {feeSats !== null && (
               <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                 <span>Fee:</span>
-                <strong>{feeSats} sats</strong>
+                <strong>up to {feeSats} sats</strong>
               </div>
             )}
           </div>
@@ -185,7 +206,7 @@ const SendLightning: React.FC = () => {
         {sendState === 'idle' && (
           <WideButton data-testid="verify-payment-button" onClick={prepareTransaction} style={{ backgroundColor: '#FF9500' }}>
             <ZapIcon />
-            <ThemedText>Verify Payment</ThemedText>
+            <ThemedText>Send</ThemedText>
           </WideButton>
         )}
 

--- a/shared/class/wallet-factory.ts
+++ b/shared/class/wallet-factory.ts
@@ -1,0 +1,37 @@
+import { TLightningWallet } from '../types/TWallet';
+import { IBackgroundCaller } from '../types/IBackgroundCaller';
+import { NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK, Networks } from '../types/networks';
+import { BreezWallet, getBreezNetwork } from '../class/wallets/breez-wallet';
+import { SparkWallet } from '../class/wallets/spark-wallet';
+
+export class WalletFactory {
+  private static instance: WalletFactory;
+  private constructor() {}
+
+  public static getInstance(): WalletFactory {
+    if (!WalletFactory.instance) {
+      WalletFactory.instance = new WalletFactory();
+    }
+    return WalletFactory.instance;
+  }
+
+  public async getLightningWallet(network: Networks, accountNumber: number, BackgroundCaller: IBackgroundCaller): Promise<TLightningWallet> {
+    if (network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET) {
+      const subMnemonic = await BackgroundCaller.getSubMnemonic(accountNumber);
+      const bNetwork = getBreezNetwork(network);
+
+      return new BreezWallet(subMnemonic, bNetwork);
+    }
+
+    if (network === NETWORK_SPARK) {
+      const subMnemonic = await BackgroundCaller.getSubMnemonic(accountNumber);
+
+      const w = new SparkWallet();
+      w.setSecret(subMnemonic);
+      await w.init();
+      return w;
+    }
+
+    throw new Error(`Lightning wallet on ${network} is not supported`);
+  }
+}

--- a/shared/class/wallets/breez-wallet.ts
+++ b/shared/class/wallets/breez-wallet.ts
@@ -98,7 +98,7 @@ export class BreezWallet implements InterfaceLightningWallet {
     return receiveResponse.destination;
   }
 
-  async payLightningInvoice(invoice: string, masFeePercentage: number = 1): Promise<boolean> {
+  async payLightningInvoice(invoice: string, maxFeePercentage: number = 1): Promise<boolean> {
     const decoded = bolt11.decode(invoice);
     if (!decoded.satoshis) throw new Error('Cant pay zero-amount invoices');
 
@@ -109,8 +109,8 @@ export class BreezWallet implements InterfaceLightningWallet {
 
     const prepareResponse = await this.prepareSendPayment(prepareSendRequest);
 
-    if (prepareResponse?.feesSat && prepareResponse.feesSat > (decoded.satoshis / 100) * masFeePercentage) {
-      throw new Error(`Potential fees to pay this invoice are more than ${masFeePercentage}%`);
+    if (prepareResponse?.feesSat && prepareResponse.feesSat > (decoded.satoshis / 100) * maxFeePercentage) {
+      throw new Error(`Potential fees to pay this invoice are more than ${maxFeePercentage}%`);
     }
 
     const sendRequest: SendPaymentRequest = {

--- a/shared/types/TWallet.ts
+++ b/shared/types/TWallet.ts
@@ -1,0 +1,8 @@
+import { BreezWallet } from '../class/wallets/breez-wallet';
+import { SparkWallet } from '../class/wallets/spark-wallet';
+import { ArkWallet } from '../class/wallets/ark-wallet';
+import { EvmWallet } from '../class/evm-wallet';
+import { HDSegwitBech32Wallet } from '../class/wallets/hd-segwit-bech32-wallet';
+
+export type TWallet = BreezWallet | SparkWallet | ArkWallet | HDSegwitBech32Wallet | EvmWallet;
+export type TLightningWallet = BreezWallet | SparkWallet;


### PR DESCRIPTION
building on top of https://github.com/layerztec/layerzwallet/pull/185

* send screen on home screen now offers available ln wallets
* ln-send screen is now wallet-agnostic
* tried to formalize wallets more with introduction of WalletFactory and TLightningWallet but not 100% happy with the result. however the current implementation is good enough
* refactored ln-receive screen to poll for invoice status instead of checking whole wallet balance


TODO in next PRs

* [ ]  port changes to mobile
* [ ] 'Lightning' network should display multiple balances (liquid & spark atm)


<img width="782" height="512" alt="image" src="https://github.com/user-attachments/assets/06fdef03-b673-414d-86d0-f722b8b88b25" />
