### PR TITLE
feat: pay picknpay and ecentric invoices via lightning

### DIFF
--- a/ext/src/pages/Popup/SendLightning.tsx
+++ b/ext/src/pages/Popup/SendLightning.tsx
@@ -19,6 +19,7 @@ import { BreezWallet } from '@shared/class/wallets/breez-wallet';
 import { SparkWallet } from '@shared/class/wallets/spark-wallet';
 import { ArkWallet } from '@shared/class/wallets/ark-wallet';
 import Lnurl, { LnurlPayServicePayload } from '@shared/class/lnurl';
+import { convertMerchantQRToLightningAddress } from '@shared/modules/merchants';
 
 export interface SendLightningProps {
   network: typeof NETWORK_SPARK | typeof NETWORK_LIQUID | typeof NETWORK_LIQUID_TESTNET | typeof NETWORK_ARK;
@@ -53,24 +54,34 @@ const SendLightning: React.FC = () => {
     setLnAddressAmountToSend('');
 
     try {
-      if (Lnurl.isLightningAddress(scanned)) {
+      let invoice2use = scanned;
+      const merchantLightningAddress = convertMerchantQRToLightningAddress({ qrContent: scanned, network: 'mainnet' });
+      if (merchantLightningAddress) {
+        invoice2use = merchantLightningAddress;
+      }
+
+      if (Lnurl.isLightningAddress(invoice2use)) {
         try {
-          const ln = new Lnurl(scanned);
+          const ln = new Lnurl(invoice2use);
           const response = await ln.callLnurlPayService();
+          console.log('response=', response);
           if (response) {
             setLnurl(ln);
-            setLnurlPayServicePayload((prev) => ({ ...prev, [scanned]: response }));
+            setLnurlPayServicePayload((prev) => ({ ...prev, [scanned]: response, [invoice2use]: response }));
             if (response.min && response.min === response.max) {
               setLnAddressAmountToSend(String(response.min));
             }
           }
           // ignore LN decode errors, otherwise it will throw while user is typing
-        } catch {}
+        } catch (error: any) {
+          console.log('Lightning Address error: ' + error.message);
+          setError('Lightning Address error: ' + error.message);
+        }
         return;
       }
 
       try {
-        const bip21decoded = bip21.decode(scanned);
+        const bip21decoded = bip21.decode(invoice2use);
         // @ts-ignore lightning is a widely used bip21 extension
         if (bip21decoded?.options?.lightning) {
           // @ts-ignore
@@ -80,7 +91,7 @@ const SendLightning: React.FC = () => {
         }
       } catch {}
 
-      const decoded = bolt11.decode(scanned);
+      const decoded = bolt11.decode(invoice2use);
       setAmountToSend(decoded.satoshis ? String(decoded.satoshis) : '');
 
       if (!decoded.satoshis) {

--- a/mobile/app/SendLightning.tsx
+++ b/mobile/app/SendLightning.tsx
@@ -23,6 +23,7 @@ import { BreezWallet } from '@shared/class/wallets/breez-wallet';
 import { SparkWallet } from '@shared/class/wallets/spark-wallet';
 import { ArkWallet } from '@shared/class/wallets/ark-wallet';
 import Lnurl, { LnurlPayServicePayload } from '@shared/class/lnurl';
+import { convertMerchantQRToLightningAddress } from '@shared/modules/merchants';
 
 export type SendLightningProps = {
   network: typeof NETWORK_SPARK | typeof NETWORK_LIQUID | typeof NETWORK_LIQUID_TESTNET | typeof NETWORK_ARK;
@@ -35,7 +36,6 @@ const SendLightning: React.FC = () => {
   const params = useLocalSearchParams<SendLightningProps>();
   const router = useRouter();
   const network = params.network;
-  const invoice = params.invoice ?? '';
   const { scanQr } = useContext(ScanQrContext);
   const { askMnemonic } = useContext(AskMnemonicContext);
   const [error, setError] = useState<string>('');
@@ -43,6 +43,7 @@ const SendLightning: React.FC = () => {
   const [feeSats, setFeeSats] = useState<number | null>(null);
   const [amountToSend, setAmountToSend] = useState<string>('');
   const [memo, setMemo] = useState<string>('');
+  const [invoice, setInvoice] = useState<string>(params.invoice ?? '');
   const { accountNumber } = useContext(AccountNumberContext);
   const walletRef = useRef<TLightningWallet | null>(null);
 
@@ -54,44 +55,54 @@ const SendLightning: React.FC = () => {
 
   const onInvoiceInput = async (scanned: string) => {
     const scanned2use = scanned.trim().replace('lightning:', '').replace('LIGHTNING:', ''); // sanitize
-    router.setParams({ invoice: scanned2use });
+    setInvoice(scanned2use);
   };
 
   useEffect(() => {
     (async () => {
-      if (invoice) console.log('got invoice in useEffect params!', invoice);
-      if (!invoice) return;
+      let invoice2use = invoice;
+      if (invoice2use) console.log('got invoice in useEffect params!', invoice2use);
+      if (!invoice2use) return;
 
       try {
         setError('');
-        if (Lnurl.isLightningAddress(invoice)) {
+
+        const merchantLightningAddress = convertMerchantQRToLightningAddress({ qrContent: invoice2use, network: 'mainnet' });
+        if (merchantLightningAddress) {
+          invoice2use = merchantLightningAddress;
+        }
+
+        if (Lnurl.isLightningAddress(invoice2use)) {
           try {
             // need to fetch details, like minimum and maximum sat payment
-            const ln = new Lnurl(invoice);
+            const ln = new Lnurl(invoice2use);
             const response = await ln.callLnurlPayService();
             if (response) {
               setLnurl(ln);
-              setLnurlPayServicePayload((prev) => ({ ...prev, [invoice]: response }));
+              setLnurlPayServicePayload((prev) => ({ ...prev, [invoice]: response, [invoice2use]: response }));
               if (response.min && response.min === response.max) {
                 setLnAddressAmountToSend(String(response.min));
               }
               return;
             }
-          } catch {}
+          } catch (error: any) {
+            console.log('Lightning Address fetch error:', error.message);
+            setError('Lightning Address fetch error: ' + error.message);
+          }
           return;
         }
 
         try {
-          const bip21decoded = bip21.decode(invoice);
+          const bip21decoded = bip21.decode(invoice2use);
           // @ts-ignore `lightning` is not part of bip21 spec, but a valid extension of bip21 thats widely used
           if (bip21decoded?.options?.lightning) {
             // @ts-ignore
-            router.setParams({ invoice: bip21decoded?.options?.lightning });
+            setInvoice(bip21decoded?.options?.lightning);
             return; // useEffect will re-run with the correct parsed invoice
           }
         } catch {}
 
-        const decoded = bolt11.decode(invoice);
+        const decoded = bolt11.decode(invoice2use);
         setAmountToSend(decoded.satoshis ? String(decoded.satoshis) : '');
 
         if (!decoded.satoshis) {
@@ -110,7 +121,7 @@ const SendLightning: React.FC = () => {
         setError(error.message);
       }
     })();
-  }, [invoice, router]);
+  }, [invoice, params.invoice, router]);
 
   const handleQRScan = async () => {
     const scanned = await scanQr();
@@ -165,6 +176,7 @@ const SendLightning: React.FC = () => {
 
       if (bolt11payload && bolt11payload.pr) {
         setSendState('prepared');
+        setLnurlPayServicePayload((prev) => ({ ...prev, [bolt11payload.pr]: prev[invoice] }));
         await onInvoiceInput(bolt11payload.pr);
       } else {
         throw new Error('Fetching invoice from LNURL service failed');
@@ -231,7 +243,7 @@ const SendLightning: React.FC = () => {
   };
 
   const handleCancel = () => {
-    router.setParams({ invoice: '' });
+    setInvoice('');
     setError('');
     setLnurl(undefined);
     setLnurlPayServicePayload({});
@@ -303,9 +315,7 @@ const SendLightning: React.FC = () => {
 
                 {lnurlPayServicePayload[invoice]?.min && lnurlPayServicePayload[invoice]?.max && (
                   <>
-                    {lnurlPayServicePayload[invoice]?.description ? (
-                      <ThemedText style={[styles.detailValue, { marginBottom: 10 }]}>Description: {lnurlPayServicePayload[invoice]?.description}</ThemedText>
-                    ) : null}
+                    {lnurlPayServicePayload[invoice]?.description ? <ThemedText style={[styles.detailValue, { marginBottom: 10 }]}>{lnurlPayServicePayload[invoice]?.description}</ThemedText> : null}
                     <TextInput
                       placeholderTextColor="rgba(255, 255, 255, 0.6)"
                       style={styles.invoiceInput}

--- a/shared/modules/merchants.ts
+++ b/shared/modules/merchants.ts
@@ -1,0 +1,52 @@
+/**
+ *
+ * https://github.com/GaloyMoney/galoy-client/blob/main/src/parsing/merchants.ts
+ */
+
+export type Network = 'mainnet' | 'signet' | 'regtest';
+
+type MerchantConfig = {
+  id: string;
+  identifierRegex: RegExp;
+  defaultDomain: string;
+  domains: { [K in Network]: string };
+};
+
+export const merchants: MerchantConfig[] = [
+  {
+    id: 'picknpay',
+    identifierRegex: /(?<identifier>.*za\.co\.electrum\.picknpay.*)/iu,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+  {
+    id: 'ecentric',
+    identifierRegex: /(?<identifier>.*za\.co\.ecentric.*)/iu,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+];
+
+export const convertMerchantQRToLightningAddress = ({ qrContent, network }: { qrContent: string; network: Network }): string | null => {
+  if (!qrContent) {
+    return null;
+  }
+
+  for (const merchant of merchants) {
+    const match = qrContent.match(merchant.identifierRegex);
+    if (match?.groups?.identifier) {
+      const domain = merchant.domains[network] || merchant.defaultDomain;
+      return `${encodeURIComponent(match.groups.identifier)}@${domain}`;
+    }
+  }
+
+  return null;
+};

--- a/shared/tests/unit-vi/merchants.test.ts
+++ b/shared/tests/unit-vi/merchants.test.ts
@@ -1,0 +1,118 @@
+/**
+ *
+ * https://github.com/GaloyMoney/galoy-client/blob/main/src/parsing/merchants.spec.ts
+ */
+import { describe, test, expect } from 'vitest';
+import { convertMerchantQRToLightningAddress } from '../../modules/merchants';
+export type Network = 'mainnet' | 'signet' | 'regtest';
+
+describe('convertMerchantQRToLightningAddress', () => {
+  // Test cases for valid QR contents and networks
+  test.each([
+    {
+      description: 'PicknPay EMV QR code on mainnet',
+      qrContent: '00020126260008za.co.mp0110248723666427530023za.co.electrum.picknpay0122ydgKJviKSomaVw0297RaZw5303710540571.406304CE9C',
+      network: 'mainnet' as Network,
+      expected: '00020126260008za.co.mp0110248723666427530023za.co.electrum.picknpay0122ydgKJviKSomaVw0297RaZw5303710540571.406304CE9C@cryptoqr.net',
+    },
+    {
+      description: 'PicknPay EMV QR code on signet',
+      qrContent: '00020126260008za.co.mp0110628654976427530023za.co.electrum.picknpay0122a/r4RBWjSNGflZtjFg4VJQ530371054041.2363044A53',
+      network: 'signet' as Network,
+      expected: '00020126260008za.co.mp0110628654976427530023za.co.electrum.picknpay0122a%2Fr4RBWjSNGflZtjFg4VJQ530371054041.2363044A53@staging.cryptoqr.net',
+    },
+    {
+      description: 'Ecentric EMV QR code on mainnet',
+      qrContent: '00020129530019za.co.ecentric.payment0122RD2HAK3KTI53EC/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2',
+      network: 'mainnet' as Network,
+      expected: '00020129530019za.co.ecentric.payment0122RD2HAK3KTI53EC%2Fconfirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@cryptoqr.net',
+    },
+    {
+      description: 'PicknPay QR code with uppercase content',
+      qrContent: '00020129530023ZA.CO.ELECTRUM.PICKNPAY0122RD2HAK3KTI53EC/CONFIRM520458125303710540115802ZA5916CRYPTOQRTESTSCAN6002CT63049BE2',
+      network: 'mainnet' as Network,
+      expected: '00020129530023ZA.CO.ELECTRUM.PICKNPAY0122RD2HAK3KTI53EC%2FCONFIRM520458125303710540115802ZA5916CRYPTOQRTESTSCAN6002CT63049BE2@cryptoqr.net',
+    },
+    {
+      description: 'Ecentric QR code with mixed case',
+      qrContent: '00020129530019Za.Co.EcEnTrIc.payment0122RD2HAK3KTI53EC/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2',
+      network: 'mainnet' as Network,
+      expected: '00020129530019Za.Co.EcEnTrIc.payment0122RD2HAK3KTI53EC%2Fconfirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@cryptoqr.net',
+    },
+    {
+      description: 'PicknPay QR code with Unicode characters',
+      qrContent: '00020129530023za.co.electrum.picknpay0122RD2HAK3KTI53EC/confirm★測試520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2',
+      network: 'mainnet' as Network,
+      expected: '00020129530023za.co.electrum.picknpay0122RD2HAK3KTI53EC%2Fconfirm%E2%98%85%E6%B8%AC%E8%A9%A6520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@cryptoqr.net',
+    },
+    {
+      description: 'Ecentric QR code with emoji',
+      qrContent: '00020129530019za.co.ecentric.payment0122RD2HAK3KTI53EC/confirm🎉test520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2',
+      network: 'mainnet' as Network,
+      expected: '00020129530019za.co.ecentric.payment0122RD2HAK3KTI53EC%2Fconfirm%F0%9F%8E%89test520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@cryptoqr.net',
+    },
+  ])('$description', ({ qrContent, network, expected }) => {
+    const result = convertMerchantQRToLightningAddress({ qrContent, network });
+    expect(result).toBe(expected);
+  });
+
+  // Test cases for invalid QR contents
+  test.each([
+    {
+      description: 'non-matching merchant in EMV format',
+      qrContent: '00020129530023other.merchant.code0122RD2HAK3KTI53EC/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2',
+      network: 'mainnet' as Network,
+    },
+    {
+      description: 'empty QR content',
+      qrContent: '',
+      network: 'mainnet' as Network,
+    },
+    {
+      description: 'malformed EMV QR format',
+      qrContent: '000201za.co.picknpay',
+      network: 'mainnet' as Network,
+    },
+    {
+      description: 'invalid merchant identifier',
+      qrContent: 'Nakamoto+btc',
+      network: 'mainnet' as Network,
+    },
+    {
+      description: 'invalid merchant identifier in EMV format',
+      qrContent: '00020129530023za.co.unknown.merchant0122RD2HAK3KTI53EC/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2',
+      network: 'mainnet' as Network,
+    },
+  ])('returns null for $description', ({ qrContent, network }) => {
+    const result = convertMerchantQRToLightningAddress({ qrContent, network });
+    expect(result).toBeNull();
+  });
+
+  // Edge cases and special scenarios
+  test('handles multiple merchant identifiers in the same QR content', () => {
+    const qrContent = '00020129530023za.co.electrum.picknpay.za.co.ecentric0122RD2HAK3KTI53EC/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2';
+    const result = convertMerchantQRToLightningAddress({
+      qrContent,
+      network: 'mainnet',
+    });
+    expect(result).toBe('00020129530023za.co.electrum.picknpay.za.co.ecentric0122RD2HAK3KTI53EC%2Fconfirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@cryptoqr.net');
+  });
+
+  test('handles URL-unsafe characters in EMV format', () => {
+    const qrContent = '00020129530023za.co.electrum.picknpay0122RD2HAK3KTI53EC?param=value&other=123520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2';
+    const result = convertMerchantQRToLightningAddress({
+      qrContent,
+      network: 'mainnet',
+    });
+    expect(result).toBe('00020129530023za.co.electrum.picknpay0122RD2HAK3KTI53EC%3Fparam%3Dvalue%26other%3D123520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@cryptoqr.net');
+  });
+
+  test('preserves original case in EMV format', () => {
+    const qrContent = '00020129530023ZA.co.ELECTRUM.picknpay0122RD2HAK3KTI53EC/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2';
+    const result = convertMerchantQRToLightningAddress({
+      qrContent,
+      network: 'mainnet',
+    });
+    expect(result).toBe('00020129530023ZA.co.ELECTRUM.picknpay0122RD2HAK3KTI53EC%2Fconfirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@cryptoqr.net');
+  });
+});


### PR DESCRIPTION
* pay POS terminals qr codes via lightning (from send-lighting screen)
* scanning qr on mobile/SendLightning was broken and i could not figure it out, no matter what i did with params or setParams worked, so i removed it for not and applied simpliet, stat-only approach. my understanding we might need setParams when we will be implementing deeplink handling


cc @Relborg737 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable paying Pick n Pay and Ecentric POS QR codes by auto-converting them to Lightning Addresses, integrating into SendLightning (web/mobile) with improved LNURL flow and unit tests.
> 
> - **Shared**
>   - **Merchant QR parsing**: Add `shared/modules/merchants.ts` with `convertMerchantQRToLightningAddress` to map Pick n Pay/Ecentric EMV QR to Lightning Address (env-aware domains).
>   - **Tests**: Add `shared/tests/unit-vi/merchants.test.ts` covering multiple cases, invalid inputs, and edge cases.
> - **Popup (Extension)**
>   - **LN input handling**: Pre-process scanned input via `convertMerchantQRToLightningAddress` before LNURL/BIP21/BOLT11 parsing; store LNURL payload keyed by both original and converted inputs; surface errors on LNURL fetch.
> - **Mobile**
>   - **State handling**: Switch from `router.setParams` to local `invoice` state; adjust effects/deps and cancel flow.
>   - **LN input handling**: Same merchant QR conversion and LNURL integration as extension; map LNURL response to both keys; add error messaging; minor UI tweak for description display.
>   - **LNURL flow**: When fetching BOLT11 from LNURL, persist payload for the generated `pr` and continue payment flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f00a66ccaeae867eec0cb77f4ce46225b4096974. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->