### PR TITLE
feat: Transactions list

### DIFF
--- a/ext/src/modules/background-caller.ts
+++ b/ext/src/modules/background-caller.ts
@@ -1,5 +1,5 @@
 import { Messenger } from './messenger';
-import { GetSubMnemonicResponse, GetBtcSendDataResponse, IBackgroundCaller, MessageType } from '@shared/types/IBackgroundCaller';
+import { GetSubMnemonicResponse, GetBtcSendDataResponse, IBackgroundCaller, MessageType, GetCommonTransactionsResponse } from '@shared/types/IBackgroundCaller';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
 import { LayerzStorage } from '../class/layerz-storage';
 import { SecureStorage } from '../class/secure-storage';
@@ -120,5 +120,9 @@ export const BackgroundCaller: IBackgroundCaller = {
 
   async getSubMnemonic(...params): Promise<GetSubMnemonicResponse> {
     return await Messenger.sendGenericMessageToBackground(MessageType.GET_SUB_MNEMONIC, params);
+  },
+
+  async getCommonTransactions(...params): Promise<GetCommonTransactionsResponse> {
+    return await Messenger.sendGenericMessageToBackground(MessageType.GET_COMMON_TRANSACTIONS, params);
   },
 };

--- a/ext/src/modules/breeze-adapter.ts
+++ b/ext/src/modules/breeze-adapter.ts
@@ -1,5 +1,15 @@
-import init, { BindingLiquidSdk, connect, defaultConfig, PrepareReceiveRequest, ReceivePaymentRequest, PrepareSendRequest, SendPaymentRequest, GetPaymentRequest } from '@breeztech/breez-sdk-liquid';
-import { BreezConnection, IBreezAdapter, assetMetadata } from '@shared/class/wallets/breez-wallet';
+import init, {
+  BindingLiquidSdk,
+  connect,
+  defaultConfig,
+  PrepareReceiveRequest,
+  ReceivePaymentRequest,
+  PrepareSendRequest,
+  SendPaymentRequest,
+  GetPaymentRequest,
+  ListPaymentsRequest,
+} from '@breeztech/breez-sdk-liquid';
+import { BreezConnection, IBreezAdapter, getAssertMetadata } from '@shared/class/wallets/breez-wallet';
 
 const API_KEY = process.env.EXPO_PUBLIC_BREEZ_API_KEY;
 
@@ -40,7 +50,7 @@ class BreezAdapter implements IBreezAdapter {
     }
     await this.sdk?.disconnect();
     const config = defaultConfig(connection.network, API_KEY);
-    config.assetMetadata = assetMetadata;
+    config.assetMetadata = getAssertMetadata(connection.network);
     this.sdk = await connect({ mnemonic: connection.mnemonic, config });
     this.cc = connection;
     return this.sdk;
@@ -74,6 +84,10 @@ class BreezAdapter implements IBreezAdapter {
     return await sdk.getPayment(args);
   }
 
+  private async listPayments(sdk: BindingLiquidSdk, args: ListPaymentsRequest) {
+    return await sdk.listPayments(args);
+  }
+
   get api() {
     const getInfo = this.withLockAndSdk(this.getInfo.bind(this));
     const fetchLightningLimits = this.withLockAndSdk(this.fetchLightningLimits.bind(this));
@@ -82,6 +96,7 @@ class BreezAdapter implements IBreezAdapter {
     const prepareSendPayment = this.withLockAndSdk(this.prepareSendPayment.bind(this));
     const sendPayment = this.withLockAndSdk(this.sendPayment.bind(this));
     const getPayment = this.withLockAndSdk(this.getPayment.bind(this));
+    const listPayments = this.withLockAndSdk(this.listPayments.bind(this));
 
     return {
       getInfo,
@@ -91,6 +106,7 @@ class BreezAdapter implements IBreezAdapter {
       prepareSendPayment,
       sendPayment,
       getPayment,
+      listPayments,
     };
   }
 

--- a/ext/src/pages/Popup/SendTokenEvm.tsx
+++ b/ext/src/pages/Popup/SendTokenEvm.tsx
@@ -29,7 +29,7 @@ const SendTokenEvm: React.FC = () => {
   const { accountNumber } = useContext(AccountNumberContext);
   const { contractAddress } = location.state as SendTokenEvmProps;
   const list = getTokenList(network);
-  const token = list.find((token) => token.address === contractAddress);
+  const token = list.find((token) => token.id === contractAddress);
   const { balance } = useTokenBalance(network, accountNumber, contractAddress, BackgroundCaller);
 
   const [address, setAddress] = useState<string>(''); // our address
@@ -70,7 +70,7 @@ const SendTokenEvm: React.FC = () => {
       const satValueBN = new BigNumber(amountToSend);
       const satValue = satValueBN.multipliedBy(new BigNumber(10).pow(token?.decimals ?? 1)).toString(10);
       navigate('/transaction-success', {
-        state: { transactionId, amount: '0', network: network, bytes, recipient: toAddress, amountToken: satValue, tokenContractAddress: token?.address } as TransactionSuccessProps,
+        state: { transactionId, amount: '0', network: network, bytes, recipient: toAddress, amountToken: satValue, tokenContractAddress: token?.id } as TransactionSuccessProps,
       });
     } catch (error: any) {
       setError(error.message);

--- a/ext/src/pages/Popup/TransactionSuccessEvm.tsx
+++ b/ext/src/pages/Popup/TransactionSuccessEvm.tsx
@@ -27,7 +27,7 @@ const TransactionSuccessEvm: React.FC = () => {
   const { receipt } = useTransactionReceipt(network, transactionId);
 
   const list = getTokenList(network);
-  const tokenInfo = list.find((token) => token.address === tokenContractAddress);
+  const tokenInfo = list.find((token) => token.id === tokenContractAddress);
 
   const [showTimedOutTxIcon, setShowTimedOutTxIcon] = useState(false);
 

--- a/ext/src/pages/Popup/components/TokensView.tsx
+++ b/ext/src/pages/Popup/components/TokensView.tsx
@@ -10,14 +10,14 @@ import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-uti
 import { BackgroundCaller } from '../../../modules/background-caller';
 import { SendTokenEvmProps } from '../SendTokenEvm';
 
-const TokenRow: React.FC<{ tokenAddress: string }> = ({ tokenAddress }) => {
+const TokenRow: React.FC<{ id: string }> = ({ id }) => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
   const navigate = useNavigate();
   const list = getTokenList(network);
-  const token = list.find((token) => token.address === tokenAddress);
+  const token = list.find((token) => token.id === id);
 
-  const { balance } = useTokenBalance(network, accountNumber, tokenAddress, BackgroundCaller);
+  const { balance } = useTokenBalance(network, accountNumber, id, BackgroundCaller);
 
   if (!balance) return null;
 
@@ -49,7 +49,7 @@ const TokenRow: React.FC<{ tokenAddress: string }> = ({ tokenAddress }) => {
       </span>
       <div style={{ display: 'flex', gap: 6 }}>
         <button
-          onClick={() => navigate('/send-token-evm', { state: { contractAddress: token?.address } as SendTokenEvmProps })}
+          onClick={() => navigate('/send-token-evm', { state: { contractAddress: token?.id } as SendTokenEvmProps })}
           title="Send"
           style={{
             border: 'none',
@@ -98,7 +98,7 @@ const TokensView: React.FC = () => {
       <h2 style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10, textAlign: 'center' }}>Tokens</h2>
       <div>
         {tokenList.map((token) => (
-          <TokenRow key={token.address} tokenAddress={token.address} />
+          <TokenRow key={token.id} id={token.id} />
         ))}
       </div>
     </div>

--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -12,6 +12,7 @@ import GradientScreen from '@/components/GradientScreen';
 import LiquidTokensView from '@/components/LiquidTokensView';
 import { ThemedText } from '@/components/ThemedText';
 import TokensView from '@/components/TokensView';
+import Transaction from '@/components/Transaction';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { getNetworkImageAsset } from '@/utils/networkAssets';
 import { AccountNumberContext, accountItems } from '@shared/hooks/AccountNumberContext';
@@ -20,6 +21,7 @@ import { useAccountBalance } from '@shared/hooks/useAccountBalance';
 import { useAvailableNetworks } from '@shared/hooks/useAvailableNetworks';
 import { useBalance } from '@shared/hooks/useBalance';
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
+import { useTransactions } from '@shared/hooks/useTransactions';
 import { fiatOnRamp } from '@shared/models/fiat-on-ramp';
 import { getDecimalsByNetwork, getExplorerUrlByNetwork, getIsEVM, getIsTestnet, getTickerByNetwork } from '@shared/models/network-getters';
 import { getSwapPairs } from '@shared/models/swap-providers-list';
@@ -29,15 +31,6 @@ import { NETWORK_ARK_MUTINYNET, NETWORK_BITCOIN, NETWORK_LIGHTNING, NETWORK_LIGH
 import { SwapPlatform } from '@shared/types/swap';
 
 const logo = require('@/assets/images/ui/logo-main-screen.svg');
-
-interface Transaction {
-  id: string;
-  type: 'received' | 'sent';
-  amount: string;
-  usdAmount: string;
-  date: string;
-  status?: 'pending' | 'completed';
-}
 
 export default function Home() {
   const { network } = useContext(NetworkContext);
@@ -57,39 +50,12 @@ export default function Home() {
     }
   }, [params.showSwapInterface, router]);
 
-  // Mock transactions data - in real app this would come from API
-  const [transactions] = useState<Transaction[]>([
-    {
-      id: '1',
-      type: 'received',
-      amount: '0.00250',
-      usdAmount: '1,000',
-      date: 'Pending...',
-      status: 'pending',
-    },
-    {
-      id: '2',
-      type: 'received',
-      amount: '0.00250',
-      usdAmount: '1,000',
-      date: 'April 04, 2025',
-      status: 'completed',
-    },
-    {
-      id: '3',
-      type: 'sent',
-      amount: '-0.00250',
-      usdAmount: '1,000',
-      date: 'April 04, 2025',
-      status: 'completed',
-    },
-  ]);
-
   // Get balance data
   const { balance } = useBalance(network, accountNumber, BackgroundExecutor);
   const { exchangeRate } = useExchangeRate(network, 'USD');
   const availableNetworks = useAvailableNetworks();
   const { accountBalance } = useAccountBalance(accountNumber, availableNetworks);
+  const { transactions, error: transactionsError } = useTransactions(network, accountNumber, BackgroundExecutor);
   const accountItem = accountItems[accountNumber];
 
   // Lightning network specific balance logic
@@ -120,6 +86,9 @@ export default function Home() {
   // Always show native token balance as main balance, USD as sub-balance
   const displayBalance = `${formattedBalance} ${ticker}`;
   const displaySubBalance = `${usdValue} USD`;
+
+  // Get latest transactions (limit to 3 for display)
+  const latestTransactions = transactions?.slice(0, 3) || [];
 
   const handleSend = () => {
     switch (network) {
@@ -246,26 +215,6 @@ export default function Home() {
     },
   ];
 
-  const renderTransactionItem = (transaction: Transaction) => (
-    <View key={transaction.id} style={styles.transactionItem}>
-      <View style={styles.transactionIcon}>
-        <MaterialIcons name={transaction.type === 'received' ? 'call-received' : 'call-made'} size={24} color="rgba(255, 255, 255, 0.8)" />
-      </View>
-
-      <View style={styles.transactionDetails}>
-        <ThemedText style={styles.transactionType}>{transaction.type === 'received' ? 'Received' : 'Sent'}</ThemedText>
-        <ThemedText style={styles.transactionDate}>{transaction.status === 'pending' ? 'Pending...' : transaction.date}</ThemedText>
-      </View>
-
-      <View style={styles.transactionAmounts}>
-        <ThemedText style={styles.transactionAmount}>
-          {transaction.amount} {ticker}
-        </ThemedText>
-        <ThemedText style={styles.transactionUsd}>{transaction.usdAmount} USD</ThemedText>
-      </View>
-    </View>
-  );
-
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
@@ -372,7 +321,21 @@ export default function Home() {
           <BlurView intensity={25} tint="dark" style={styles.transactionsContainer}>
             <ThemedText style={styles.transactionsTitle}>Latest Transactions</ThemedText>
 
-            <View style={styles.transactionsList}>{transactions.map(renderTransactionItem)}</View>
+            {latestTransactions.length > 0 ? (
+              <View style={styles.transactionsList}>
+                {latestTransactions.map((transaction) => (
+                  <Transaction key={transaction.txid} network={network} transaction={transaction} />
+                ))}
+              </View>
+            ) : transactionsError ? (
+              <View style={styles.transactionsList}>
+                <ThemedText style={styles.transactionDate}>Error loading transactions</ThemedText>
+              </View>
+            ) : (
+              <View style={styles.transactionsList}>
+                <ThemedText style={styles.transactionDate}>No transactions yet</ThemedText>
+              </View>
+            )}
 
             <Button title="Transaction History" onPress={handleTransactionHistory} variant="dark" />
           </BlurView>

--- a/mobile/app/SendTokenEvm.tsx
+++ b/mobile/app/SendTokenEvm.tsx
@@ -40,7 +40,7 @@ const SendTokenEvm: React.FC = () => {
   const { scanQr } = useContext(ScanQrContext);
 
   const list = getTokenList(network);
-  const token = list.find((token) => token.address === contractAddress);
+  const token = list.find((token) => token.id === contractAddress);
 
   const { balance } = useTokenBalance(network, accountNumber, contractAddress, BackgroundExecutor);
 
@@ -103,7 +103,7 @@ const SendTokenEvm: React.FC = () => {
           bytes,
           recipient: toAddress,
           amountToken: satValue,
-          tokenContractAddress: token?.address,
+          tokenContractAddress: token?.id,
         },
       });
     } catch (error: any) {

--- a/mobile/app/TransactionSuccessEvm.tsx
+++ b/mobile/app/TransactionSuccessEvm.tsx
@@ -30,7 +30,7 @@ const TransactionSuccessEvm: React.FC = () => {
   const { receipt } = useTransactionReceipt(network, transactionId);
 
   const list = getTokenList(network);
-  const tokenInfo = list.find((token) => token.address === tokenContractAddress);
+  const tokenInfo = list.find((token) => token.id === tokenContractAddress);
 
   const [showTimedOutTxIcon, setShowTimedOutTxIcon] = useState(false);
 

--- a/mobile/components/LiquidTokensView.tsx
+++ b/mobile/components/LiquidTokensView.tsx
@@ -2,6 +2,7 @@ import type { AssetBalance } from '@breeztech/breez-sdk-liquid';
 import { useRouter } from 'expo-router';
 import React, { useContext, useEffect, useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import assert from 'assert';
 import { BlurView } from 'expo-blur';
 
 import { ThemedText } from '@/components/ThemedText';
@@ -10,8 +11,7 @@ import { BreezWallet, getBreezNetwork, LBTC_ASSET_IDS } from '@shared/class/wall
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { NETWORK_LIQUID, NETWORK_LIQUID_TESTNET } from '@shared/types/networks';
-import assert from 'assert';
-import { getTokenIconColor } from '@shared/models/token-list';
+import { getTokenIconColor, getTokenInfo } from '@shared/models/token-list';
 
 const LiquidTokensView: React.FC = () => {
   const router = useRouter();
@@ -73,8 +73,9 @@ const LiquidTokensView: React.FC = () => {
       <ThemedText style={styles.title}>Assets</ThemedText>
       <View style={styles.assetsList}>
         {assetBalances.map((item) => {
-          const iconColor = getTokenIconColor(item.name);
-          const assetSymbol = item.ticker || getAssetName(item);
+          const tokenInfo = getTokenInfo(item.assetId);
+          const iconColor = getTokenIconColor(tokenInfo.name);
+          const assetSymbol = tokenInfo.symbol;
 
           return (
             <TouchableOpacity key={item.assetId} style={styles.assetRow} onPress={() => goToSend(item.assetId)} activeOpacity={0.7}>

--- a/mobile/components/TokensView.tsx
+++ b/mobile/components/TokensView.tsx
@@ -8,15 +8,14 @@ import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useTokenBalance } from '@shared/hooks/useTokenBalance';
-import { getTokenList, getTokenIconColor } from '@shared/models/token-list';
+import { getTokenList, getTokenIconColor, getTokenInfo } from '@shared/models/token-list';
 import { formatBalance } from '@shared/modules/string-utils';
 
 const TokenRow: React.FC<{ tokenAddress: string }> = ({ tokenAddress }) => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
   const router = useRouter();
-  const list = getTokenList(network);
-  const token = list.find((token) => token.address === tokenAddress);
+  const token = getTokenInfo(tokenAddress);
 
   const { balance } = useTokenBalance(network, accountNumber, tokenAddress, BackgroundExecutor);
 
@@ -33,7 +32,7 @@ const TokenRow: React.FC<{ tokenAddress: string }> = ({ tokenAddress }) => {
   const goToSend = () => {
     router.push({
       pathname: '/SendTokenEvm',
-      params: { contractAddress: token?.address },
+      params: { contractAddress: token?.id },
     });
   };
 
@@ -71,7 +70,7 @@ const TokensView: React.FC = () => {
       <ThemedText style={styles.title}>Tokens</ThemedText>
       <View style={styles.tokensList}>
         {tokenList.map((token) => (
-          <TokenRow key={token.address} tokenAddress={token.address} />
+          <TokenRow key={token.id} tokenAddress={token.id} />
         ))}
       </View>
     </BlurView>

--- a/mobile/components/Transaction.tsx
+++ b/mobile/components/Transaction.tsx
@@ -1,0 +1,197 @@
+import { MaterialIcons } from '@expo/vector-icons';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
+import { useExchangeRate } from '@shared/hooks/useExchangeRate';
+import { formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
+import { CommonTransaction } from '@shared/types/common-transaction';
+import { Networks, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET } from '@shared/types/networks';
+import { getTokenIconColor, getTokenInfo } from '@shared/models/token-list';
+
+interface TransactionProps {
+  transaction: CommonTransaction;
+  network: Networks;
+}
+
+export default function Transaction({ network, transaction }: TransactionProps) {
+  const ticker = getTickerByNetwork(network);
+  const decimals = getDecimalsByNetwork(network);
+  const { exchangeRate } = useExchangeRate(network, 'USD');
+
+  // Helper function to format transaction amount
+  const formatTransactionAmount = () => {
+    if (transaction.amount !== undefined) {
+      const isNegative = transaction.direction === 'send';
+      const sign = isNegative && transaction.amount ? '-' : '';
+      const formattedAmount = formatBalance(Math.abs(transaction.amount).toString(), decimals);
+      return `${sign}${formattedAmount} ${ticker}`;
+    }
+    return '0 ' + ticker;
+  };
+
+  // Helper function to format transaction USD amount
+  const formatTransactionUsdAmount = () => {
+    if (transaction.amount !== undefined && exchangeRate) {
+      const usdAmount = formatFiatBalance(Math.abs(transaction.amount).toString(), decimals, exchangeRate);
+      return `${usdAmount} USD`;
+    }
+    return '0.00 USD';
+  };
+
+  // Helper function to format transaction date
+  const formatTransactionDate = () => {
+    if (transaction.status === 'pending') {
+      return 'Pending...';
+    }
+
+    const date = new Date(transaction.timestamp * 1000);
+    return date.toLocaleDateString('en-US', {
+      month: 'long',
+      day: '2-digit',
+      year: 'numeric',
+    });
+  };
+
+  // Helper function to get transaction type display text
+  const getTransactionTypeText = () => {
+    switch (transaction.direction) {
+      case 'send':
+        return 'Sent';
+      case 'receive':
+        return 'Received';
+      case 'swap':
+        return 'Swap';
+      default:
+        return 'Transaction';
+    }
+  };
+
+  // Helper function to get transaction icon
+  const getTransactionIcon = () => {
+    switch (transaction.direction) {
+      case 'receive':
+        return 'call-received';
+      case 'send':
+        return 'call-made';
+      case 'swap':
+        return 'swap-horiz';
+      default:
+        return 'call-made';
+    }
+  };
+
+  // Helper function to render token transfers
+  const renderTokenTransfers = () => {
+    if (!transaction.tokenTransfers || transaction.tokenTransfers.length === 0) {
+      return null;
+    }
+
+    return (
+      <View style={styles.tokenTransfers}>
+        {transaction.tokenTransfers.map((transfer, index) => {
+          const tokenInfo = getTokenInfo(transfer.address);
+          const iconColor = getTokenIconColor(tokenInfo.name);
+          const formattedAmount = transfer.amount;
+          const isNegative = transaction.direction === 'send';
+          const sign = isNegative ? '-' : '';
+
+          return (
+            <View key={index} style={styles.tokenTransfer}>
+              <View style={[styles.tokenIcon, { backgroundColor: iconColor }]}>
+                <ThemedText style={styles.tokenIconText}>{tokenInfo.symbol?.charAt(0).toUpperCase() || '?'}</ThemedText>
+              </View>
+              <ThemedText style={styles.tokenAmount}>
+                {sign}
+                {formattedAmount} {tokenInfo.symbol}
+              </ThemedText>
+            </View>
+          );
+        })}
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.transactionItem}>
+      <View style={styles.transactionIcon}>
+        <MaterialIcons name={getTransactionIcon()} size={24} color="rgba(255, 255, 255, 0.8)" />
+      </View>
+
+      <View style={styles.transactionDetails}>
+        <ThemedText style={styles.transactionType}>{getTransactionTypeText()}</ThemedText>
+        <ThemedText style={styles.transactionDate}>{formatTransactionDate()}</ThemedText>
+        {renderTokenTransfers()}
+      </View>
+
+      <View style={styles.transactionAmounts}>
+        <ThemedText style={styles.transactionAmount}>{formatTransactionAmount()}</ThemedText>
+        <ThemedText style={styles.transactionUsd}>{formatTransactionUsdAmount()}</ThemedText>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  transactionItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  transactionIcon: {
+    width: 24,
+    height: 24,
+  },
+  transactionDetails: {
+    flex: 1,
+    marginLeft: 16,
+  },
+  transactionType: {
+    fontSize: 16,
+    color: 'rgba(255, 255, 255, 0.8)',
+    marginBottom: 6,
+  },
+  transactionDate: {
+    fontSize: 14,
+    color: 'rgba(255, 255, 255, 0.4)',
+  },
+  transactionAmounts: {
+    alignItems: 'flex-end',
+  },
+  transactionAmount: {
+    fontSize: 15,
+    color: 'rgba(255, 255, 255, 0.8)',
+    marginBottom: 6,
+  },
+  transactionUsd: {
+    fontSize: 13,
+    color: 'rgba(255, 255, 255, 0.4)',
+    fontWeight: '500',
+  },
+  tokenTransfers: {
+    marginTop: 8,
+    gap: 6,
+  },
+  tokenTransfer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  tokenIcon: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tokenIconText: {
+    fontSize: 10,
+    fontWeight: '600',
+    color: 'white',
+  },
+  tokenAmount: {
+    fontSize: 12,
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontWeight: '400',
+  },
+});

--- a/mobile/src/modules/background-executor.ts
+++ b/mobile/src/modules/background-executor.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import * as BlueElectrum from '@shared/blue_modules/BlueElectrum';
 import { EvmWallet } from '@shared/class/evm-wallet';
 import { BreezWallet, getBreezNetwork } from '@shared/class/wallets/breez-wallet';
@@ -14,7 +16,6 @@ import { Csprng } from '../class/rng';
 import { SecureStorage } from '../class/secure-storage';
 import { decrypt, encrypt } from '../modules/encryption';
 import { ArkWallet } from '@shared/class/wallets/ark-wallet';
-import assert from 'assert';
 
 /**
  * A drop-in replacement for BackgroundCaller in `ext` project. Since we have only one js context on mobile,
@@ -43,7 +44,7 @@ export const BackgroundExecutor: IBackgroundCaller = {
     } else if (network === NETWORK_LIQUID || network === NETWORK_LIQUID_TESTNET) {
       const wallet = await BackgroundExecutor.lazyInitWallet(network, accountNumber);
       assert(wallet instanceof BreezWallet);
-      const address = wallet.getAddressLiquid();
+      const address = await wallet.getAddressLiquid();
       return address;
     } else {
       const xpub = await LayerzStorage.getItem(STORAGE_KEY_EVM_XPUB);
@@ -245,5 +246,19 @@ export const BackgroundExecutor: IBackgroundCaller = {
 
   async getSubMnemonic(accountNumber) {
     return await SecureStorage.getItem(STORAGE_KEY_SUB_MNEMONIC + accountNumber);
+  },
+
+  async getCommonTransactions(network, accountNumber, afterTxid, limit) {
+    if (network === NETWORK_BITCOIN) {
+      const wallet = await BackgroundExecutor.lazyInitWallet(network, accountNumber);
+      assert(wallet instanceof WatchOnlyWallet);
+      await wallet.fetchTransactions();
+      return wallet.getCommonTransactions(afterTxid, limit);
+    } else if (network === NETWORK_LIQUID || network === NETWORK_LIQUID_TESTNET) {
+      const wallet = await BackgroundExecutor.lazyInitWallet(network, accountNumber);
+      assert(wallet instanceof BreezWallet);
+      return await wallet.getCommonTransactions(afterTxid, limit);
+    }
+    return [];
   },
 };

--- a/mobile/src/modules/breeze-adapter.ts
+++ b/mobile/src/modules/breeze-adapter.ts
@@ -2,7 +2,7 @@ import type * as JSAPI from '@breeztech/breez-sdk-liquid';
 import * as RNAPI from '@breeztech/react-native-breez-sdk-liquid';
 import * as Crypto from 'expo-crypto';
 
-import { BreezConnection, IBreezAdapter, assetMetadata } from '@shared/class/wallets/breez-wallet';
+import { BreezConnection, IBreezAdapter, getAssertMetadata } from '@shared/class/wallets/breez-wallet';
 
 const API_KEY = process.env.EXPO_PUBLIC_BREEZ_API_KEY;
 
@@ -122,8 +122,7 @@ class BreezAdapter implements IBreezAdapter {
     // set the working directory to a unique path based on the mnemonic
     config.workingDir = `${config.workingDir}/${sha256(connection.mnemonic)}`;
     // set the asset metadata
-    // filter out Bitcoin testnet here, it is only needed in Extension
-    config.assetMetadata = assetMetadata.filter(({ assetId }) => assetId !== '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49');
+    config.assetMetadata = getAssertMetadata(connection.network);
     try {
       await RNAPI.connect({ mnemonic: connection.mnemonic, config });
     } catch (e: any) {
@@ -184,6 +183,10 @@ class BreezAdapter implements IBreezAdapter {
     return result;
   }
 
+  private async listPayments(args: JSAPI.ListPaymentsRequest) {
+    return await RNAPI.listPayments(args as RNAPI.ListPaymentsRequest);
+  }
+
   get api() {
     const getInfo = this.withLockAndSdk(this.getInfo.bind(this));
     const prepareReceivePayment = this.withLockAndSdk(this.prepareReceivePayment.bind(this));
@@ -192,6 +195,7 @@ class BreezAdapter implements IBreezAdapter {
     const prepareSendPayment = this.withLockAndSdk(this.prepareSendPayment.bind(this));
     const sendPayment = this.withLockAndSdk(this.sendPayment.bind(this));
     const getPayment = this.withLockAndSdk(this.getPayment.bind(this));
+    const listPayments = this.withLockAndSdk(this.listPayments.bind(this));
 
     return {
       getInfo,
@@ -201,6 +205,7 @@ class BreezAdapter implements IBreezAdapter {
       prepareSendPayment,
       sendPayment,
       getPayment,
+      listPayments,
     };
   }
 

--- a/shared/class/evm-wallet.ts
+++ b/shared/class/evm-wallet.ts
@@ -57,10 +57,10 @@ export class EvmWallet {
   }
 
   async createTokenTransferTransaction(from: string, to: string, token: TokenInfo, amount: StringNumber): Promise<TransactionRequest> {
-    const iface = new ethers.Contract(token.address, ['function transfer(address,uint256)']);
+    const iface = new ethers.Contract(token.id, ['function transfer(address,uint256)']);
     const data = iface.interface.encodeFunctionData('transfer', [to, amount]);
 
-    return { data, from, to: token.address };
+    return { data, from, to: token.id };
   }
 
   private getWalletFromMnemonic(mnemonic: string, accountNumber: number): Wallet {

--- a/shared/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/shared/class/wallets/abstract-hd-electrum-wallet.ts
@@ -21,6 +21,9 @@ import ecc from '@bitcoinerlab/secp256k1';
 import { AbstractHDWallet } from './abstract-hd-wallet';
 import { CreateTransactionResult, CreateTransactionTarget, CreateTransactionUtxo, Transaction, Utxo } from './types';
 import { ICsprng } from '../../types/ICsprng';
+import { CommonTransaction } from '../../types/common-transaction';
+import { NETWORK_BITCOIN } from '../../types/networks';
+
 const ECPair = ECPairFactory(ecc);
 const bip32 = BIP32Factory(ecc);
 
@@ -1316,5 +1319,48 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
 
   _getBalancesByPaymentCodeIndex(paymentCode: string): BalanceByIndex {
     return this._balances_by_payment_code_index[paymentCode] || { c: 0, u: 0 };
+  }
+
+  /**
+   * Returns common transactions for the wallet. The transactions are sorted by received timestamp (newest first).
+   *
+   * @param afterTxid - if provided, only transactions after this txid will be returned
+   * @param limit - maximum number of transactions to return
+   * @returns CommonTransaction[]
+   */
+  async getCommonTransactions(afterTxid?: string, limit: number = 10): Promise<CommonTransaction[]> {
+    const txs = this.getTransactions().reverse();
+    let filtered: Transaction[] = [];
+
+    // filter
+    if (afterTxid) {
+      let found = false;
+      for (const tx of txs) {
+        if (found) {
+          filtered.push(tx);
+        }
+        found = tx.txid === afterTxid;
+      }
+    } else {
+      filtered = txs;
+    }
+    filtered = filtered.slice(0, limit);
+
+    // convert to common transaction
+    const commonTransactions: CommonTransaction[] = [];
+    for (const tx of filtered) {
+      const direction = tx?.value ? (tx.value > 0 ? 'receive' : 'send') : 'other';
+      commonTransactions.push({
+        txid: tx.txid,
+        network: NETWORK_BITCOIN,
+        timestamp: (tx.received ?? 0) / 1000,
+        direction,
+        amount: tx?.value,
+        tokenTransfers: [],
+        status: tx.confirmations > 3 ? 'confirmed' : 'pending',
+      });
+    }
+
+    return commonTransactions;
   }
 }

--- a/shared/class/wallets/breez-wallet.ts
+++ b/shared/class/wallets/breez-wallet.ts
@@ -4,6 +4,7 @@ import type {
   GetPaymentRequest,
   LightningPaymentLimitsResponse,
   LiquidNetwork,
+  ListPaymentsRequest,
   Payment,
   PrepareReceiveRequest,
   PrepareReceiveResponse,
@@ -15,8 +16,11 @@ import type {
   SendPaymentResponse,
 } from '@breeztech/breez-sdk-liquid';
 import bolt11 from 'bolt11';
-import { NETWORK_LIQUID, NETWORK_LIQUID_TESTNET } from '../../types/networks';
+
 import { createLightningInvoiceResponse, InterfaceLightningWallet } from './interface-lightning-wallet';
+import { CommonTokenTransfer, CommonTransaction } from '@shared/types/common-transaction';
+import { getTokenList } from '@shared/models/token-list';
+import { NETWORK_LIQUID, NETWORK_LIQUID_TESTNET } from '@shared/types/networks';
 
 export type BreezConnection = {
   mnemonic: string;
@@ -32,6 +36,7 @@ export interface IBreezAdapter {
     prepareSendPayment: (connection: BreezConnection, args: PrepareSendRequest) => Promise<PrepareSendResponse>;
     sendPayment: (connection: BreezConnection, args: SendPaymentRequest) => Promise<SendPaymentResponse>;
     getPayment(connection: BreezConnection, args: GetPaymentRequest): Promise<Payment | undefined>;
+    listPayments(connection: BreezConnection, args: ListPaymentsRequest): Promise<Payment[]>;
   };
 }
 
@@ -83,6 +88,10 @@ export class BreezWallet implements InterfaceLightningWallet {
 
   public async sendPayment(args: SendPaymentRequest) {
     return await this.adapter.api.sendPayment(this.connection, args);
+  }
+
+  public async listPayments(args: ListPaymentsRequest) {
+    return await this.adapter.api.listPayments(this.connection, args);
   }
 
   public async getAddressLiquid() {
@@ -185,35 +194,54 @@ export class BreezWallet implements InterfaceLightningWallet {
 
     return false;
   }
+
+  async getCommonTransactions(afterTxid?: string, limit: number = 10): Promise<CommonTransaction[]> {
+    const payments = await this.listPayments({});
+
+    // convert to common transaction
+    const commonTransactions: CommonTransaction[] = [];
+    for (const payment of payments) {
+      let tokenTransfers: CommonTokenTransfer[] = [];
+      // Make sure it is a token transfer
+      if (payment.details.type === 'liquid' && !Object.values(LBTC_ASSET_IDS).includes(payment.details.assetId)) {
+        const address = payment.details.assetId;
+        let amount = payment.details.assetInfo?.amount ?? null;
+        if (amount === null) {
+          // if assetInfo is not present, we parse `destination` field as URL
+          const url = new URL(payment.details.destination);
+          amount = Number(url.searchParams.get('amount'));
+        }
+        tokenTransfers = [{ address, amount }];
+      }
+
+      commonTransactions.push({
+        txid: payment.txId!,
+        network: NETWORK_LIQUID,
+        timestamp: payment.timestamp,
+        direction: payment.paymentType,
+        amount: payment.amountSat,
+        status: payment.status === 'complete' ? 'confirmed' : 'pending',
+        fee: payment.feesSat,
+        tokenTransfers,
+      });
+    }
+
+    return commonTransactions;
+  }
 }
 
-// Additional assets
-export const assetMetadata: AssetMetadata[] = [
-  {
-    assetId: '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49',
-    name: 'Testnet Bitcoin',
-    ticker: 'tBTC',
-    precision: 8,
-  },
-  {
-    assetId: 'ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af256',
-    name: 'KEK LOL',
-    ticker: 'LOLx',
-    precision: 7,
-  },
-  {
-    assetId: 'ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9',
-    name: 'KEK LOL2',
-    ticker: 'LOLx2',
-    precision: 7,
-  },
-  {
-    assetId: '139768b54fb12cdb732d02d12aba8abb7de8f8f5ae776ca13e2ba10cbf306aa9',
-    name: 'KEK LOL3',
-    ticker: 'LOLx3',
-    precision: 7,
-  },
-];
+export const getAssertMetadata = (liquidNetwork: LiquidNetwork): AssetMetadata[] => {
+  const network = liquidNetwork === 'mainnet' ? NETWORK_LIQUID : NETWORK_LIQUID_TESTNET;
+  // we need to filter out BTC and USDT assets, otherwise we will get an error
+  const filterOut = [LBTC_ASSET_IDS.mainnet, LBTC_ASSET_IDS.testnet, 'ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2'];
+  const list = getTokenList(network).filter((token) => !filterOut.includes(token.id));
+  return list.map((token) => ({
+    assetId: token.id,
+    name: token.name,
+    ticker: token.symbol,
+    precision: token.decimals,
+  }));
+};
 
 // L-BTC asset IDs for mainnet and testnet
 export const LBTC_ASSET_IDS = {

--- a/shared/class/wallets/watch-only-wallet.ts
+++ b/shared/class/wallets/watch-only-wallet.ts
@@ -312,4 +312,9 @@ export class WatchOnlyWallet extends LegacyWallet {
     if (this._hdWalletInstance) return this._hdWalletInstance.isSegwit();
     return super.isSegwit();
   }
+
+  getCommonTransactions(...args: Parameters<HDSegwitBech32Wallet['getCommonTransactions']>) {
+    if (this._hdWalletInstance) return this._hdWalletInstance.getCommonTransactions(...args);
+    throw new Error("Not a HD watch-only wallet, can't use getCommonTransactions");
+  }
 }

--- a/shared/hooks/useTransactions.ts
+++ b/shared/hooks/useTransactions.ts
@@ -1,0 +1,75 @@
+import useSWR from 'swr';
+
+import { CommonTransaction } from '@shared/types/common-transaction';
+import { IBackgroundCaller } from '../types/IBackgroundCaller';
+import { NETWORK_ARK_MUTINYNET, NETWORK_BITCOIN, NETWORK_LIGHTNING, NETWORK_LIGHTNING_TESTNET, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_SPARK, Networks } from '../types/networks';
+
+interface txFetcherArg {
+  cacheKey: string;
+  accountNumber: number;
+  network: Networks;
+  backgroundCaller: IBackgroundCaller;
+}
+
+/**
+ * extra key `backgroundCaller` can mutate unpredictably, causing more cache saves, and messing up logic. this middleware removes it from the key
+ */
+function keyCleanupMiddleware(useSWRNext: any) {
+  return (key: any, fetcher: any, config: any) => {
+    let newKey = key;
+    if (typeof key === 'object' && key.backgroundCaller) {
+      newKey = Object.assign({}, key);
+      delete newKey.backgroundCaller;
+    }
+
+    return useSWRNext(newKey, () => fetcher(key), config);
+  };
+}
+
+export const txFetcher = async (arg: txFetcherArg): Promise<CommonTransaction[]> => {
+  const { accountNumber, network, backgroundCaller } = arg;
+  if (network === NETWORK_BITCOIN) {
+    return await backgroundCaller.getCommonTransactions(network, accountNumber);
+  }
+
+  if (network === NETWORK_LIQUID || network === NETWORK_LIQUID_TESTNET) {
+    return await backgroundCaller.getCommonTransactions(network, accountNumber);
+  }
+
+  return [];
+};
+
+export function useTransactions(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller) {
+  let refreshInterval = 12_000; // ETH block time
+
+  switch (network) {
+    case NETWORK_SPARK:
+    case NETWORK_ARK_MUTINYNET:
+      refreshInterval = 5_000; // transfers are just server interactions, should be fast
+      break;
+
+    case NETWORK_LIGHTNING:
+    case NETWORK_LIGHTNING_TESTNET:
+    case NETWORK_LIQUID:
+    case NETWORK_LIQUID_TESTNET:
+      refreshInterval = 5_000; // we are just fetching data from the SDK, should be fast
+      break;
+
+    case NETWORK_BITCOIN:
+      refreshInterval = 60_000; // 1 min for btc
+  }
+
+  const arg: txFetcherArg = { cacheKey: 'txFetcher', accountNumber, network, backgroundCaller };
+  const { data, error, isLoading } = useSWR(arg, txFetcher, {
+    use: [keyCleanupMiddleware],
+    refreshInterval,
+    refreshWhenHidden: false,
+    keepPreviousData: true,
+  });
+
+  return {
+    transactions: data,
+    isLoading,
+    error,
+  };
+}

--- a/shared/models/token-list.ts
+++ b/shared/models/token-list.ts
@@ -1,11 +1,37 @@
 import { Networks } from '../types/networks';
-import { TokenInfo } from '../types/token-info';
+import { TokenInfo, EVMTokenInfo, LiquidTokenInfo } from '../types/token-info';
 import { getChainIdByNetwork } from './network-getters';
 import { hexToDec } from '../modules/string-utils';
 
 // kept as a separate json just because in evm world token list is standard by itself and
 // json files can be shared, imported etc
-const list: TokenInfo[] = require('./tokenlist.json');
+const evmList: EVMTokenInfo[] = require('./tokenlist.json');
+const liquidList: LiquidTokenInfo[] = require('./tokenlist-liquid.json');
+
+export function evmToCommonTokenInfo(token: EVMTokenInfo): TokenInfo {
+  return {
+    id: token.address,
+    chainId: token.chainId,
+    name: token.name,
+    decimals: token.decimals,
+    symbol: token.symbol,
+    logoURI: token.logoURI,
+    tags: token.tags,
+    extensions: token.extensions,
+  };
+}
+
+function liquidToCommonTokenInfo(token: LiquidTokenInfo): TokenInfo {
+  return {
+    id: token.assetId,
+    chainId: token.chainId,
+    name: token.name,
+    decimals: token.decimals,
+    symbol: token.symbol,
+  };
+}
+
+const list: TokenInfo[] = [...evmList.map(evmToCommonTokenInfo), ...liquidList.map(liquidToCommonTokenInfo)];
 
 export function getTokenList(network: Networks): TokenInfo[] {
   let ret: TokenInfo[] = [];
@@ -17,6 +43,21 @@ export function getTokenList(network: Networks): TokenInfo[] {
   }
 
   return ret;
+}
+
+export function getTokenInfo(id: string): TokenInfo {
+  const token = list.find((t) => t.id === id);
+  if (token) {
+    return token;
+  }
+  // if token is not found, we return something
+  return {
+    id,
+    name: 'Unknown Token',
+    decimals: 8,
+    symbol: id.substring(0, 8),
+    chainId: 99999,
+  };
 }
 
 // Unified function for getting token/asset icon colors

--- a/shared/models/tokenlist-liquid.json
+++ b/shared/models/tokenlist-liquid.json
@@ -1,0 +1,58 @@
+[
+  {
+    "assetId": "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d",
+    "name": "Liquid Bitcoin",
+    "symbol": "L-BTC",
+    "decimals": 8,
+    "chainId": 11
+  },
+  {
+    "assetId": "144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49",
+    "name": "Testnet Bitcoin",
+    "symbol": "tBTC",
+    "decimals": 8,
+    "chainId": 12
+  },
+  {
+    "assetId": "ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af256",
+    "name": "KEK LOL",
+    "symbol": "LOLx",
+    "decimals": 7,
+    "chainId": 12
+  },
+  {
+    "assetId": "ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9",
+    "name": "KEK LOL2",
+    "symbol": "LOLx2",
+    "decimals": 7,
+    "chainId": 12
+  },
+  {
+    "assetId": "139768b54fb12cdb732d02d12aba8abb7de8f8f5ae776ca13e2ba10cbf306aa9",
+    "name": "KEK LOL3",
+    "symbol": "LOLx3",
+    "decimals": 7,
+    "chainId": 12
+  },
+  {
+    "assetId": "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
+    "name": "Tether USDt",
+    "symbol": "USDt",
+    "decimals": 2,
+    "chainId": 11
+  },
+  {
+    "assetId": "3438ecb49fc45c08e687de4749ed628c511e326460ea4336794e1cf02741329e",
+    "name": "JPY Stablecoin",
+    "symbol": "JPYS",
+    "decimals": 2,
+    "chainId": 11
+  },
+  {
+    "assetId": "18729918ab4bca843656f08d4dd877bed6641fbd596a0a963abbf199cfeb3cec",
+    "name": "PEGx EURx",
+    "symbol": "EURx",
+    "decimals": 2,
+    "chainId": 11
+  }
+]

--- a/shared/tests/integration-vi/integration.test.ts
+++ b/shared/tests/integration-vi/integration.test.ts
@@ -54,6 +54,9 @@ const backgroundCallerMock2: IBackgroundCaller = {
   getSubMnemonic() {
     throw new Error('Function not implemented.');
   },
+  getCommonTransactions() {
+    throw new Error('Function not implemented.');
+  },
 };
 
 test('can fetch balance', async (context) => {

--- a/shared/tests/unit-vi/bitcoin-wallet.test.ts
+++ b/shared/tests/unit-vi/bitcoin-wallet.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, vi, assert } from 'vitest';
+import { AbstractHDElectrumWallet } from '../../class/wallets/abstract-hd-electrum-wallet';
+import { NETWORK_BITCOIN } from '../../types/networks';
+import { Transaction } from '../../class/wallets/types';
+
+describe('Bitcoin Wallet - getCommonTransactions', () => {
+  it('should return transactions in correct order', async () => {
+    const wallet = new AbstractHDElectrumWallet();
+
+    const fakeTransactions = [
+      // incoming, confirmed
+      {
+        txid: 'tx1',
+        received: 1234567890000,
+        value: 100000000,
+        confirmations: 5,
+      },
+      // outgoing, confirmed
+      {
+        txid: 'tx2',
+        received: 1234567891000,
+        value: -50000000,
+        confirmations: 5,
+      },
+      // incoming, unconfirmed
+      {
+        txid: 'tx3',
+        received: 1234567892000,
+        value: 100000000,
+        confirmations: 0,
+      },
+    ] as Transaction[];
+
+    vi.spyOn(wallet, 'getTransactions').mockReturnValue(fakeTransactions);
+
+    const result1 = await wallet.getCommonTransactions();
+
+    assert.deepEqual(result1, [
+      {
+        txid: 'tx3',
+        network: NETWORK_BITCOIN,
+        timestamp: 1234567892,
+        direction: 'receive',
+        amount: 100000000,
+        tokenTransfers: [],
+        status: 'pending',
+      },
+      {
+        txid: 'tx2',
+        network: NETWORK_BITCOIN,
+        timestamp: 1234567891,
+        direction: 'send',
+        amount: -50000000,
+        tokenTransfers: [],
+        status: 'confirmed',
+      },
+      {
+        txid: 'tx1',
+        network: NETWORK_BITCOIN,
+        timestamp: 1234567890,
+        direction: 'receive',
+        amount: 100000000,
+        tokenTransfers: [],
+        status: 'confirmed',
+      },
+    ]);
+
+    // filter by txid
+    const result2 = await wallet.getCommonTransactions('tx2');
+
+    assert.deepEqual(result2, [
+      {
+        txid: 'tx3',
+        network: NETWORK_BITCOIN,
+        timestamp: 1234567892,
+        direction: 'receive',
+        amount: 100000000,
+        tokenTransfers: [],
+        status: 'pending',
+      },
+    ]);
+  });
+});

--- a/shared/tests/unit-vi/breez-wallet.test.ts
+++ b/shared/tests/unit-vi/breez-wallet.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, vi, assert } from 'vitest';
+import { BreezWallet } from '../../class/wallets/breez-wallet';
+import { NETWORK_LIQUID } from '../../types/networks';
+import { Payment } from '@breeztech/breez-sdk-liquid';
+
+// @ts-ignore: no need to use real breez adapter
+globalThis.breezAdapter = null;
+
+describe('Breez Wallet - getCommonTransactions', () => {
+  it('should return transactions in correct order', async () => {
+    const wallet = new BreezWallet('test mnemonic', 'mainnet');
+
+    const fakePayments = [
+      // BTC
+      {
+        txId: '095cf834f56cc032708bb2465463ae348164b4d498b181f52fd98d0097c08629',
+        timestamp: 1754383510,
+        amountSat: 1123,
+        feesSat: 0,
+        status: 'complete',
+        details: {
+          assetId: '6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d',
+          type: 'liquid',
+          assetInfo: {
+            name: 'Bitcoin',
+            amount: 0.00001123,
+            ticker: 'BTC',
+            fees: undefined,
+          },
+        },
+        paymentType: 'receive',
+      },
+      // USDT
+      {
+        amountSat: 0,
+        details: {
+          assetId: 'ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2',
+          assetInfo: {
+            amount: 0.03,
+            name: 'Tether USD',
+            ticker: 'USDt',
+          },
+          type: 'liquid',
+        },
+        feesSat: 81,
+        paymentType: 'send',
+        status: 'complete',
+        timestamp: 1754384530,
+        txId: 'tx2',
+      },
+      // Lightning
+      {
+        feesSat: 48,
+        paymentType: 'receive',
+        status: 'complete',
+        details: {
+          type: 'lightning',
+          paymentHash: '3e28957ff7e6dc624823bbb3e9d95864075f1dcb63490f7285d593dd9868b7b9',
+          swapId: 'KBnpxEfCxPSX',
+          claimTxId: 'tx3',
+          liquidExpirationBlockheight: 3420492,
+          invoice:
+            'lnbc1010n1p59znsksp5gkv0ss3kd80vhn284ev2g40zsjxj6hm7epgrzfta9prsl2yngksqpp58c5f2llhumwxyjprhwe7nk2cvsr478wtvdys7u596kfamxrgk7usdpz2pshjmt9de6zqar0ypp9gseqwaskcmr9wsxqyp2xqcqz95rzjqg2c53zuagptyaf32d9rdsww9qz8fcd4jwgneapuuuu9v3ykehcjkzzxeyqq28qqqqqqqqqqqqqqq9gq2y9qyysgqh7t4hhxlhqueaeyma0v92mz2sjypl79vg0qv2ckvy9pd6yn88qfhfz402wlw5r0gsmf0swyaep9enkzws8ns94fgwt23aqdwn9nrlgcpgn87fv',
+          preimage: '2d974f6182c02c9f0f156b773bb1c228695d0b117c2499c920efc9a33b6a6ad3',
+        },
+        swapperFeesSat: 1,
+        txId: 'tx3',
+        timestamp: 1750158910,
+        amountSat: 53,
+      },
+      // Unknown asset
+      {
+        details: {
+          type: 'liquid',
+          assetId: 'ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9',
+          description: 'Liquid transfer',
+          destination:
+            'liquidtestnet:tlq1qqt0ms77xycr0c40jz8rtdsp230vmx8yzczrm5d7fjm95wc89pe6667uzw86jt53684mudx3qha50qwuhyqxtsmdfpyh6pfycx?assetid=ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9&amount=0.00000001',
+        },
+        destination:
+          'liquidtestnet:tlq1qqt0ms77xycr0c40jz8rtdsp230vmx8yzczrm5d7fjm95wc89pe6667uzw86jt53684mudx3qha50qwuhyqxtsmdfpyh6pfycx?assetid=ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9&amount=0.00000001',
+        timestamp: 1749209827,
+        amountSat: 1,
+        feesSat: 40,
+        paymentType: 'send',
+        status: 'complete',
+        txId: '1d9939da15721adbd021d550286fec9f8476c0218073416966e62ef8f4de1f9b',
+        unblindingData:
+          '94,ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9,e8b2ddfc070e0048d2275e3e05545f50a83141472197b6f0f78bad71e2a61606,d18841bb2cda97d31ecc37b563d623f5aa03d37c9d82954cdff30af83579c7c3,298529,144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49,2ab52dc6784b10519928593b94eeee2e06358d45fc26fbc48e6364734420f651,65dbb7f3a40a660a0c7ee9d5a6e684675dbeb048bf48e7196d2df021e3d72e3b,93,ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9,fc39a189b9fbc47bb25e5c27d7e1099e9bab7400aaa8a19e26a5860d45dee11f,6cd220bb2ff7c49faa7f8fc43084c8480666e898e02cf1b495b721bfe624bb71,298489,144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49,20736870a559409d312d463643b82a38ffb7c607cb50366ff4469e3843970718,58f7a90773245a2a79d71b1cdc804280baa08a5e3ca9fb97629f27a46d9c43cc',
+      },
+    ] as Payment[];
+
+    vi.spyOn(wallet, 'listPayments').mockResolvedValue(fakePayments);
+
+    const result1 = await wallet.getCommonTransactions();
+
+    assert.deepEqual(result1, [
+      {
+        txid: '095cf834f56cc032708bb2465463ae348164b4d498b181f52fd98d0097c08629',
+        network: NETWORK_LIQUID,
+        timestamp: 1754383510,
+        direction: 'receive',
+        status: 'confirmed',
+        fee: 0,
+        amount: 1123,
+        tokenTransfers: [],
+      },
+      {
+        txid: 'tx2',
+        network: NETWORK_LIQUID,
+        timestamp: 1754384530,
+        direction: 'send',
+        status: 'confirmed',
+        fee: 81,
+        amount: 0,
+        tokenTransfers: [
+          {
+            address: 'ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2',
+            amount: 0.03,
+          },
+        ],
+      },
+      {
+        amount: 53,
+        direction: 'receive',
+        fee: 48,
+        network: NETWORK_LIQUID,
+        status: 'confirmed',
+        timestamp: 1750158910,
+        tokenTransfers: [],
+        txid: 'tx3',
+      },
+      {
+        amount: 1,
+        direction: 'send',
+        fee: 40,
+        network: 'liquid',
+        status: 'confirmed',
+        timestamp: 1749209827,
+        tokenTransfers: [
+          {
+            address: 'ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9',
+            amount: 1e-8,
+          },
+        ],
+        txid: '1d9939da15721adbd021d550286fec9f8476c0218073416966e62ef8f4de1f9b',
+      },
+    ]);
+  });
+});

--- a/shared/tests/unit-vi/rpc-controller.test.ts
+++ b/shared/tests/unit-vi/rpc-controller.test.ts
@@ -85,6 +85,9 @@ const backgroundCallerMock2: IBackgroundCaller = {
   getSubMnemonic() {
     throw new Error('Function not implemented.');
   },
+  getCommonTransactions() {
+    throw new Error('Function not implemented.');
+  },
 };
 
 beforeEach(() => {

--- a/shared/types/IBackgroundCaller.ts
+++ b/shared/types/IBackgroundCaller.ts
@@ -1,6 +1,7 @@
 import { CreateTransactionUtxo } from '../class/wallets/types';
 import { Networks } from '../types/networks';
 import { TLazyInitedWallets, TSupportedLazyInitWalletNetworks } from '../modules/wallet-utils';
+import { CommonTransaction } from './common-transaction';
 
 // Message types for background script communication
 export enum MessageType {
@@ -15,6 +16,7 @@ export enum MessageType {
   GET_ADDRESS,
   GET_BTC_SEND_DATA,
   GET_SUB_MNEMONIC,
+  GET_COMMON_TRANSACTIONS,
 }
 
 // Message types for background script communication
@@ -63,6 +65,10 @@ export type MessageTypeMap = {
     params: GetSubMnemonicRequest;
     response: GetSubMnemonicResponse;
   };
+  [MessageType.GET_COMMON_TRANSACTIONS]: {
+    params: GetCommonTransactionsRequest;
+    response: GetCommonTransactionsResponse;
+  };
 };
 
 export type GetAddressParams = [network: Networks, accountNumber: number];
@@ -95,6 +101,9 @@ export type GetBtcSendDataResponse = { utxos: CreateTransactionUtxo[]; changeAdd
 export type GetSubMnemonicRequest = [accountNumber: number];
 export type GetSubMnemonicResponse = string;
 
+export type GetCommonTransactionsRequest = [network: Networks, accountNumber: number, afterTxid?: string, limit?: number];
+export type GetCommonTransactionsResponse = CommonTransaction[];
+
 export interface ProcessRPCRequest {
   method: string;
   params: any;
@@ -122,4 +131,5 @@ export interface IBackgroundCaller {
   openPopup(...params: OpenPopupRequest): Promise<void>;
   getBtcSendData(...params: GetBtcSendDataRequest): Promise<GetBtcSendDataResponse>;
   getSubMnemonic(...params: GetSubMnemonicRequest): Promise<GetSubMnemonicResponse>;
+  getCommonTransactions(...params: GetCommonTransactionsRequest): Promise<GetCommonTransactionsResponse>;
 }

--- a/shared/types/common-transaction.ts
+++ b/shared/types/common-transaction.ts
@@ -1,0 +1,62 @@
+import { Networks } from './networks';
+
+/**
+ * Simplified token transfer information for cross-chain compatibility
+ */
+export interface CommonTokenTransfer {
+  /** Token symbol (e.g., 'USDT', 'DAI') */
+  // symbol: string;
+  /** Transfer amount in token's base units */
+  amount: number;
+  /** Address the transfer is from (for receives) or to (for sends) */
+  address: string;
+  /** Token contract address (for EVM chains) or identifier (for other chains) */
+  tokenId?: string;
+}
+
+/**
+ * Transaction status across different networks
+ */
+export type TransactionStatus = 'pending' | 'confirmed' | 'failed' | 'cancelled';
+
+/**
+ * Common transaction structure that works across Bitcoin, Lightning, and EVM chains.
+ * This provides a unified view without being over-fitted to any specific chain.
+ */
+export interface CommonTransaction {
+  /** Transaction hash or identifier */
+  txid: string;
+
+  /** Network this transaction occurred on */
+  network: Networks;
+
+  /** Transaction timestamp (Unix timestamp in seconds) */
+  timestamp: number;
+
+  /** Transaction direction from wallet's perspective */
+  direction: 'send' | 'receive' | 'swap' | 'other';
+
+  /** Base amount in the network's main currency */
+  amount?: number;
+
+  /** Optional token transfers within this transaction */
+  tokenTransfers?: CommonTokenTransfer[];
+
+  /** Transaction status */
+  status?: TransactionStatus;
+
+  /** Transaction fee in network's base currency */
+  fee?: number;
+
+  /** Optional memo or note attached to transaction */
+  memo?: string;
+
+  /** Number of confirmations (not applicable to Lightning) */
+  confirmations?: number;
+
+  /** Counterparty address or identifier */
+  counterparty?: string;
+
+  /** Block height where transaction was included (not applicable to Lightning) */
+  blockHeight?: number;
+}

--- a/shared/types/token-info.ts
+++ b/shared/types/token-info.ts
@@ -1,6 +1,6 @@
 export interface TokenInfo {
+  readonly id: string;
   readonly chainId: number;
-  readonly address: string;
   readonly name: string;
   readonly decimals: number;
   readonly symbol: string;
@@ -9,4 +9,12 @@ export interface TokenInfo {
   readonly extensions?: {
     readonly [key: string]: string | number | boolean | null;
   };
+}
+
+export interface EVMTokenInfo extends Omit<TokenInfo, 'id'> {
+  readonly address: string;
+}
+
+export interface LiquidTokenInfo extends Omit<TokenInfo, 'id'> {
+  readonly assetId: string;
 }


### PR DESCRIPTION
- bitcoin and liquid (plus tokens) for now
- both wallets has getCommonTransaction call, that return Transaction type that we can easy to render
- new TokenInfo type includes Liquid tokens
- for now only show last 3 transactions on home screen
- no exchange rates for tokens

<img width="200" height="2556" alt="image" src="https://github.com/user-attachments/assets/31b9d695-6f46-4290-932b-6cc9c8b5d604" />

<img width="200" height="2556" alt="image" src="https://github.com/user-attachments/assets/fdae9b6d-032b-4761-9e42-a4610dc0bc39" />
