### PR TITLE
refactor: wallet init

### DIFF
--- a/ext/src/modules/background-caller.ts
+++ b/ext/src/modules/background-caller.ts
@@ -3,26 +3,46 @@ import { GetSubMnemonicResponse, GetBtcSendDataResponse, IBackgroundCaller, Mess
 import { ENCRYPTED_PREFIX, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
 import { LayerzStorage } from '../class/layerz-storage';
 import { SecureStorage } from '../class/secure-storage';
-import { NETWORK_SPARK } from '@shared/types/networks';
+import { NETWORK_BITCOIN, NETWORK_SPARK } from '@shared/types/networks';
 import { SparkWallet } from '@shared/class/wallets/spark-wallet';
+import { lazyInitWallet as lazyInitWalletOrig, LazyInitWallets, SupportedLazyInitWalletNetworks } from '@shared/modules/wallet-utils';
+import assert from 'assert';
 
 const STORAGE_KEY_WHITELIST = 'STORAGE_KEY_WHITELIST';
 const STORAGE_KEY_ACCEPTED_TOS = 'STORAGE_KEY_ACCEPTED_TOS';
+
+/**
+ * Cache of wallets by network and account number
+ * 1 of 2 - this one resides in context of whoever is calling BackgroundCaller, which is most likely
+ * the Popup
+ */
+const cachedWallets: Record<SupportedLazyInitWalletNetworks, Record<number, LazyInitWallets>> = {
+  [NETWORK_BITCOIN]: {},
+  [NETWORK_SPARK]: {},
+};
 
 /**
  * Makes calls to the background script and handles responses. The background script executes sensitive operations
  * in an isolated context for security. Communication is handled via the `Messenger` service
  */
 export const BackgroundCaller: IBackgroundCaller = {
+  /**
+   * ACHTUNG!
+   *
+   * this will create a wallet object that will exist in the __context where it was called__.
+   * there might be a situation (in ext) when same wallet was created in background script and popup
+   */
+  async lazyInitWallet(network: SupportedLazyInitWalletNetworks, accountNumber: number) {
+    return lazyInitWalletOrig(network, accountNumber, cachedWallets, LayerzStorage, SecureStorage);
+  },
+
   async getAddress(...params) {
     const [network, accountNumber] = params;
     if (network === NETWORK_SPARK) {
       // executing in Popup context instead of background script context since spark lib cant work there (expects `window.`)
       // @see https://github.com/buildonspark/spark/issues/32  // fixme
-      const sp = new SparkWallet();
-      const submnemonic = await BackgroundCaller.getSubMnemonic(accountNumber);
-      sp.setSecret(submnemonic);
-      await sp.init();
+      const sp = await BackgroundCaller.lazyInitWallet(network, accountNumber);
+      assert(sp instanceof SparkWallet);
       return String(await sp.getOffchainReceiveAddress());
     }
 

--- a/ext/src/modules/background-message-controller.ts
+++ b/ext/src/modules/background-message-controller.ts
@@ -3,7 +3,7 @@ import { EvmWallet } from '@shared/class/evm-wallet';
 import { BreezWallet, getBreezNetwork } from '@shared/class/wallets/breez-wallet';
 import { WatchOnlyWallet } from '@shared/class/wallets/watch-only-wallet';
 import { getDeviceID } from '@shared/modules/device-id';
-import { lazyInitWallet, saveBitcoinXpubs, saveSubMnemonics, saveWalletState, sanitizeAndValidateMnemonic } from '@shared/modules/wallet-utils';
+import { lazyInitWallet, saveBitcoinXpubs, saveSubMnemonics, saveWalletState, sanitizeAndValidateMnemonic, LazyInitWallets, SupportedLazyInitWalletNetworks } from '@shared/modules/wallet-utils';
 import { IBackgroundCaller, MessageType, MessageTypeMap, OpenPopupRequest, ProcessRPCRequest } from '@shared/types/IBackgroundCaller';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_EVM_XPUB, STORAGE_KEY_MNEMONIC, STORAGE_KEY_SUB_MNEMONIC } from '@shared/types/IStorage';
 import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK } from '@shared/types/networks';
@@ -12,10 +12,7 @@ import { LayerzStorage } from '../class/layerz-storage';
 import { SecureStorage } from '../class/secure-storage';
 import { decrypt, encrypt } from '../modules/encryption';
 import { ArkWallet } from '@shared/class/wallets/ark-wallet';
-
-// we only keep bitcoin wallets in the background for now
-type TBackgroundWallets = WatchOnlyWallet;
-type TBackgroundNetworks = typeof NETWORK_BITCOIN;
+import assert from 'assert';
 
 // All possible background messages with their params
 type TBackgroundMessage = { [K in keyof MessageTypeMap]: { type: K; params: MessageTypeMap[K]['params'] } }[keyof MessageTypeMap];
@@ -24,8 +21,14 @@ type TSendResponse = (response: MessageTypeMap[keyof MessageTypeMap]['response']
 // Allowed method names for background executor
 type TMethods = 'getAddress' | 'saveMnemonic' | 'createMnemonic' | 'getBtcBalance' | 'encryptMnemonic' | 'signPersonalMessage' | 'signTypedData' | 'getBtcSendData' | 'getSubMnemonic';
 
-const cachedWallets: Record<TBackgroundNetworks, Record<number, TBackgroundWallets>> = {
+/**
+ * Cache of wallets by network and account number
+ * 2 of 2 - this one resides in background script (aka service worker), which lives a bit longer than Popup but
+ * browser still might decide to terminate it
+ */
+const cachedWallets: Record<SupportedLazyInitWalletNetworks, Record<number, LazyInitWallets>> = {
   [NETWORK_BITCOIN]: {},
+  [NETWORK_SPARK]: {},
 };
 
 async function handleOpenPopup([method, params, id, from]: OpenPopupRequest, sender: chrome.runtime.MessageSender, sendResponse: (response?: any) => void) {
@@ -67,7 +70,8 @@ function openPopupWindow(request: ProcessRPCRequest, sendResponse: (response?: a
 export const BackgroundExtensionExecutor: Pick<IBackgroundCaller, TMethods> = {
   async getAddress(network, accountNumber) {
     if (network === NETWORK_BITCOIN) {
-      const wallet = await lazyInitWallet(network, accountNumber, cachedWallets, LayerzStorage);
+      const wallet = await lazyInitWallet(network, accountNumber, cachedWallets, LayerzStorage, SecureStorage);
+      assert(wallet instanceof WatchOnlyWallet);
       const address = await wallet.getAddressAsync();
       await saveWalletState(LayerzStorage, wallet, network, accountNumber);
       return address;
@@ -125,7 +129,8 @@ export const BackgroundExtensionExecutor: Pick<IBackgroundCaller, TMethods> = {
       await BlueElectrum.connectMain();
     }
 
-    const wallet = await lazyInitWallet(NETWORK_BITCOIN, accountNumber, cachedWallets, LayerzStorage);
+    const wallet = await lazyInitWallet(NETWORK_BITCOIN, accountNumber, cachedWallets, LayerzStorage, SecureStorage);
+    assert(wallet instanceof WatchOnlyWallet);
     await wallet.fetchBalance();
     await saveWalletState(LayerzStorage, wallet, NETWORK_BITCOIN, accountNumber);
 
@@ -204,7 +209,8 @@ export const BackgroundExtensionExecutor: Pick<IBackgroundCaller, TMethods> = {
     if (!BlueElectrum.mainConnected) {
       await BlueElectrum.connectMain();
     }
-    const wallet = await lazyInitWallet(NETWORK_BITCOIN, accountNumber, cachedWallets, LayerzStorage);
+    const wallet = await lazyInitWallet(NETWORK_BITCOIN, accountNumber, cachedWallets, LayerzStorage, SecureStorage);
+    assert(wallet instanceof WatchOnlyWallet);
     await wallet.fetchBalance();
     await wallet.fetchUtxo();
     const changeAddress = await wallet.getChangeAddressAsync();

--- a/mobile/src/modules/background-executor.ts
+++ b/mobile/src/modules/background-executor.ts
@@ -4,7 +4,15 @@ import { BreezWallet, getBreezNetwork } from '@shared/class/wallets/breez-wallet
 import { SparkWallet } from '@shared/class/wallets/spark-wallet';
 import { WatchOnlyWallet } from '@shared/class/wallets/watch-only-wallet';
 import { getDeviceID } from '@shared/modules/device-id';
-import { lazyInitWallet as lazyInitWalletOrig, sanitizeAndValidateMnemonic, saveBitcoinXpubs, saveSubMnemonics, saveWalletState } from '@shared/modules/wallet-utils';
+import {
+  lazyInitWallet as lazyInitWalletOrig,
+  sanitizeAndValidateMnemonic,
+  saveBitcoinXpubs,
+  saveSubMnemonics,
+  saveWalletState,
+  SupportedLazyInitWalletNetworks,
+  LazyInitWallets,
+} from '@shared/modules/wallet-utils';
 import { IBackgroundCaller, OpenPopupRequest } from '@shared/types/IBackgroundCaller';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_ACCEPTED_TOS, STORAGE_KEY_EVM_XPUB, STORAGE_KEY_MNEMONIC, STORAGE_KEY_SUB_MNEMONIC, STORAGE_KEY_WHITELIST } from '@shared/types/IStorage';
 import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK } from '@shared/types/networks';
@@ -14,19 +22,14 @@ import { Csprng } from '../class/rng';
 import { SecureStorage } from '../class/secure-storage';
 import { decrypt, encrypt } from '../modules/encryption';
 import { ArkWallet } from '@shared/class/wallets/ark-wallet';
+import assert from 'assert';
 
-// Cache of wallets by network and account number (currently only bitcoin)
-const cachedWallets: Record<string, Record<number, WatchOnlyWallet>> = {
+// Cache of wallets by network and account number
+const cachedWallets: Record<SupportedLazyInitWalletNetworks, Record<number, LazyInitWallets>> = {
   [NETWORK_BITCOIN]: {},
+  [NETWORK_SPARK]: {},
   // [NETWORK_LIQUID]: {},
   // [NETWORK_LIQUIDTESTNET]: {},
-};
-
-const lazyInitWallet = async (...args: Parameters<typeof lazyInitWalletOrig>) => {
-  if (args[0] !== NETWORK_BITCOIN) {
-    throw new Error('lazyInitWallet only supports NETWORK_BITCOIN');
-  }
-  return lazyInitWalletOrig(...args) as unknown as WatchOnlyWallet;
 };
 
 /**
@@ -34,9 +37,14 @@ const lazyInitWallet = async (...args: Parameters<typeof lazyInitWalletOrig>) =>
  * no need to handle calls via messages, we can just execute them on the spot
  */
 export const BackgroundExecutor: IBackgroundCaller = {
+  async lazyInitWallet(network: SupportedLazyInitWalletNetworks, accountNumber: number) {
+    return lazyInitWalletOrig(network, accountNumber, cachedWallets, LayerzStorage, SecureStorage);
+  },
+
   async getAddress(network, accountNumber) {
     if (network === NETWORK_BITCOIN) {
-      const wallet = await lazyInitWallet(network, accountNumber, cachedWallets, LayerzStorage);
+      const wallet = await BackgroundExecutor.lazyInitWallet(network, accountNumber);
+      assert(wallet instanceof WatchOnlyWallet);
       const address = await wallet.getAddressAsync();
       await saveWalletState(LayerzStorage, wallet, network, accountNumber);
       return address;
@@ -47,10 +55,8 @@ export const BackgroundExecutor: IBackgroundCaller = {
       await aw.init();
       return await aw.getOffchainReceiveAddress();
     } else if (network === NETWORK_SPARK) {
-      const sp = new SparkWallet();
-      const submnemonic = await BackgroundExecutor.getSubMnemonic(accountNumber);
-      sp.setSecret(submnemonic);
-      await sp.init();
+      const sp = await BackgroundExecutor.lazyInitWallet(network, accountNumber);
+      assert(sp instanceof SparkWallet);
       return String(await sp.getOffchainReceiveAddress());
     } else if (network === NETWORK_LIQUID || network === NETWORK_LIQUIDTESTNET) {
       const mnemonic = await SecureStorage.getItem(STORAGE_KEY_SUB_MNEMONIC + accountNumber);
@@ -137,7 +143,8 @@ export const BackgroundExecutor: IBackgroundCaller = {
     if (!BlueElectrum.mainConnected) {
       await BlueElectrum.connectMain();
     }
-    const wallet = await lazyInitWallet(NETWORK_BITCOIN, accountNumber, cachedWallets, LayerzStorage);
+    const wallet = await BackgroundExecutor.lazyInitWallet(NETWORK_BITCOIN, accountNumber);
+    assert(wallet instanceof WatchOnlyWallet);
     await wallet.fetchBalance();
     await saveWalletState(LayerzStorage, wallet, NETWORK_BITCOIN, accountNumber);
     return {
@@ -241,7 +248,8 @@ export const BackgroundExecutor: IBackgroundCaller = {
     if (!BlueElectrum.mainConnected) {
       await BlueElectrum.connectMain();
     }
-    const wallet = await lazyInitWallet(NETWORK_BITCOIN, accountNumber, cachedWallets, LayerzStorage);
+    const wallet = await BackgroundExecutor.lazyInitWallet(NETWORK_BITCOIN, accountNumber);
+    assert(wallet instanceof WatchOnlyWallet);
     await wallet.fetchBalance();
     await wallet.fetchUtxo();
     const changeAddress = await wallet.getChangeAddressAsync();

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -86,6 +86,13 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
     return Number(balance.balance);
   }
 
+  async cleanupConnections() {
+    if (!this._sdkWallet) throw new Error('Spark wallet not initialized');
+
+    this._sdkWallet.removeAllListeners();
+    await this._sdkWallet.cleanupConnections();
+  }
+
   async createLightningInvoice(amountSats: number, memo: string = ''): Promise<createLightningInvoiceResponse> {
     if (!this._sdkWallet) throw new Error('Spark wallet not initialized');
 

--- a/shared/hooks/useBalance.ts
+++ b/shared/hooks/useBalance.ts
@@ -8,6 +8,7 @@ import { getRpcProvider } from '../models/network-getters';
 import { IBackgroundCaller } from '../types/IBackgroundCaller';
 import { NETWORK_ARKMUTINYNET, NETWORK_BITCOIN, NETWORK_LIGHTNING, NETWORK_LIGHTNINGTESTNET, NETWORK_LIQUID, NETWORK_LIQUIDTESTNET, NETWORK_SPARK, Networks } from '../types/networks';
 import { StringNumber } from '../types/string-number';
+import assert from 'assert';
 
 interface balanceFetcherArg {
   cacheKey: string;
@@ -56,20 +57,25 @@ export const balanceFetcher = async (arg: balanceFetcherArg): Promise<StringNumb
   }
 
   if (network === NETWORK_SPARK) {
-    const sw = new SparkWallet();
-    const submnemonic = await backgroundCaller.getSubMnemonic(accountNumber);
-    sw.setSecret(submnemonic);
-    await sw.init();
+    const start = +new Date();
+    const sw = await backgroundCaller.lazyInitWallet(network, accountNumber);
+    assert(sw instanceof SparkWallet);
     const virtualBalance = await sw.getOffchainBalance();
+    const end = +new Date();
+    console.log('spark balance took', (end - start) / 1000, 'sec, balance =', virtualBalance.toString(10));
+    setTimeout(() => sw.cleanupConnections(), 2_000);
     return virtualBalance.toString(10);
   }
 
   if (network === NETWORK_ARKMUTINYNET) {
+    const start = +new Date();
     const aw = new ArkWallet();
     const submnemonic = await backgroundCaller.getSubMnemonic(accountNumber);
     aw.setSecret(submnemonic);
     await aw.init();
+    const end = +new Date();
     const virtualBalance = await aw.getOffchainBalance();
+    console.log('ark balance took', (end - start) / 1000, 'sec, balance =', virtualBalance.toString(10));
     return virtualBalance.toString(10);
   }
 
@@ -87,14 +93,14 @@ export function useBalance(network: Networks, accountNumber: number, backgroundC
   switch (network) {
     case NETWORK_SPARK:
     case NETWORK_ARKMUTINYNET:
-      refreshInterval = 3_000; // transfers are just server interactions, should be fast
+      refreshInterval = 5_000; // transfers are just server interactions, should be fast
       break;
 
     case NETWORK_LIGHTNING:
     case NETWORK_LIGHTNINGTESTNET:
     case NETWORK_LIQUID:
     case NETWORK_LIQUIDTESTNET:
-      refreshInterval = 3_000; // we are just fetching data from the SDK, should be fast
+      refreshInterval = 5_000; // we are just fetching data from the SDK, should be fast
       break;
 
     case NETWORK_BITCOIN:

--- a/shared/modules/wallet-utils.ts
+++ b/shared/modules/wallet-utils.ts
@@ -2,8 +2,9 @@ import { BIP85 } from 'bip85';
 
 import { HDSegwitBech32Wallet } from '../class/wallets/hd-segwit-bech32-wallet';
 import { WatchOnlyWallet } from '../class/wallets/watch-only-wallet';
+import { SparkWallet } from '../class/wallets/spark-wallet';
 import { IStorage, STORAGE_KEY_SUB_MNEMONIC, STORAGE_KEY_BTC_XPUB, getSerializedStorageKey } from '../types/IStorage';
-import { NETWORK_BITCOIN, Networks } from '../types/networks';
+import { NETWORK_BITCOIN, NETWORK_SPARK, Networks } from '../types/networks';
 import { WalletSerializer } from './wallet-serializer';
 
 /**
@@ -45,7 +46,8 @@ export async function saveWalletState(storage: IStorage, wallet: WatchOnlyWallet
   }
 }
 
-type SupportedWalletNetworks = typeof NETWORK_BITCOIN;
+export type SupportedLazyInitWalletNetworks = typeof NETWORK_BITCOIN | typeof NETWORK_SPARK;
+export type LazyInitWallets = WatchOnlyWallet | SparkWallet;
 
 /**
  * Initialize and cache a wallet for the given network/account, using serialization if available.
@@ -55,16 +57,34 @@ type SupportedWalletNetworks = typeof NETWORK_BITCOIN;
  * @param accountNumber Account index
  * @param cachedWallets Cache object to store/retrieve wallets
  * @param storage Storage instance (LayerzStorage or compatible)
+ * @param secureStorage
  * @returns The initialized wallet instance
  */
-export async function lazyInitWallet(network: SupportedWalletNetworks, accountNumber: number, cachedWallets: Record<string, Record<number, any>>, storage: IStorage): Promise<WatchOnlyWallet> {
-  if (![NETWORK_BITCOIN].includes(network)) {
+export async function lazyInitWallet(
+  network: SupportedLazyInitWalletNetworks,
+  accountNumber: number,
+  cachedWallets: Record<SupportedLazyInitWalletNetworks, Record<number, LazyInitWallets>>,
+  storage: IStorage,
+  secureStorage: IStorage
+): Promise<LazyInitWallets> {
+  if (![NETWORK_BITCOIN, NETWORK_SPARK].includes(network)) {
     throw new Error(`Unsupported network for lazyInitWallet: ${network}`);
   }
   // cache hit
   if (cachedWallets[network]?.[accountNumber]) {
     return cachedWallets[network][accountNumber];
   }
+
+  if (network === NETWORK_SPARK) {
+    // we dont save it to storage
+    const sw = new SparkWallet();
+    const submnemonic = await secureStorage.getItem(STORAGE_KEY_SUB_MNEMONIC + accountNumber);
+    sw.setSecret(submnemonic);
+    await sw.init();
+    cachedWallets[network][accountNumber] = sw;
+    return sw;
+  }
+
   // try to restore wallet from the storage
   const storageKey = getSerializedStorageKey(network, accountNumber);
   try {

--- a/shared/tests/integration-vi/integration.test.ts
+++ b/shared/tests/integration-vi/integration.test.ts
@@ -11,6 +11,7 @@ import { NETWORK_BOTANIXTESTNET, NETWORK_ROOTSTOCK, NETWORK_SEPOLIA, NETWORK_STR
 import { exchangeRateFetcher } from '../../hooks/useExchangeRate';
 
 const backgroundCallerMock2: IBackgroundCaller = {
+  lazyInitWallet: () => Promise.reject(),
   log: () => Promise.resolve(),
   getWhitelist: async () => Promise.resolve([]),
   hasAcceptedTermsOfService: async () => Promise.resolve(false),

--- a/shared/tests/unit-vi/rpc-controller.test.ts
+++ b/shared/tests/unit-vi/rpc-controller.test.ts
@@ -42,6 +42,7 @@ const storageMock: IStorage = {
 };
 
 const backgroundCallerMock2: IBackgroundCaller = {
+  lazyInitWallet: () => Promise.reject(),
   log: () => Promise.resolve(),
   getWhitelist: async () => Promise.resolve([]),
   hasAcceptedTermsOfService: async () => Promise.resolve(false),

--- a/shared/types/IBackgroundCaller.ts
+++ b/shared/types/IBackgroundCaller.ts
@@ -1,5 +1,6 @@
 import { CreateTransactionUtxo } from '../class/wallets/types';
 import { Networks } from '../types/networks';
+import { LazyInitWallets, SupportedLazyInitWalletNetworks } from '../modules/wallet-utils';
 
 // Message types for background script communication
 export enum MessageType {
@@ -102,6 +103,7 @@ export interface ProcessRPCRequest {
 }
 
 export interface IBackgroundCaller {
+  lazyInitWallet(network: SupportedLazyInitWalletNetworks, accountNumber: number): Promise<LazyInitWallets>;
   getAddress(...params: GetAddressParams): Promise<GetAddressResponse>;
   acceptTermsOfService(): Promise<void>;
   hasAcceptedTermsOfService(): Promise<boolean>;


### PR DESCRIPTION
in this PR i added `lazyInitWallet` to the BackgroundCaller itself. this made it on EXT side to have 2 cached wallets arrays, in a context of UI, and in context of Background Script (`background-message-controller.ts`). 
this is suboptimal, but this allowed to reuse cached wallets on UI, when fetching balance and when rendering receive address. for example, Spark address balance dropped from 5 sec to 1 sec because we dont need to reinitialize the wallet that often.
plus, i noticed spark sdk relies a lot on permanent connection to their backend to claim transfers and stuff, so just kiling old wallet object and creating new one often screwed up its internal logic  and made it work worse.


on MOBILE side nothing changed, since we have only 1 context  we have only 1 cached wallets array.



if we find this approach viable, as next steps i will move more wallets to be cached (like liquid & ark).



PS. i realize this all is a bit complex; everything would be way simpler if we had only 1 app, and not a monorepo that need to share code