### PR TITLE
refactor: network selector carousel only renders cached data

### DIFF
--- a/mobile/app/NetworkSelector.tsx
+++ b/mobile/app/NetworkSelector.tsx
@@ -3,10 +3,11 @@ import React, { useContext, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Networks } from '@shared/types/networks';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
-import { getIsTestnet } from '@shared/models/network-getters';
+import { getIsTestnet, getTickerByNetwork } from '@shared/models/network-getters';
 import { useAvailableNetworks } from '@shared/hooks/useAvailableNetworks';
 import { getNetworkGradient, getNetworkIcon } from '@shared/constants/Colors';
-import DashboardTiles from '@/components/DashboardTiles';
+import DashboardTiles, { LayerCard } from '@/components/DashboardTiles';
+import { capitalizeFirstLetter } from '@shared/modules/string-utils';
 
 const NetworkSelector: React.FC = () => {
   const router = useRouter();
@@ -19,15 +20,15 @@ const NetworkSelector: React.FC = () => {
   };
 
   // Transform network data into the format DashboardTiles expects
-  const networkCards = useMemo(() => {
+  const networkCards: (LayerCard & { isSelected: boolean })[] = useMemo(() => {
     return networks.map((network) => {
       const isTestnet = getIsTestnet(network);
       const gradientColors = getNetworkGradient(network);
       const iconName = getNetworkIcon(network);
 
       return {
-        name: network.charAt(0).toUpperCase() + network.slice(1),
-        ticker: network.toUpperCase(),
+        name: capitalizeFirstLetter(network),
+        ticker: getTickerByNetwork(network),
         balance: currentNetwork === network ? 'Selected' : 'Available',
         usdValue: isTestnet ? 'Testnet' : 'Mainnet',
         color: gradientColors[0],

--- a/mobile/components/DashboardTiles.tsx
+++ b/mobile/components/DashboardTiles.tsx
@@ -5,14 +5,13 @@ import { Ionicons } from '@expo/vector-icons';
 import Animated, { useSharedValue, useAnimatedStyle, withSpring, withTiming, runOnUI, runOnJS, interpolate, useAnimatedScrollHandler, useAnimatedReaction } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { BlurView } from 'expo-blur';
-import { getAvailableNetworks } from '@shared/types/networks';
+import { getAvailableNetworks, NETWORK_BITCOIN, Networks } from '@shared/types/networks';
 import { getNetworkGradient, getNetworkIcon } from '@shared/constants/Colors';
 import { getIsTestnet, getTickerByNetwork, getDecimalsByNetwork } from '@shared/models/network-getters';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
-import { useBalance } from '@shared/hooks/useBalance';
-import { useExchangeRate } from '@shared/hooks/useExchangeRate';
-import { formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
-import { BackgroundExecutor } from '@/src/modules/background-executor';
+import { useCachedBalance } from '@shared/hooks/useCachedBalance';
+import { useCachedExchangeRate } from '@shared/hooks/useCachedExchangeRate';
+import { capitalizeFirstLetter, formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
 
 const { width, height } = Dimensions.get('window');
 const CARD_WIDTH = width - 32;
@@ -23,7 +22,7 @@ const ZOOM_SCALE = 2.5;
 const CARD_SPACING = -50;
 const SCROLL_SNAP_THRESHOLD = CARD_HEIGHT + CARD_SPACING;
 
-interface LayerCard {
+export interface LayerCard {
   name: string;
   ticker: string;
   balance: string;
@@ -34,7 +33,7 @@ interface LayerCard {
   tags?: string[];
   tokenCount?: number;
   originalIndex?: number;
-  networkId?: string;
+  networkId: Networks;
 }
 
 interface DashboardTileProps {
@@ -425,7 +424,7 @@ const useNetworkCards = (accountNumber: number): LayerCard[] => {
       const ticker = getTickerByNetwork(network);
 
       return {
-        name: network.charAt(0).toUpperCase() + network.slice(1),
+        name: capitalizeFirstLetter(network),
         ticker: ticker,
         balance: '0.00000',
         usdValue: isTestnet ? 'Testnet' : '$0.00',
@@ -453,8 +452,8 @@ const NetworkCard = ({
   disableNavigation,
   accountNumber,
 }: LayerCardTileProps & { accountNumber: number }) => {
-  const { balance, isLoading: balanceLoading, error: balanceError } = useBalance(card.networkId as any, accountNumber, BackgroundExecutor);
-  const { exchangeRate, isLoading: exchangeRateLoading, error: exchangeRateError } = useExchangeRate(card.networkId as any, 'USD');
+  const { balance } = useCachedBalance(card.networkId, accountNumber);
+  const { exchangeRate } = useCachedExchangeRate(card.networkId, 'USD');
   const [hasTimedOut, setHasTimedOut] = useState(false);
 
   useEffect(() => {
@@ -467,26 +466,32 @@ const NetworkCard = ({
 
   const cardData = useMemo(() => {
     const isTestnet = getIsTestnet(card.networkId as any);
+    let formattedBalance = '0.00000';
 
-    const formattedBalance =
-      balance !== undefined && balance !== null ? formatBalance(balance, getDecimalsByNetwork(card.networkId as any), 8) : balanceLoading && !hasTimedOut ? '···' : balanceError ? 'Error' : '0.00000';
+    if (balance !== undefined && balance !== null) {
+      formattedBalance = formatBalance(balance, getDecimalsByNetwork(card.networkId as any), 8);
+    } else if (!hasTimedOut) {
+      formattedBalance = '···';
+    } else {
+      formattedBalance = '0.00000';
+    }
 
-    const formattedUsdValue = isTestnet
-      ? 'Testnet'
-      : balance !== undefined && balance !== null && exchangeRate
-        ? `$${formatFiatBalance(balance, getDecimalsByNetwork(card.networkId as any), exchangeRate)}`
-        : exchangeRateLoading && !hasTimedOut
-          ? '···'
-          : exchangeRateError
-            ? 'Rate Error'
-            : '$0.00';
+    let formattedUsdValue = '$0.00';
+
+    if (isTestnet) {
+      formattedUsdValue = 'Testnet';
+    } else if (balance !== undefined && balance !== null && exchangeRate) {
+      formattedUsdValue = `$${formatFiatBalance(balance, getDecimalsByNetwork(card.networkId as any), +exchangeRate)}`;
+    } else {
+      formattedUsdValue = '...';
+    }
 
     return {
       ...card,
       balance: formattedBalance,
       usdValue: formattedUsdValue,
     };
-  }, [card, balance, exchangeRate, balanceLoading, exchangeRateLoading, hasTimedOut, balanceError, exchangeRateError]);
+  }, [card, balance, exchangeRate, hasTimedOut]);
 
   return (
     <LayerCardTile
@@ -519,7 +524,7 @@ const DashboardTiles = ({ cards: providedCards, onCardPress: onExternalCardPress
   const scrollOffset = useSharedValue(0);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [isInitialized, setIsInitialized] = useState(false);
-  const [currentNetworkId, setCurrentNetworkId] = useState<string>('bitcoin');
+  const [currentNetworkId, setCurrentNetworkId] = useState<Networks>(NETWORK_BITCOIN);
   // Initialize opacity immediately to prevent flash
   const opacity = useSharedValue(isNetworkSelector ? 1 : 0);
 

--- a/shared/hooks/useCachedBalance.ts
+++ b/shared/hooks/useCachedBalance.ts
@@ -1,0 +1,31 @@
+import { useSWRConfig } from 'swr';
+import { Networks } from '../types/networks';
+import { StringNumber } from '../types/string-number';
+
+/**
+ * Hook to get cached balance for a specific network and account from the SWR cache.
+ * This hook accesses the SWR cache directly without triggering network requests.
+ *
+ * @param network - the network for which to get the balance
+ * @param accountNumber - the account number
+ *
+ * @returns the cached balance as a StringNumber, or undefined if not found in cache
+ */
+export function useCachedBalance(network: Networks, accountNumber: number): { balance: StringNumber | undefined } {
+  const { cache } = useSWRConfig();
+
+  for (const key of cache.keys()) {
+    if (key.includes(`balanceFetcher`) && key.includes(`accountNumber:${accountNumber}`) && key.includes(`network:"${network}"`)) {
+      const balance = cache.get(key);
+      if (balance?.data) {
+        return {
+          balance: balance.data,
+        };
+      }
+    }
+  }
+
+  return {
+    balance: undefined,
+  };
+}

--- a/shared/hooks/useCachedExchangeRate.ts
+++ b/shared/hooks/useCachedExchangeRate.ts
@@ -1,0 +1,29 @@
+import { useSWRConfig } from 'swr';
+import { Networks } from '../types/networks';
+import { TFiat } from './useExchangeRate';
+import { StringNumber } from '../types/string-number';
+
+/**
+ * This hook gets exchange rate from SWR cache instead of doing network request
+ *
+ * @param network - the network for which to get the rate
+ * @param fiat - currently only 'USD'
+ */
+export function useCachedExchangeRate(network: Networks, fiat: TFiat): { exchangeRate: StringNumber | undefined } {
+  const { cache } = useSWRConfig();
+
+  for (const key of cache.keys()) {
+    if (key.includes(`exchangeRateFetcher`) && key.includes(`network:"${network}"`)) {
+      const rate = cache.get(key);
+      if (rate?.data) {
+        return {
+          exchangeRate: String(rate.data),
+        };
+      }
+    }
+  }
+
+  return {
+    exchangeRate: undefined,
+  };
+}

--- a/shared/hooks/useExchangeRate.ts
+++ b/shared/hooks/useExchangeRate.ts
@@ -4,12 +4,20 @@ import { Networks } from '../types/networks';
 import { getFiatRate } from '../models/fiatUnit';
 import { getIsTestnet } from '../models/network-getters';
 
-type TFiat = 'USD';
+export type TFiat = 'USD';
 
 interface exchangeRateFetcherArg {
   cacheKey: string;
   network: Networks;
   fiat: TFiat;
+}
+
+function middleware(useSWRNext: any) {
+  return (key: any, fetcher: any, config: any) => {
+    console.log(`useExchangeRate(${JSON.stringify(key)})`); // logging
+
+    return useSWRNext(key, () => fetcher(key), config);
+  };
 }
 
 export const exchangeRateFetcher = async (arg: exchangeRateFetcherArg): Promise<number> => {
@@ -35,6 +43,7 @@ export function useExchangeRate(network: Networks, fiat: TFiat) {
   );
 
   const { data, error, isLoading } = useSWR(arg, exchangeRateFetcher, {
+    use: [middleware],
     refreshInterval,
     refreshWhenHidden: false,
   });


### PR DESCRIPTION
* cards on network selector carousel now use only cached balance and cached exchange rate. i was a bit hesitant about this at first since data will be stale eventually, but when i tried this it drastically improved performance on my a bit dated pixel 6 device, so i think we can later come up with a refresh strategy that will update data in cache when its not impacting app usability, animations etc
* refactored carousel a bit. tried to do a big refactor since types there are a mess, but it led to a lot of changes and i abandoned the idea for now