### PR TITLE
ci: unblock android submit

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -27,6 +27,7 @@
     "android": {
       "edgeToEdgeEnabled": true,
       "permissions": ["android.permission.CAMERA"],
+      "blockedPermissions": ["android.permission.READ_EXTERNAL_STORAGE", "android.permission.WRITE_EXTERNAL_STORAGE", "android.permission.READ_MEDIA_IMAGES", "android.permission.READ_MEDIA_VIDEO"],
       "package": "com.layerzwallet.mobile",
       "allowBackup": false,
       "icon": "./assets/images/android_512x512.png",


### PR DESCRIPTION
attempt to stop google erroring android submits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `android.blockedPermissions` to explicitly block external storage and media read/write permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d11c7d8a3aa54c8774706c0e2735d93733086567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->