### PR TITLE
fix: rearrange dashboard tiles layout

### DIFF
--- a/mobile/components/DashboardTiles.tsx
+++ b/mobile/components/DashboardTiles.tsx
@@ -130,6 +130,7 @@ const LayerCardTile = ({ card, index, onCardPress, transitionId: _transitionId, 
                   <Text style={styles.iconPlaceholderText}>{displayCard.ticker.charAt(0)}</Text>
                 </View>
               )}
+              <Text style={styles.cardName}>{displayCard.name}</Text>
             </View>
             <View style={styles.tagsContainer}>
               {displayCard.tokenCount && displayCard.tokenCount > 0 ? (
@@ -150,10 +151,9 @@ const LayerCardTile = ({ card, index, onCardPress, transitionId: _transitionId, 
           </View>
 
           <View style={styles.bottomRow}>
-            <Text style={styles.cardName}>{displayCard.name}</Text>
             <View style={styles.cardBalanceContainer}>
               <Text style={styles.cardBalance}>
-                {displayCard.balance || '0'} {displayCard.ticker}
+                {displayCard.balance || '0'} <Text style={styles.cardTicker}>{displayCard.ticker}</Text>
               </Text>
               <Text style={styles.cardUsdValue}>{displayCard.usdValue || '0.00'}</Text>
             </View>
@@ -376,6 +376,7 @@ const styles = StyleSheet.create({
   cardHeader: {
     flexDirection: 'row',
     alignItems: 'center',
+    flex: 1,
   },
   cardIcon: {
     width: 44,
@@ -391,13 +392,13 @@ const styles = StyleSheet.create({
   },
   cardName: {
     color: 'white',
-    fontSize: 24,
+    fontSize: 20,
     fontWeight: 'bold',
+    marginLeft: 12,
     flex: 1,
-    marginRight: 12,
   },
   cardBalanceContainer: {
-    alignItems: 'flex-end',
+    alignItems: 'flex-start',
     flex: 1,
     justifyContent: 'flex-end',
   },
@@ -405,13 +406,18 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 20,
     fontWeight: 'bold',
-    textAlign: 'right',
+    textAlign: 'left',
+  },
+  cardTicker: {
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontSize: 14,
+    fontWeight: '500',
   },
   cardUsdValue: {
     color: 'rgba(255, 255, 255, 0.9)',
     fontSize: 16,
     marginTop: 4,
-    textAlign: 'right',
+    textAlign: 'left',
   },
   tagsContainer: {
     flexDirection: 'row',


### PR DESCRIPTION
Closes https://github.com/layerztec/layerzwallet/issues/271

Moves titles and balances around to make sure they fit every display size.
<img width="359" height="548" alt="Screenshot 2025-09-29 at 21 01 58" src="https://github.com/user-attachments/assets/7b53bd27-5023-4a6f-b44d-78bb84ad55a2" />
