### PR TITLE
fix: clear wallets cache on app reset

### DIFF
--- a/ext/src/modules/background-caller.ts
+++ b/ext/src/modules/background-caller.ts
@@ -125,4 +125,8 @@ export const BackgroundCaller: IBackgroundCaller = {
   async getCommonTransactions(...params): Promise<GetCommonTransactionsResponse> {
     return await Messenger.sendGenericMessageToBackground(MessageType.GET_COMMON_TRANSACTIONS, params);
   },
+
+  async clear(...params) {
+    return await Messenger.sendGenericMessageToBackground(MessageType.CLEAR, params);
+  },
 };

--- a/ext/src/modules/background-message-controller.ts
+++ b/ext/src/modules/background-message-controller.ts
@@ -3,7 +3,7 @@ import { EvmWallet } from '@shared/class/evm-wallet';
 import { BreezWallet } from '@shared/class/wallets/breez-wallet';
 import { WatchOnlyWallet } from '@shared/class/wallets/watch-only-wallet';
 import { getDeviceID } from '@shared/modules/device-id';
-import { lazyInitWallet, sanitizeAndValidateMnemonic, saveBitcoinXpubs, saveSubMnemonics, saveWalletState } from '@shared/modules/wallet-utils';
+import { clearWalletCache, lazyInitWallet, sanitizeAndValidateMnemonic, saveBitcoinXpubs, saveSubMnemonics, saveWalletState } from '@shared/modules/wallet-utils';
 import { IBackgroundCaller, MessageType, MessageTypeMap, OpenPopupRequest, ProcessRPCRequest } from '@shared/types/IBackgroundCaller';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_EVM_XPUB, STORAGE_KEY_MNEMONIC, STORAGE_KEY_SUB_MNEMONIC } from '@shared/types/IStorage';
 import { NETWORK_ARK_MUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_SPARK } from '@shared/types/networks';
@@ -19,7 +19,7 @@ type TBackgroundMessage = { [K in keyof MessageTypeMap]: { type: K; params: Mess
 // Function type for sending a response from background
 type TSendResponse = (response: MessageTypeMap[keyof MessageTypeMap]['response'] | { error: true; message: string }) => void;
 // Allowed method names for background executor
-type TMethods = 'getAddress' | 'saveMnemonic' | 'createMnemonic' | 'getBtcBalance' | 'encryptMnemonic' | 'signPersonalMessage' | 'signTypedData' | 'getBtcSendData' | 'getSubMnemonic';
+type TMethods = 'getAddress' | 'saveMnemonic' | 'createMnemonic' | 'getBtcBalance' | 'encryptMnemonic' | 'signPersonalMessage' | 'signTypedData' | 'getBtcSendData' | 'getSubMnemonic' | 'clear';
 
 async function handleOpenPopup([method, params, id, from]: OpenPopupRequest, sender: chrome.runtime.MessageSender, sendResponse: (response?: any) => void) {
   if (!sender.tab?.id) {
@@ -217,6 +217,10 @@ export const BackgroundExtensionExecutor: Pick<IBackgroundCaller, TMethods> = {
     }
     return mnemonic;
   },
+
+  async clear() {
+    clearWalletCache();
+  },
 };
 
 const callBackgroundMethod = async (method: Function, params: any, sendResponse: Function) => {
@@ -240,6 +244,7 @@ const MessageHandlerMap = {
   [MessageType.SIGN_TYPED_DATA]: BackgroundExtensionExecutor.signTypedData,
   [MessageType.GET_BTC_SEND_DATA]: BackgroundExtensionExecutor.getBtcSendData,
   [MessageType.GET_SUB_MNEMONIC]: BackgroundExtensionExecutor.getSubMnemonic,
+  [MessageType.CLEAR]: BackgroundExtensionExecutor.clear,
 };
 
 export function handleMessage(msg: TBackgroundMessage, sender: chrome.runtime.MessageSender, sendResponse: TSendResponse) {

--- a/ext/src/pages/Popup/SettingsPage.tsx
+++ b/ext/src/pages/Popup/SettingsPage.tsx
@@ -1,16 +1,18 @@
-import * as BlueElectrum from '@shared/blue_modules/BlueElectrum';
-import { HDSegwitBech32Wallet } from '@shared/class/wallets/hd-segwit-bech32-wallet';
-import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
-import { EStep, InitializationContext } from '@shared/hooks/InitializationContext';
-import { useSettings } from '@shared/hooks/useSettings';
-import { SETTINGS_CONFIG } from '@shared/hooks/SettingsContext';
 import React, { useContext } from 'react';
 import { useNavigate } from 'react-router';
+
+import { BackgroundCaller } from '../../modules/background-caller';
+import * as BlueElectrum from '@shared/blue_modules/BlueElectrum';
+import { HDSegwitBech32Wallet } from '@shared/class/wallets/hd-segwit-bech32-wallet';
+import { SparkWallet } from '@shared/class/wallets/spark-wallet';
+import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
+import { EStep, InitializationContext } from '@shared/hooks/InitializationContext';
+import { SETTINGS_CONFIG } from '@shared/hooks/SettingsContext';
+import { useSettings } from '@shared/hooks/useSettings';
 import { Csprng } from '../../class/rng';
+import { ThemedText } from '../../components/ThemedText';
 import { decrypt, encrypt } from '../../modules/encryption';
 import { Button, Select } from './DesignSystem';
-import { ThemedText } from '../../components/ThemedText';
-import { SparkWallet } from '@shared/class/wallets/spark-wallet';
 
 const pck = require('../../../package.json');
 
@@ -156,6 +158,7 @@ const SettingsPage: React.FC = () => {
 
       <Button
         onClick={async () => {
+          await BackgroundCaller.clear();
           chrome.storage.local.clear();
           localStorage.clear();
           setAccountNumber(-1); // to notify change

--- a/mobile/app/Settings.tsx
+++ b/mobile/app/Settings.tsx
@@ -18,6 +18,7 @@ import { SETTINGS_CONFIG } from '@shared/hooks/SettingsContext';
 import { useSettings } from '@shared/hooks/useSettings';
 import { capitalizeFirstLetter } from '@shared/modules/string-utils';
 import { STORAGE_KEY_BTC_XPUB, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
+import { BackgroundExecutor } from '@/src/modules/background-executor';
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -48,6 +49,7 @@ export default function SettingsScreen() {
         onPress: async () => {
           setIsClearing(true);
           try {
+            await BackgroundExecutor.clear();
             await AsyncStorage.clear();
             await SecureStorage.setItem(STORAGE_KEY_MNEMONIC, '');
             Alert.alert('Storage Cleared', 'All app data has been cleared successfully. The app will now restart.', [

--- a/mobile/src/modules/background-executor.ts
+++ b/mobile/src/modules/background-executor.ts
@@ -2,11 +2,19 @@ import assert from 'assert';
 
 import * as BlueElectrum from '@shared/blue_modules/BlueElectrum';
 import { EvmWallet } from '@shared/class/evm-wallet';
-import { BreezWallet, getBreezNetwork } from '@shared/class/wallets/breez-wallet';
+import { BreezWallet } from '@shared/class/wallets/breez-wallet';
 import { SparkWallet } from '@shared/class/wallets/spark-wallet';
 import { WatchOnlyWallet } from '@shared/class/wallets/watch-only-wallet';
 import { getDeviceID } from '@shared/modules/device-id';
-import { lazyInitWallet as lazyInitWalletOrig, sanitizeAndValidateMnemonic, saveBitcoinXpubs, saveSubMnemonics, saveWalletState, TSupportedLazyInitWalletNetworks } from '@shared/modules/wallet-utils';
+import {
+  lazyInitWallet as lazyInitWalletOrig,
+  sanitizeAndValidateMnemonic,
+  saveBitcoinXpubs,
+  saveSubMnemonics,
+  saveWalletState,
+  TSupportedLazyInitWalletNetworks,
+  clearWalletCache,
+} from '@shared/modules/wallet-utils';
 import { IBackgroundCaller, OpenPopupRequest } from '@shared/types/IBackgroundCaller';
 import { ENCRYPTED_PREFIX, STORAGE_KEY_ACCEPTED_TOS, STORAGE_KEY_EVM_XPUB, STORAGE_KEY_MNEMONIC, STORAGE_KEY_SUB_MNEMONIC, STORAGE_KEY_WHITELIST } from '@shared/types/IStorage';
 import { NETWORK_ARK_MUTINYNET, NETWORK_BITCOIN, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_SPARK } from '@shared/types/networks';
@@ -260,5 +268,9 @@ export const BackgroundExecutor: IBackgroundCaller = {
       return await wallet.getCommonTransactions(afterTxid, limit);
     }
     return [];
+  },
+
+  async clear() {
+    clearWalletCache();
   },
 };

--- a/shared/modules/wallet-utils.ts
+++ b/shared/modules/wallet-utils.ts
@@ -178,3 +178,9 @@ export const sanitizeAndValidateMnemonic = (mnemonic: string): string => {
 
   return sanitizedMnemonic;
 };
+
+export const clearWalletCache = () => {
+  (Object.keys(cachedWallets) as Array<TSupportedLazyInitWalletNetworks>).forEach((network) => {
+    cachedWallets[network] = {};
+  });
+};

--- a/shared/tests/integration-vi/integration.test.ts
+++ b/shared/tests/integration-vi/integration.test.ts
@@ -57,6 +57,9 @@ const backgroundCallerMock2: IBackgroundCaller = {
   getCommonTransactions() {
     throw new Error('Function not implemented.');
   },
+  clear() {
+    throw new Error('Function not implemented.');
+  },
 };
 
 test('can fetch balance', async (context) => {

--- a/shared/tests/unit-vi/rpc-controller.test.ts
+++ b/shared/tests/unit-vi/rpc-controller.test.ts
@@ -88,6 +88,9 @@ const backgroundCallerMock2: IBackgroundCaller = {
   getCommonTransactions() {
     throw new Error('Function not implemented.');
   },
+  clear() {
+    throw new Error('Function not implemented.');
+  },
 };
 
 beforeEach(() => {

--- a/shared/types/IBackgroundCaller.ts
+++ b/shared/types/IBackgroundCaller.ts
@@ -17,6 +17,7 @@ export enum MessageType {
   GET_BTC_SEND_DATA,
   GET_SUB_MNEMONIC,
   GET_COMMON_TRANSACTIONS,
+  CLEAR,
 }
 
 // Message types for background script communication
@@ -68,6 +69,10 @@ export type MessageTypeMap = {
   [MessageType.GET_COMMON_TRANSACTIONS]: {
     params: GetCommonTransactionsRequest;
     response: GetCommonTransactionsResponse;
+  };
+  [MessageType.CLEAR]: {
+    params: [];
+    response: void;
   };
 };
 
@@ -132,4 +137,5 @@ export interface IBackgroundCaller {
   getBtcSendData(...params: GetBtcSendDataRequest): Promise<GetBtcSendDataResponse>;
   getSubMnemonic(...params: GetSubMnemonicRequest): Promise<GetSubMnemonicResponse>;
   getCommonTransactions(...params: GetCommonTransactionsRequest): Promise<GetCommonTransactionsResponse>;
+  clear(): Promise<void>;
 }


### PR DESCRIPTION
Introduce new background executor call `clear` than cleans `cachedWallets`
Also fully reload RN after reset using `Updates.reloadAsync()` from  `expo-updates`. 