### PR TITLE
refactor: spark tokens cache

### DIFF
--- a/ext/src/modules/background-caller.ts
+++ b/ext/src/modules/background-caller.ts
@@ -5,7 +5,7 @@ import { LayerzStorage } from '../class/layerz-storage';
 import { SecureStorage } from '../class/secure-storage';
 import { NETWORK_SPARK } from '@shared/types/networks';
 import { SparkWallet } from '@shared/class/wallets/spark-wallet';
-import { lazyInitWallet as lazyInitWalletOrig, TSupportedLazyInitWalletNetworks } from '@shared/modules/wallet-utils';
+import { lazyInitWallet as lazyInitWalletOrig, TSupportedLazyInitWalletNetworks, lazyInitWalletReady as lazyInitWalletReadyOrig } from '@shared/modules/wallet-utils';
 import assert from 'assert';
 
 const STORAGE_KEY_WHITELIST = 'STORAGE_KEY_WHITELIST';
@@ -24,6 +24,10 @@ export const BackgroundCaller: IBackgroundCaller = {
    */
   async lazyInitWallet(network: TSupportedLazyInitWalletNetworks, accountNumber: number) {
     return lazyInitWalletOrig(network, accountNumber, LayerzStorage, SecureStorage);
+  },
+
+  lazyInitWalletReady(network: TSupportedLazyInitWalletNetworks, accountNumber: number) {
+    return lazyInitWalletReadyOrig(network, accountNumber);
   },
 
   async getAddress(...params) {

--- a/ext/src/pages/Popup/components/TokensView.tsx
+++ b/ext/src/pages/Popup/components/TokensView.tsx
@@ -7,23 +7,24 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useTokenBalance } from '@shared/hooks/useTokenBalance';
 import { useTokenDiscovery } from '@shared/hooks/useTokenDiscovery';
 import { NETWORK_SPARK } from '@shared/types/networks';
-import { TokenInfo } from '@shared/types/token-info';
+import { CachedTokenInfo } from '@shared/types/token-info';
 import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-utils';
 
 import { BackgroundCaller } from '../../../modules/background-caller';
 import { SendTokenEvmProps } from '../SendTokenEvm';
 import { SendTokenSparkProps } from '../SendTokenSpark';
+import { LayerzStorage } from '../../../class/layerz-storage';
 
-const TokenRow: React.FC<{ token: TokenInfo }> = ({ token }) => {
+const TokenRow: React.FC<{ token: CachedTokenInfo }> = ({ token }) => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
   const navigate = useNavigate();
 
   const { balance } = useTokenBalance(network, accountNumber, token.id, BackgroundCaller);
 
-  if (!balance) return null;
+  if (!balance && !token.balance) return null;
 
-  const formattedBalance = formatBalance(balance, token.decimals, 2);
+  const formattedBalance = formatBalance(balance ?? token.balance ?? '0', token.decimals, 2);
 
   const navigateToSendToken = () => {
     if (network === NETWORK_SPARK) {
@@ -101,7 +102,7 @@ const TokenRow: React.FC<{ token: TokenInfo }> = ({ token }) => {
 const TokensView: React.FC = () => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
-  const { tokenList, error } = useTokenDiscovery(network, accountNumber, BackgroundCaller);
+  const { tokenList, error } = useTokenDiscovery(network, accountNumber, BackgroundCaller, LayerzStorage);
 
   if (error) {
     return (

--- a/mobile/app/SendArk.tsx
+++ b/mobile/app/SendArk.tsx
@@ -148,7 +148,7 @@ const SendArk = () => {
                   }
                 }}
               >
-                <Ionicons name="qr-code-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
+                <Ionicons name="scan-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
               </TouchableOpacity>
             </View>
           </View>

--- a/mobile/app/SendBtc.tsx
+++ b/mobile/app/SendBtc.tsx
@@ -191,19 +191,6 @@ const SendBtc: React.FC = () => {
     setCustomFeeRate(Number(text));
   };
 
-  const handleScanQr = async () => {
-    const scanned = await scanQr();
-    if (scanned) {
-      try {
-        const decoded = bip21.decode(scanned);
-        if (decoded?.address) router.setParams({ toAddress: decoded.address });
-        if (decoded?.options?.amount) router.setParams({ amount: String(decoded.options.amount) });
-      } catch {
-        router.setParams({ toAddress: scanned });
-      }
-    }
-  };
-
   if (isSuccess) {
     return (
       <GradientScreen variant={network}>

--- a/mobile/app/SendEvm.tsx
+++ b/mobile/app/SendEvm.tsx
@@ -262,7 +262,7 @@ export default function SendScreen() {
                 autoCorrect={false}
               />
               <TouchableOpacity style={styles.qrButton} onPress={handleScanQr}>
-                <Ionicons name="qr-code-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
+                <Ionicons name="scan-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
               </TouchableOpacity>
             </View>
           </View>

--- a/mobile/app/SendTokenEvm.tsx
+++ b/mobile/app/SendTokenEvm.tsx
@@ -190,7 +190,7 @@ const SendTokenEvm: React.FC = () => {
                   placeholderTextColor="rgba(255, 255, 255, 0.6)"
                 />
                 <TouchableOpacity style={styles.scanButton} onPress={handleScanQr}>
-                  <Ionicons name="qr-code-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
+                  <Ionicons name="scan-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
                 </TouchableOpacity>
               </View>
             </View>

--- a/mobile/app/SendTokenSpark.tsx
+++ b/mobile/app/SendTokenSpark.tsx
@@ -211,7 +211,7 @@ export default function SendTokenSparkScreen() {
                       editable={step === SendTokenSparkStep.Init}
                     />
                     <TouchableOpacity style={styles.scanButton} onPress={handleScanQR} activeOpacity={0.7}>
-                      <Ionicons name="qr-code-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
+                      <Ionicons name="scan-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
                     </TouchableOpacity>
                   </View>
                 </View>

--- a/mobile/components/TokensView.tsx
+++ b/mobile/components/TokensView.tsx
@@ -10,20 +10,21 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useTokenBalance } from '@shared/hooks/useTokenBalance';
 import { useTokenDiscovery } from '@shared/hooks/useTokenDiscovery';
 import { NETWORK_SPARK } from '@shared/types/networks';
-import { TokenInfo } from '@shared/types/token-info';
+import { CachedTokenInfo } from '@shared/types/token-info';
 import { getTokenIconColor } from '@shared/models/token-list';
 import { formatBalance } from '@shared/modules/string-utils';
+import { LayerzStorage } from '@/src/class/layerz-storage';
 
-const TokenRow: React.FC<{ token: TokenInfo }> = ({ token }) => {
+const TokenRow: React.FC<{ token: CachedTokenInfo }> = ({ token }) => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
   const router = useRouter();
 
   const { balance } = useTokenBalance(network, accountNumber, token.id, BackgroundExecutor);
 
-  if (!balance) return null;
+  if (!balance && !token.balance) return null;
 
-  const formattedBalance = formatBalance(balance, token.decimals, 2);
+  const formattedBalance = formatBalance(balance ?? token.balance ?? '0', token.decimals, 2);
 
   // displaying token only if its balance is above the threshold. Threshold is arbitrary atm, probably
   // should be configurable per token
@@ -75,7 +76,7 @@ const TokenRow: React.FC<{ token: TokenInfo }> = ({ token }) => {
 const TokensView: React.FC = () => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
-  const { tokenList, error } = useTokenDiscovery(network, accountNumber, BackgroundExecutor);
+  const { tokenList, error } = useTokenDiscovery(network, accountNumber, BackgroundExecutor, LayerzStorage);
 
   if (error) {
     return (

--- a/mobile/src/modules/background-executor.ts
+++ b/mobile/src/modules/background-executor.ts
@@ -8,6 +8,7 @@ import { WatchOnlyWallet } from '@shared/class/wallets/watch-only-wallet';
 import { getDeviceID } from '@shared/modules/device-id';
 import {
   lazyInitWallet as lazyInitWalletOrig,
+  lazyInitWalletReady as lazyInitWalletReadyOrig,
   sanitizeAndValidateMnemonic,
   saveBitcoinXpubs,
   saveSubMnemonics,
@@ -32,6 +33,10 @@ import { ArkWallet } from '@shared/class/wallets/ark-wallet';
 export const BackgroundExecutor: IBackgroundCaller = {
   async lazyInitWallet(network: TSupportedLazyInitWalletNetworks, accountNumber: number) {
     return lazyInitWalletOrig(network, accountNumber, LayerzStorage, SecureStorage);
+  },
+
+  lazyInitWalletReady(network: TSupportedLazyInitWalletNetworks, accountNumber: number) {
+    return lazyInitWalletReadyOrig(network, accountNumber);
   },
 
   async getAddress(network, accountNumber) {

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -92,6 +92,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
   async getOffchainBalance() {
     if (!this._sdkWallet) throw new Error('Spark wallet not initialized');
     const balance = await this._sdkWallet.getBalance();
+    this._lastBalanceFetch = Date.now();
     this.tokenBalances = balance.tokenBalances;
     return Number(balance.balance);
   }

--- a/shared/hooks/useTokenDiscovery.ts
+++ b/shared/hooks/useTokenDiscovery.ts
@@ -1,16 +1,37 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Networks, NETWORK_SPARK } from '../types/networks';
-import { TokenInfo } from '../types/token-info';
+import { CachedTokenInfo } from '../types/token-info';
 import { getTokenList } from '../models/token-list';
 import { IBackgroundCaller } from '../types/IBackgroundCaller';
 import { SparkWallet } from '../class/wallets/spark-wallet';
 import assert from 'assert';
+import { IStorage } from '../types/IStorage';
 
-export function useTokenDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, refreshInterval = 1_000) {
-  const [tokenList, setTokenList] = useState<TokenInfo[]>([]);
+const STORAGE_KEY_CACHED_TOKEN_LIST = 'STORAGE_KEY_CACHED_TOKEN_LIST';
+
+export function useTokenDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, storage: IStorage, refreshInterval = 2_000) {
+  const [tokenList, setTokenList] = useState<CachedTokenInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const intervalRef = useRef<NodeJS.Timeout | number | null>(null);
+
+  /**
+   * returns true if cached tokens are present, and successfully restored to state, false otherwise
+   */
+  const restoreCachedTokens = useCallback(
+    async (cacheKey: string) => {
+      try {
+        const cachedTokensString = await storage.getItem(cacheKey);
+        const cachedTokens = JSON.parse(cachedTokensString);
+        if (Array.isArray(cachedTokens) && cachedTokens.length > 0) {
+          setTokenList(cachedTokens);
+          return true;
+        }
+      } catch (_) {}
+      return false;
+    },
+    [storage]
+  );
 
   const fetchTokens = useCallback(async () => {
     try {
@@ -18,13 +39,25 @@ export function useTokenDiscovery(network: Networks, accountNumber: number, back
       setError(null);
 
       if (network === NETWORK_SPARK) {
+        const cacheKey = STORAGE_KEY_CACHED_TOKEN_LIST + network + accountNumber;
+
+        if (!backgroundCaller.lazyInitWalletReady(network, accountNumber)) {
+          // wallet not ready, definately can use cached tokens (if any)
+          if (await restoreCachedTokens(cacheKey)) return;
+        }
+
         // Lazy initialize Spark wallet
         const wallet = await backgroundCaller.lazyInitWallet(network, accountNumber);
         assert(wallet instanceof SparkWallet, 'Not a Spark wallet');
 
         // we do NOT fetch from network, we rely on cached value inside wallet internals
 
-        const tokenInfos: TokenInfo[] = [];
+        if (!wallet._lastBalanceFetch) {
+          // balance never fetched yet, so we can use cached tokens (if any)
+          if (await restoreCachedTokens(cacheKey)) return;
+        }
+
+        const tokenInfos: CachedTokenInfo[] = [];
 
         for (const [, token] of wallet.getTokenBalances()) {
           tokenInfos.push({
@@ -33,20 +66,28 @@ export function useTokenDiscovery(network: Networks, accountNumber: number, back
             name: token.tokenMetadata.tokenName,
             decimals: token.tokenMetadata.decimals,
             symbol: token.tokenMetadata.tokenTicker,
+            balance: String(token.balance),
           });
         }
+
+        if (tokenInfos.length > 0) await storage.setItem(cacheKey, JSON.stringify(tokenInfos)); // saving to cache
 
         setTokenList(tokenInfos);
       } else {
         // For all other networks, return the standard token list
-        setTokenList(getTokenList(network));
+        // Adapt TokenInfo[] to CachedTokenInfo[] by adding a default balance
+        const tokens = getTokenList(network).map((token) => ({
+          ...token,
+          balance: undefined,
+        }));
+        setTokenList(tokens);
       }
     } catch (err) {
       setError(err instanceof Error ? err : new Error('Unknown error'));
     } finally {
       setIsLoading(false);
     }
-  }, [network, accountNumber, backgroundCaller]);
+  }, [network, accountNumber, backgroundCaller, restoreCachedTokens, storage]);
 
   useEffect(() => {
     // Initial fetch

--- a/shared/modules/wallet-utils.ts
+++ b/shared/modules/wallet-utils.ts
@@ -163,6 +163,10 @@ export async function lazyInitWallet(network: TSupportedLazyInitWalletNetworks, 
   return wallet;
 }
 
+export function lazyInitWalletReady(network: TSupportedLazyInitWalletNetworks, accountNumber: number): boolean {
+  return !!cachedWallets[network]?.[accountNumber];
+}
+
 export const sanitizeAndValidateMnemonic = (mnemonic: string): string => {
   // Remove extra spaces and newlines
   const sanitizedMnemonic = mnemonic.replace(/\s+/g, ' ').trim().toLocaleLowerCase();

--- a/shared/tests/integration-vi/integration.test.ts
+++ b/shared/tests/integration-vi/integration.test.ts
@@ -12,6 +12,7 @@ import { exchangeRateFetcher } from '../../hooks/useExchangeRate';
 
 const backgroundCallerMock2: IBackgroundCaller = {
   lazyInitWallet: () => Promise.reject(),
+  lazyInitWalletReady: () => false,
   log: () => Promise.resolve(),
   getWhitelist: async () => Promise.resolve([]),
   hasAcceptedTermsOfService: async () => Promise.resolve(false),

--- a/shared/tests/unit-vi/rpc-controller.test.ts
+++ b/shared/tests/unit-vi/rpc-controller.test.ts
@@ -43,6 +43,7 @@ const storageMock: IStorage = {
 
 const backgroundCallerMock2: IBackgroundCaller = {
   lazyInitWallet: () => Promise.reject(),
+  lazyInitWalletReady: () => false,
   log: () => Promise.resolve(),
   getWhitelist: async () => Promise.resolve([]),
   hasAcceptedTermsOfService: async () => Promise.resolve(false),

--- a/shared/types/IBackgroundCaller.ts
+++ b/shared/types/IBackgroundCaller.ts
@@ -118,6 +118,7 @@ export interface ProcessRPCRequest {
 
 export interface IBackgroundCaller {
   lazyInitWallet(network: TSupportedLazyInitWalletNetworks, accountNumber: number): Promise<TLazyInitedWallets>;
+  lazyInitWalletReady(network: TSupportedLazyInitWalletNetworks, accountNumber: number): boolean;
   getAddress(...params: GetAddressParams): Promise<GetAddressResponse>;
   acceptTermsOfService(): Promise<void>;
   hasAcceptedTermsOfService(): Promise<boolean>;

--- a/shared/types/token-info.ts
+++ b/shared/types/token-info.ts
@@ -11,6 +11,11 @@ export interface TokenInfo {
   };
 }
 
+/* Same as TokenInfo, but with a balance */
+export interface CachedTokenInfo extends TokenInfo {
+  readonly balance: string | undefined;
+}
+
 export interface EVMTokenInfo extends Omit<TokenInfo, 'id'> {
   readonly address: string;
 }


### PR DESCRIPTION
added cache so spark tokens show almost instantly, without having to wait for spark wallet to initialize (few seconds), and then fetch tokens from network (few more seconds).

TokenRow can now still render token without waiting for useTokenBalance hook, cached value is used if present.

caching hapens inside useTokenDiscovery hook, which might eventually evolve into powerfull mechanism to discover and store tokens for all the networks (as a reminder, EVM tokens are pre-defined in a list, we dont discover it as its problematic in EVM).

side note, hopefully, one day we can merge LiquidTokensView and TokensView

PS. fixed few icons for scanning qrs