### PR TITLE
Cursor/prevent accidental keystore cleanup for existing users 7015

### DIFF
--- a/mobile/src/class/secure-storage.ts
+++ b/mobile/src/class/secure-storage.ts
@@ -12,7 +12,7 @@ const checkAndClearOnFreshInstall = async () => {
     if (Platform.OS === 'ios') {
       // Check if user has existing EVM xpub - this indicates they're not a fresh install
       const evmXpub = await AsyncStorage.getItem(STORAGE_KEY_EVM_XPUB);
-      
+
       if (!evmXpub) {
         // No EVM xpub found - this is a fresh install, clear secure storage
         console.log('Fresh install detected on iOS - clearing secure storage');


### PR DESCRIPTION
simplify and use `STORAGE_KEY_EVM_XPUB` as an indication whether its a fresh reinstall or not