### PR TITLE
Fix minimum Lightning fee for small payments

### DIFF
--- a/mobile/app/SendLightning.tsx
+++ b/mobile/app/SendLightning.tsx
@@ -79,7 +79,7 @@ const SendLightning: React.FC = () => {
       }
 
       const feeBN = new BigNumber(decoded.satoshis).dividedBy(100).multipliedBy(maxFeePercent).toNumber();
-      setFeeSats(Math.max(Math.round(feeBN), 1));
+      setFeeSats(Math.max(Math.round(feeBN), 2));
       setError('');
     } catch (error: any) {
       setError(error.message);

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -56,7 +56,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
     const decoded = bolt11.decode(invoice);
     if (!decoded.satoshis) throw new Error('Cant pay zero-amount invoices');
 
-    const maxFeeSats = Math.ceil((decoded.satoshis / 100) * masFeePercentage);
+    const maxFeeSats = Math.max(2, Math.ceil((decoded.satoshis / 100) * masFeePercentage));
 
     const payment_response = await this._sdkWallet.payLightningInvoice({
       invoice,


### PR DESCRIPTION
## Summary
- Fixes payment failures for small Lightning transactions by setting minimum fee to 2 sats
- Updates both payment logic and UI to reflect accurate minimum fee requirements

## Problem
When sending small Lightning payments (e.g., 100 sats), the fee calculation would result in `maxFeeSats: 1`, which is below the actual minimum network fee of 2 sats. This caused payments to fail with the error: "ValidationError: SparkSDKError: maxFeeSats does not cover fee estimate".

## Solution
- Set minimum `maxFeeSats` to 2 in the Spark wallet payment logic
- Update the UI fee display to show "up to 2 sats" minimum instead of "up to 1 sats"

## Test Plan
- [x] Test sending small Lightning payments (100 sats)
- [x] Verify fee display shows correct minimum (2 sats)
- [x] Confirm payments process successfully without validation errors
- [ ] Test larger payments to ensure percentage-based fees still work correctly