### PR TITLE
fix: balance should be one line

### DIFF
--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -348,7 +348,7 @@ export default function Home() {
           ) : (
             <View style={styles.balanceSection} testID="LayerBalance">
               <View style={styles.balanceContainer}>
-                <ThemedText style={styles.balanceAmount} testID="LayerActualBalance">
+                <ThemedText style={styles.balanceAmount} adjustsFontSizeToFit={true} numberOfLines={1} testID="LayerActualBalance">
                   {balance ? displayBalance : '???'}
                 </ThemedText>
                 <ThemedText style={styles.balanceUsd}>{displaySubBalance}</ThemedText>


### PR DESCRIPTION
prevent balance to take 2 lines

Before / After

<img width="200"  alt="Simulator Screenshot - iPhone 16 - 2025-08-11 at 13 33 02" src="https://github.com/user-attachments/assets/9a0fc387-db69-4ff9-8108-3312f997b0d2" /> <img width="200"   alt="Simulator Screenshot - iPhone 16 - 2025-08-11 at 13 33 09" src="https://github.com/user-attachments/assets/22ec7267-82f9-4634-b9bc-17890f68e65c" />
