### PR TITLE
feat: bump ark to fix mobile swap issue

### DIFF
--- a/ext/package-lock.json
+++ b/ext/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "layerzwallet",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "layerzwallet",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.0-alpha.7",
-        "@arkade-os/sdk": "0.3.0-alpha.7",
+        "@arkade-os/boltz-swap": "0.2.0-alpha.8",
+        "@arkade-os/sdk": "0.3.0-alpha.8",
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@breeztech/breez-sdk-liquid": "0.11.5",
         "@buildonspark/spark-sdk": "0.3.9",
@@ -134,12 +134,12 @@
       }
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.0-alpha.7.tgz",
-      "integrity": "sha512-pTQWZv+s+6SqW1e0YLVg31A0kOYstgba6ZwI2DYNn/63ugRnF8SOFIyLPGWqZooFeFAePA7AZXu0gxMOjx5RuQ==",
+      "version": "0.2.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.0-alpha.8.tgz",
+      "integrity": "sha512-LQakb3KlLGbFhACnZE0X8ALNw/zGIk0vjpTEJmOPMSH3PU0wz4NFMuNhIXB+cNc7lHHzrXvKnYQQu7tnxk3j9g==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.0-alpha.7",
+        "@arkade-os/sdk": "0.3.0-alpha.8",
         "@noble/hashes": "2.0.0",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.0-alpha.7.tgz",
-      "integrity": "sha512-pyjRr1N1D+avGPu+bA5s7jrpiqvuKZFMSA8TwlYbw/F07JR5SxoMC2gRCw1RrjjKKRT7VM9ZzlMC3W3k3UnCCQ==",
+      "version": "0.3.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.0-alpha.8.tgz",
+      "integrity": "sha512-FrR71u/IEYxpfrYkR0uXNpbixjxDx1iG/ZtmSg2kAR/Hrft0ABtiWfsUzAj01nM+IYOFfox7mKgAZhyMB2YysA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -242,7 +242,7 @@
         "bip68": "1.0.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@arkade-os/sdk/node_modules/@noble/curves": {

--- a/ext/package.json
+++ b/ext/package.json
@@ -21,8 +21,8 @@
     "prepare": "cd .. && husky ext/.husky"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.0-alpha.7",
-    "@arkade-os/sdk": "0.3.0-alpha.7",
+    "@arkade-os/boltz-swap": "0.2.0-alpha.8",
+    "@arkade-os/sdk": "0.3.0-alpha.8",
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@breeztech/breez-sdk-liquid": "0.11.5",
     "@buildonspark/spark-sdk": "0.3.9",

--- a/ext/utils/expo-fetch-shim.js
+++ b/ext/utils/expo-fetch-shim.js
@@ -1,0 +1,3 @@
+// Alias expo/fetch to use with @arkade-os/sdk/adapters/expo
+const fetch = globalThis.fetch;
+export { fetch };

--- a/ext/vitest.config.mts
+++ b/ext/vitest.config.mts
@@ -25,7 +25,8 @@ export default defineConfig({
         aliases[moduleName] = resolve(nodeModulesPath, moduleName);
         return aliases;
       }, {
-        '@shared': resolve(__dirname, '../shared') // Add @shared alias
+        '@shared': resolve(__dirname, '../shared'), // Add @shared alias
+        '@arkade-os/sdk/adapters/expo': resolve(nodeModulesPath, '@arkade-os/sdk/dist/esm/adapters/expo.js'), // Explicit alias for expo adapter
       });
 
       // console.log(ret);

--- a/ext/webpack.config.js
+++ b/ext/webpack.config.js
@@ -19,6 +19,10 @@ var secretsPath = path.join(__dirname, 'secrets.' + env.NODE_ENV + '.js');
 // Add the @shared alias pointing to the parent directory's shared folder
 alias['@shared'] = path.join(__dirname, 'src', 'shared-link');
 
+// because @arkade-os/sdk/adapters/expo relies on expo/fetch we need to shim it
+// otherwise webpack will fail to build
+alias['expo/fetch'] = path.join(__dirname, 'utils', 'expo-fetch-shim.js');
+
 var fileExtensions = ['jpg', 'jpeg', 'png', 'gif', 'eot', 'otf', 'svg', 'ttf', 'woff', 'woff2'];
 
 if (fs.existsSync(secretsPath)) {

--- a/mobile/app/SwapDetails.tsx
+++ b/mobile/app/SwapDetails.tsx
@@ -89,6 +89,7 @@ export default function SwapDetails() {
   const handleClaim = () => {
     if ([NETWORK_SPARK, NETWORK_ARK_MUTINYNET, NETWORK_ARK].includes(swap.network as any) && swap.status === 'claimable') {
       const params: SwapXArkClaimParams = { swapJson: JSON.stringify(swap) };
+      router.back(); // close the swap details screen
       router.push({ pathname: '/SwapXArkClaim', params });
     }
   };

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.0-alpha.7",
-        "@arkade-os/sdk": "0.3.0-alpha.7",
+        "@arkade-os/boltz-swap": "0.2.0-alpha.8",
+        "@arkade-os/sdk": "0.3.0-alpha.8",
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@breeztech/breez-sdk-liquid": "0.11.5",
         "@breeztech/react-native-breez-sdk-liquid": "0.11.5",
@@ -138,12 +138,12 @@
       "license": "MIT"
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.0-alpha.7.tgz",
-      "integrity": "sha512-pTQWZv+s+6SqW1e0YLVg31A0kOYstgba6ZwI2DYNn/63ugRnF8SOFIyLPGWqZooFeFAePA7AZXu0gxMOjx5RuQ==",
+      "version": "0.2.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.0-alpha.8.tgz",
+      "integrity": "sha512-LQakb3KlLGbFhACnZE0X8ALNw/zGIk0vjpTEJmOPMSH3PU0wz4NFMuNhIXB+cNc7lHHzrXvKnYQQu7tnxk3j9g==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.0-alpha.7",
+        "@arkade-os/sdk": "0.3.0-alpha.8",
         "@noble/hashes": "2.0.0",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.0-alpha.7.tgz",
-      "integrity": "sha512-pyjRr1N1D+avGPu+bA5s7jrpiqvuKZFMSA8TwlYbw/F07JR5SxoMC2gRCw1RrjjKKRT7VM9ZzlMC3W3k3UnCCQ==",
+      "version": "0.3.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.0-alpha.8.tgz",
+      "integrity": "sha512-FrR71u/IEYxpfrYkR0uXNpbixjxDx1iG/ZtmSg2kAR/Hrft0ABtiWfsUzAj01nM+IYOFfox7mKgAZhyMB2YysA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -219,7 +219,7 @@
         "bip68": "1.0.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@arkade-os/sdk/node_modules/@noble/hashes": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -33,8 +33,8 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.0-alpha.7",
-    "@arkade-os/sdk": "0.3.0-alpha.7",
+    "@arkade-os/boltz-swap": "0.2.0-alpha.8",
+    "@arkade-os/sdk": "0.3.0-alpha.8",
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@breeztech/breez-sdk-liquid": "0.11.5",
     "@breeztech/react-native-breez-sdk-liquid": "0.11.5",

--- a/mobile/vitest.config.mts
+++ b/mobile/vitest.config.mts
@@ -25,7 +25,8 @@ export default defineConfig({
         aliases[moduleName] = resolve(nodeModulesPath, moduleName);
         return aliases;
       }, {
-        '@shared': resolve(__dirname, '../shared') // Add @shared alias
+        '@shared': resolve(__dirname, '../shared'), // Add @shared alias
+        '@arkade-os/sdk/adapters/expo': resolve(nodeModulesPath, '@arkade-os/sdk/dist/esm/adapters/expo.js'), // Explicit alias for expo adapter
       });
 
       // console.log(ret);

--- a/shared/class/wallets/ark-wallet.ts
+++ b/shared/class/wallets/ark-wallet.ts
@@ -1,17 +1,18 @@
-import { SingleKey, Wallet, TxType, Ramps } from '@arkade-os/sdk';
 import { ArkadeLightning, BoltzSwapProvider, decodeInvoice } from '@arkade-os/boltz-swap';
+import { Ramps, SingleKey, TxType, Wallet } from '@arkade-os/sdk';
+import { ExpoArkProvider, ExpoIndexerProvider } from '@arkade-os/sdk/adapters/expo';
 import ecc from '@bitcoinerlab/secp256k1';
+import assert from 'assert';
 import BIP32Factory from 'bip32';
 import * as bip39 from 'bip39';
-import assert from 'assert';
 
-import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
-import { CommonTransaction } from '../../types/common-transaction';
-import { NETWORK_ARK, NETWORK_ARK_MUTINYNET } from '../../types/networks';
-import { createLightningInvoiceResponse, InterfaceLightningWallet, LightningPaymentLimitsResponse } from './interface-lightning-wallet';
 import { IStorage } from '@shared/types/IStorage';
 import { CommonSwap } from '@shared/types/common-swap';
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
+import { CommonTransaction } from '../../types/common-transaction';
+import { NETWORK_ARK, NETWORK_ARK_MUTINYNET } from '../../types/networks';
+import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
+import { createLightningInvoiceResponse, InterfaceLightningWallet, LightningPaymentLimitsResponse } from './interface-lightning-wallet';
 
 const bip32 = BIP32Factory(ecc);
 
@@ -85,7 +86,8 @@ export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLigh
     this._wallet = await Wallet.create({
       storage,
       identity,
-      arkServerUrl: this._arkServerUrl,
+      arkProvider: new ExpoArkProvider(this._arkServerUrl),
+      indexerProvider: new ExpoIndexerProvider(this._arkServerUrl),
       arkServerPublicKey: this._arkServerPublicKey,
     });
   }

--- a/shared/models/swap-provider-xark.ts
+++ b/shared/models/swap-provider-xark.ts
@@ -11,8 +11,7 @@ export class SwapProviderXArk implements SwapProvider {
       { from: NETWORK_BITCOIN, to: NETWORK_SPARK, platform: SwapPlatform.EXT },
       { from: NETWORK_BITCOIN, to: NETWORK_SPARK, platform: SwapPlatform.MOBILE },
       { from: NETWORK_BITCOIN, to: NETWORK_ARK, platform: SwapPlatform.EXT },
-      // Disable Ark swaps for now until we fix the issue with the EventSource not available on Expo
-      // { from: NETWORK_BITCOIN, to: NETWORK_ARK, platform: SwapPlatform.MOBILE },
+      { from: NETWORK_BITCOIN, to: NETWORK_ARK, platform: SwapPlatform.MOBILE },
     ];
   }
 


### PR DESCRIPTION
I didn't want to create another Adapter, like the one we have for Spark. 
I think we better just use `@arkade-os/sdk/adapters/expo` for both mobile and ext 
But `@arkade-os/sdk/adapters/expo` depends on `expo/fetch` so I've created a simple shim for ext.
Tested both platforms work fine