### PR TITLE
chore: release versioning setup

### DIFF
--- a/ext/package.json
+++ b/ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layerzwallet",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Manage your Bitcoin across multiple Layer 2 solutions",
   "repository": {
     "type": "git",

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Layerz Wallet",
     "slug": "layerzwallet",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "orientation": "portrait",
     "scheme": ["bitcoin", "liquidnetwork", "layerzwallet"],
     "userInterfaceStyle": "automatic",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "layerzwallet",
   "main": "./entry.js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Manage your Bitcoin across multiple Layer 2 solutions",
   "repository": {
     "type": "git",

--- a/shared/tests/unit-vi/codebase.test.ts
+++ b/shared/tests/unit-vi/codebase.test.ts
@@ -25,6 +25,17 @@ describe('codebase', function () {
     assert.strictEqual(extPrettierConfig, sharedPrettierConfig);
   });
 
+  it('subproject versions are the same', async function () {
+    const extPckg = JSON.parse(fs.readFileSync(resolve(__dirname, '../../../ext/package.json'), 'utf8'));
+    const mobilePckg = JSON.parse(fs.readFileSync(resolve(__dirname, '../../../mobile/package.json'), 'utf8'));
+    const mobileAppjson = JSON.parse(fs.readFileSync(resolve(__dirname, '../../../mobile/app.json'), 'utf8'));
+
+    assert.ok(extPckg.version);
+
+    assert.strictEqual(extPckg.version, mobilePckg.version);
+    assert.strictEqual(extPckg.version, mobileAppjson.expo.version);
+  });
+
   it('all SETTINGS_CONFIG default values are among possible options', function () {
     Object.entries(SETTINGS_CONFIG).forEach(([key, config]) => {
       const defaultValue = config.default;


### PR DESCRIPTION
in this PR i propose single unified (aka "cut through") versioning

* same version is written in all subprojects
* enforced by a simple unit test
* bumping version for one subproject bumps version for all, even if different subprojects have different release schedules
*  because i bumped the version, the next apple/google store version supposedly will be `1.2.0`



cc @Relborg737 @lion-dev 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies subproject versioning by bumping all to 1.2.0 and adds a test enforcing cross-project version consistency.
> 
> - **Versioning**:
>   - Bump versions to `1.2.0` in `ext/package.json`, `mobile/package.json`, and `mobile/app.json` (`expo.version`).
> - **Tests**:
>   - Add unit test in `shared/tests/unit-vi/codebase.test.ts` to assert subproject versions match across `ext/package.json`, `mobile/package.json`, and `mobile/app.json` (`expo.version`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4b0088b2d524735b9d2dcd1b5669aec2e0788e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->