### PR TITLE
Add Lightning invoice support to Spark wallet interface

### DIFF
--- a/mobile/app/SendArk.tsx
+++ b/mobile/app/SendArk.tsx
@@ -1,8 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
+import * as bolt11 from 'bolt11';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useContext, useRef, useState } from 'react';
+import React, { useContext, useRef, useState, useEffect } from 'react';
 import { View, ScrollView, ActivityIndicator, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
 
 import GradientScreen from '@/components/GradientScreen';
@@ -38,31 +39,71 @@ const SendArk = () => {
   const [isPrepared, setIsPrepared] = useState<boolean>(false);
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
   const [isSending, setIsSending] = useState<boolean>(false);
+  const [lightningInvoiceDetails, setLightningInvoiceDetails] = useState<any>(null);
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
   const { askMnemonic } = useContext(AskMnemonicContext);
   const { balance } = useBalance(network, accountNumber, BackgroundExecutor);
   const arkWallet = useRef<ArkWallet | undefined>(undefined);
 
+  // Check if it's a Lightning invoice and decode it
+  useEffect(() => {
+    if (toAddress.toLowerCase().startsWith('lnbc') || toAddress.toLowerCase().startsWith('lntb')) {
+      try {
+        const decoded = bolt11.decode(toAddress);
+        setLightningInvoiceDetails(decoded);
+        // Set amount from invoice if available
+        if (decoded.satoshis && !amount) {
+          router.setParams({ amount: (decoded.satoshis / 100000000).toString() });
+        }
+      } catch (e) {
+        setLightningInvoiceDetails(null);
+      }
+    } else {
+      setLightningInvoiceDetails(null);
+    }
+  }, [toAddress]);
+
   const actualSend = async () => {
     let startTs = Date.now();
     try {
       setIsSending(true);
       await new Promise((resolve) => setTimeout(resolve, 100)); // sleep to propagate
-      const satValueBN = new BigNumber(amount);
-      const satValue = satValueBN.multipliedBy(new BigNumber(10).pow(getDecimalsByNetwork(network))).toString(10);
+      
+      // Check if it's a Lightning invoice
+      const isLightningInvoice = toAddress.toLowerCase().startsWith('lnbc') || toAddress.toLowerCase().startsWith('lntb');
+      
+      if (isLightningInvoice) {
+        // Handle Lightning payment through SparkWallet
+        if (!arkWallet.current || !(arkWallet.current instanceof SparkWallet)) {
+          throw new Error('Lightning payments require Spark wallet');
+        }
+        
+        const sparkWallet = arkWallet.current as SparkWallet;
+        const success = await sparkWallet.payLightningInvoice(toAddress, 1); // 1% max fee
+        
+        if (!success) {
+          throw new Error('Lightning payment failed');
+        }
+        
+        setIsSuccess(true);
+      } else {
+        // Regular Spark/Ark payment
+        const satValueBN = new BigNumber(amount);
+        const satValue = satValueBN.multipliedBy(new BigNumber(10).pow(getDecimalsByNetwork(network))).toString(10);
 
-      if (!arkWallet) {
-        throw new Error('Internal error: ArkWallet is not set');
+        if (!arkWallet) {
+          throw new Error('Internal error: ArkWallet is not set');
+        }
+        console.log('actual value to send:', +satValue);
+
+        startTs = Date.now();
+        const transactionId = await arkWallet.current?.pay(toAddress, +satValue);
+        assert(transactionId, 'Internal error: ArkWallet.pay() failed');
+        console.log('submitted txid:', transactionId);
+
+        setIsSuccess(true);
       }
-      console.log('actual value to send:', +satValue);
-
-      startTs = Date.now();
-      const transactionId = await arkWallet.current?.pay(toAddress, +satValue);
-      assert(transactionId, 'Internal error: ArkWallet.pay() failed');
-      console.log('submitted txid:', transactionId);
-
-      setIsSuccess(true);
     } catch (error: any) {
       setError(error.message);
     } finally {
@@ -129,12 +170,14 @@ const SendArk = () => {
           ) : null}
 
           <View style={styles.inputSection}>
-            <ThemedText style={styles.inputLabel}>Recipient</ThemedText>
+            <ThemedText style={styles.inputLabel}>
+              {lightningInvoiceDetails ? '⚡ Lightning Invoice' : 'Recipient'}
+            </ThemedText>
             <View style={styles.addressInputContainer}>
               <TextInput
                 style={styles.input}
                 testID="recipient-address-input"
-                placeholder="Enter the recipient's address"
+                placeholder="Enter the recipient's address or Lightning invoice"
                 placeholderTextColor="rgba(255, 255, 255, 0.6)"
                 onChangeText={(text) => router.setParams({ toAddress: text })}
                 value={toAddress}

--- a/mobile/app/SendArk.tsx
+++ b/mobile/app/SendArk.tsx
@@ -22,6 +22,7 @@ import { formatBalance } from '@shared/modules/string-utils';
 import { NETWORK_ARK_MUTINYNET, NETWORK_SPARK } from '@shared/types/networks';
 import { SparkWallet } from '@shared/class/wallets/spark-wallet';
 import { LIGHTNING_MAX_FEE_PERCENT } from '@shared/config';
+import { InterfaceLightningWallet } from '@shared/class/wallets/interface-lightning-wallet';
 
 export type SendArkParams = {
   toAddress?: string;
@@ -75,13 +76,13 @@ const SendArk = () => {
       const isLightningInvoice = toAddress.toLowerCase().startsWith('lnbc') || toAddress.toLowerCase().startsWith('lntb');
       
       if (isLightningInvoice) {
-        // Handle Lightning payment through SparkWallet
-        if (!arkWallet.current || !(arkWallet.current instanceof SparkWallet)) {
-          throw new Error('Lightning payments require Spark wallet');
+        // Handle Lightning payment
+        if (!arkWallet.current || !arkWallet.current.isLightningSupported) {
+          throw new Error('Lightning payments require a wallet with Lightning support');
         }
         
-        const sparkWallet = arkWallet.current as SparkWallet;
-        const success = await sparkWallet.payLightningInvoice(toAddress, LIGHTNING_MAX_FEE_PERCENT);
+        const lightningWallet = arkWallet.current as InterfaceLightningWallet;
+        const success = await lightningWallet.payLightningInvoice(toAddress, LIGHTNING_MAX_FEE_PERCENT);
         
         if (!success) {
           throw new Error('Lightning payment failed');

--- a/mobile/app/SendLightning.tsx
+++ b/mobile/app/SendLightning.tsx
@@ -22,7 +22,7 @@ import { Ionicons } from '@expo/vector-icons';
 import assert from 'assert';
 import { BreezWallet } from '@shared/class/wallets/breez-wallet';
 import { SparkWallet } from '@shared/class/wallets/spark-wallet';
-import { LIGHTNING_MAX_FEE_PERCENT } from '@shared/config';
+import { LIGHTNING_MAX_FEE_PERCENT, LIGHTNING_MIN_FEE_SATS } from '@shared/config';
 
 export type SendLightningProps = {
   network: typeof NETWORK_SPARK | typeof NETWORK_LIQUID | typeof NETWORK_LIQUID_TESTNET;
@@ -78,7 +78,7 @@ const SendLightning: React.FC = () => {
       }
 
       const feeBN = new BigNumber(decoded.satoshis).dividedBy(100).multipliedBy(LIGHTNING_MAX_FEE_PERCENT).toNumber();
-      setFeeSats(Math.max(Math.round(feeBN), 1));
+      setFeeSats(Math.max(Math.round(feeBN), LIGHTNING_MIN_FEE_SATS));
       setError('');
     } catch (error: any) {
       setError(error.message);

--- a/shared/class/wallets/ark-wallet.ts
+++ b/shared/class/wallets/ark-wallet.ts
@@ -16,6 +16,13 @@ export class ArkWallet extends AbstractHDElectrumWallet {
   private _arkServerPublicKey: string = '03fa73c6e4876ffb2dfc961d763cca9abc73d4b88efcb8f5e7ff92dc55e9aa553d';
   private _accountNumber: number = 0;
 
+  /**
+   * Check if this wallet supports Lightning payments
+   */
+  get isLightningSupported(): boolean {
+    return false; // Base ArkWallet doesn't support Lightning
+  }
+
   setAccountNumber(value: number) {
     this._accountNumber = value;
   }

--- a/shared/class/wallets/interface-lightning-wallet.ts
+++ b/shared/class/wallets/interface-lightning-wallet.ts
@@ -17,7 +17,7 @@ export interface LightningPaymentLimitsResponse {
 export interface InterfaceLightningWallet {
   allowLightning: true;
 
-  payLightningInvoice(invoice: string): Promise<boolean>;
+  payLightningInvoice(invoice: string, maxFeePercentage?: number): Promise<boolean>;
 
   createLightningInvoice(amountSats: number, memo: string): Promise<createLightningInvoiceResponse>;
 

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -20,6 +20,13 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
   protected adapter: ISparkAdapter;
   public allowLightning: true = true;
 
+  /**
+   * Check if this wallet supports Lightning payments
+   */
+  get isLightningSupported(): boolean {
+    return true; // SparkWallet supports Lightning
+  }
+
   protected _bolt11toReceiveRequestId: Record<string, string> = {};
   private tokenBalances: TokenBalanceMap = new Map();
 

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -3,6 +3,7 @@ import bolt11 from 'bolt11';
 import { SparkWallet as SDK, TokenBalanceMap } from '@buildonspark/spark-sdk';
 
 import { ArkWallet } from './ark-wallet';
+import { LIGHTNING_MIN_FEE_SATS } from '../../config';
 import { createLightningInvoiceResponse, InterfaceLightningWallet, LightningPaymentLimitsResponse } from './interface-lightning-wallet';
 import { CommonTransaction } from '../../types/common-transaction';
 import { NETWORK_SPARK } from '../../types/networks';
@@ -56,7 +57,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
     const decoded = bolt11.decode(invoice);
     if (!decoded.satoshis) throw new Error('Cant pay zero-amount invoices');
 
-    const maxFeeSats = Math.max(2, Math.ceil((decoded.satoshis / 100) * masFeePercentage));
+    const maxFeeSats = Math.max(LIGHTNING_MIN_FEE_SATS, Math.ceil((decoded.satoshis / 100) * masFeePercentage));
 
     const payment_response = await this._sdkWallet.payLightningInvoice({
       invoice,

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -56,7 +56,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
     const decoded = bolt11.decode(invoice);
     if (!decoded.satoshis) throw new Error('Cant pay zero-amount invoices');
 
-    const maxFeeSats = Math.ceil((decoded.satoshis / 100) * masFeePercentage);
+    const maxFeeSats = Math.max(2, Math.ceil((decoded.satoshis / 100) * masFeePercentage));
 
     const payment_response = await this._sdkWallet.payLightningInvoice({
       invoice,

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -4,3 +4,4 @@ export const DEFAULT_NETWORK: Networks = NETWORK_BITCOIN;
 
 // Lightning payment configuration
 export const LIGHTNING_MAX_FEE_PERCENT = 5; // Maximum fee percentage for Lightning payments
+export const LIGHTNING_MIN_FEE_SATS = 2; // Minimum fee in satoshis for Lightning payments


### PR DESCRIPTION
## Summary

This PR introduces native Lightning Network payment support directly within the Spark wallet interface, creating a unified payment experience for users. Users can now paste Lightning invoices into the same input field used for Spark addresses, and the app intelligently handles both payment types.

## Problem Statement

Previously, users had to navigate to a separate Lightning payment screen to pay Lightning invoices, even when using the Spark wallet which supports Lightning payments. This created unnecessary friction and confusion in the user experience, especially since Spark is built on Lightning technology.

Additionally, small Lightning payments (e.g., 100 sats) were failing with the error "maxFeeSats does not cover fee estimate" because the calculated fee of 1 sat was below the network's minimum requirement of 2 sats.

## Solution

### 1. Unified Payment Interface
- The Spark wallet send screen now accepts both Spark addresses and Lightning invoices
- Automatic detection of Lightning invoices based on their prefix (`lnbc` for mainnet, `lntb` for testnet)
- Visual feedback with a ⚡ symbol when a Lightning invoice is detected
- Automatic amount extraction from the invoice and population of the amount field

### 2. Intelligent Payment Routing
- When a Lightning invoice is detected, the payment is processed through `SparkWallet.payLightningInvoice()`
- Regular Spark addresses continue to use the standard `pay()` method
- Both payment types maintain the same user flow and confirmation process

### 3. Fixed Minimum Fee Issue
- Set minimum `maxFeeSats` to 2 sats to ensure even micro-payments can be processed
- Prevents "maxFeeSats does not cover fee estimate" errors for small transactions

## Technical Implementation

### Changes in `SendArk.tsx`:
- Added `bolt11` import for Lightning invoice parsing
- Implemented `useEffect` hook to detect and decode Lightning invoices
- Modified `actualSend()` to conditionally route payments based on address type
- Updated UI labels to show "⚡ Lightning Invoice" when appropriate
- Auto-populate amount field from decoded invoice data

### Changes in `spark-wallet.ts`:
- Updated fee calculation to enforce minimum of 2 sats: `Math.max(2, Math.ceil((decoded.satoshis / 100) * masFeePercentage))`

## Testing Performed

- [x] Successfully sent small Lightning payments (100 sats)
- [x] Verified automatic invoice detection and UI updates
- [x] Confirmed amount auto-population from invoice
- [x] Tested with both Lightning invoices and regular Spark addresses
- [x] Verified fee calculation works correctly for various amounts

## User Experience Improvements

1. **Simplified Workflow**: Users no longer need to determine which screen to use for different payment types
2. **Visual Clarity**: Clear indication when a Lightning invoice is detected
3. **Reduced Errors**: Automatic amount extraction prevents manual entry mistakes
4. **Consistent Interface**: Both payment types use the same familiar send flow

## Screenshots

The interface now shows "⚡ Lightning Invoice" when a Lightning invoice is pasted, and automatically fills in the payment amount from the invoice.

## Future Enhancements (Not in this PR)

- Display invoice memo/description
- Show invoice expiry time
- Add network validation (mainnet vs testnet)
- Implement more detailed fee estimation display

## Breaking Changes

None. This is a backward-compatible enhancement that extends existing functionality.

## Checklist

- [x] Code follows project conventions
- [x] Changes are tested on iOS simulator
- [x] No console errors or warnings
- [x] UI remains responsive during payment processing
- [ ] Unit tests added (recommended for production)
- [ ] Documentation updated (if applicable)