### PR TITLE
fix: do not use type cast for styles in create-wallet screen

### DIFF
--- a/mobile/app/Action.tsx
+++ b/mobile/app/Action.tsx
@@ -13,7 +13,6 @@ import { ThemedText } from '@/components/ThemedText';
 import { BrowserBridge } from '@/src/class/browser-bridge';
 import { AskPasswordContext } from '@/src/hooks/AskPasswordContext';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
-import { Colors } from '@shared/constants/Colors';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { EvmRpcMethod } from '@shared/types/evm-rpc-method';

--- a/mobile/app/onboarding/create-wallet.tsx
+++ b/mobile/app/onboarding/create-wallet.tsx
@@ -1,29 +1,28 @@
-import { useRouter, useLocalSearchParams } from 'expo-router';
-import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { View, StyleSheet, ViewStyle, TextStyle, ImageStyle, Animated, ActivityIndicator, FlatList, TouchableOpacity } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Animated, FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+
 import { ThemedText } from '@/components/ThemedText';
-import { Colors, gradients } from '@shared/constants/Colors';
 import { Typography } from '@/constants/Typography';
 import { useSequentialSpringAnimation } from '@/hooks/useCustomTransitions';
+import { Colors, gradients } from '@shared/constants/Colors';
+
+type CreateWalletScreenParams = {
+  mnemonic: string;
+};
 
 const WordDisplay: React.FC<{
   targetWord: string;
   index: number;
 }> = ({ targetWord, index }) => {
-  const centerContainerStyle = {
-    flex: 1,
-    alignItems: 'center' as const,
-    justifyContent: 'center' as const,
-  };
-
   return (
     <View style={styles.wordContainer}>
       <View style={styles.wordNumber}>
         <ThemedText style={styles.wordNumberText}>{index + 1}</ThemedText>
       </View>
-      <View style={centerContainerStyle}>
+      <View style={styles.centerContainerStyle}>
         <ThemedText style={styles.wordText}>{targetWord}</ThemedText>
       </View>
     </View>
@@ -32,7 +31,7 @@ const WordDisplay: React.FC<{
 
 export default function CreateWalletScreen() {
   const router = useRouter();
-  const params = useLocalSearchParams();
+  const params = useLocalSearchParams<CreateWalletScreenParams>();
   const [recoveryPhrase, setRecoveryPhrase] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>('');
@@ -50,7 +49,7 @@ export default function CreateWalletScreen() {
   }, [isLoading, error, recoveryPhrase]);
 
   useEffect(() => {
-    const mnemonic = params.mnemonic as string;
+    const mnemonic = params.mnemonic;
     if (mnemonic) {
       setRecoveryPhrase(mnemonic);
     } else {
@@ -120,40 +119,45 @@ export default function CreateWalletScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  } as ViewStyle,
+  },
   gradient: {
     flex: 1,
-  } as ViewStyle,
+  },
   safeArea: {
     flex: 1,
     backgroundColor: 'transparent',
-  } as ViewStyle,
+  },
   contentContainer: {
     flex: 1,
     paddingHorizontal: 20,
-  } as ViewStyle,
+  },
   titleContainer: {
     alignItems: 'center',
     marginVertical: 30,
-  } as ViewStyle,
+  },
   title: {
     ...Typography.headline,
     color: 'rgba(255, 255, 255, 0.95)',
     textAlign: 'center',
     marginBottom: 16,
-  } as TextStyle,
+  },
   subtitle: {
     ...Typography.paragraph,
     color: 'rgba(255, 255, 255, 0.7)',
     textAlign: 'center',
-  } as TextStyle,
+  },
   wordsContentContainer: {
     paddingBottom: 20,
-  } as ViewStyle,
+  },
   flatListRow: {
     justifyContent: 'space-between',
     paddingHorizontal: 0,
-  } as ViewStyle,
+  },
+  centerContainerStyle: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   wordContainer: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -164,11 +168,11 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     width: '48%',
     minHeight: 50,
-  } as ViewStyle,
+  },
   image: {
     alignSelf: 'center',
     marginRight: 8,
-  } as ImageStyle,
+  },
   wordNumber: {
     width: 24,
     height: 24,
@@ -177,22 +181,22 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     marginRight: 12,
-  } as ViewStyle,
+  },
   wordNumberText: {
     ...Typography.buttonText,
     color: 'rgba(255, 255, 255, 0.9)',
     fontSize: 12,
     fontWeight: '600',
-  } as TextStyle,
+  },
   wordText: {
     ...Typography.paragraph,
     color: 'rgba(255, 255, 255, 0.9)',
     fontWeight: '500',
     flex: 1,
-  } as TextStyle,
+  },
   actionButtonsContainer: {
     marginBottom: 20,
-  } as ViewStyle,
+  },
   actionButton: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -203,15 +207,15 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     paddingHorizontal: 20,
     marginBottom: 12,
-  } as ViewStyle,
+  },
   actionButtonText: {
     ...Typography.buttonText,
     color: 'rgba(255, 255, 255, 0.9)',
     marginLeft: 12,
-  } as TextStyle,
+  },
   bottomButtonContainer: {
     marginBottom: 20,
-  } as ViewStyle,
+  },
   verifyButton: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -220,16 +224,16 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     paddingVertical: 18,
     paddingHorizontal: 20,
-  } as ViewStyle,
+  },
   errorContainer: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     paddingVertical: 40,
-  } as ViewStyle,
+  },
   errorText: {
     ...Typography.paragraph,
     color: '#FF6B6B',
     textAlign: 'center',
-  } as TextStyle,
+  },
 });

--- a/mobile/constants/Typography.ts
+++ b/mobile/constants/Typography.ts
@@ -36,4 +36,4 @@ export const Typography = {
     fontSize: 16,
     fontFamily: fontFamily.medium,
   },
-};
+} as const;

--- a/shared/constants/Typography.ts
+++ b/shared/constants/Typography.ts
@@ -4,7 +4,7 @@ const fontFamily = {
   medium: 'Inter-Medium',
   bold: 'Inter-Bold',
   black: 'Inter-Black',
-};
+} as const;
 
 export const Typography = {
   headline: {
@@ -36,4 +36,4 @@ export const Typography = {
     letterSpacing: -0.32,
     textAlign: 'center' as const,
   },
-};
+} as const;


### PR DESCRIPTION
I was able to get rid of type casting in styles for create-wallet screen