### PR TITLE
fix: more SAR POS terminals suppport

### DIFF
--- a/shared/modules/merchants.ts
+++ b/shared/modules/merchants.ts
@@ -33,6 +33,96 @@ export const merchants: MerchantConfig[] = [
       regtest: 'staging.cryptoqr.net',
     },
   },
+  {
+    id: 'yoyo',
+    identifierRegex: /(?<identifier>.*wigroup\.co.*)/iu,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+  {
+    id: 'yoyo2',
+    identifierRegex: /(?<identifier>.*yoyogroup.co.*)/,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+  {
+    id: 'zapper',
+    identifierRegex: /(?<identifier>.*(zapper\.com|\.wigroup\.|payat\.io|paynow\.netcash\.co\.za|paynow\.sagepay\.co\.za|\.zap\.pe|transactionjunction\.co\.za).*)/iu,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+  {
+    id: 'scantopay',
+    identifierRegex: /(?<identifier>.*scantopay\.io.*)/,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+  {
+    id: 'scantopay-numeric',
+    identifierRegex: /^(?<identifier>\d{10})$/,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+  {
+    id: 'Checkers/Shoprite',
+    identifierRegex: /(?<identifier>.*za.co.electrum.*)/,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+  {
+    id: 'snapscan',
+    identifierRegex: /(?<identifier>.*snapscan.*)/,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+  {
+    id: 'Ecentric T1/T2 retailers',
+    identifierRegex: /(?<identifier>.*za.co.ecentric.*)/,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
+  {
+    id: 'moneybadger',
+    identifierRegex: /(?<identifier>.*cryptoqr.net.*)/,
+    defaultDomain: 'cryptoqr.net',
+    domains: {
+      mainnet: 'cryptoqr.net',
+      signet: 'staging.cryptoqr.net',
+      regtest: 'staging.cryptoqr.net',
+    },
+  },
 ];
 
 export const convertMerchantQRToLightningAddress = ({ qrContent, network }: { qrContent: string; network: Network }): string | null => {

--- a/shared/tests/unit-vi/merchants.test.ts
+++ b/shared/tests/unit-vi/merchants.test.ts
@@ -51,6 +51,75 @@ describe('convertMerchantQRToLightningAddress', () => {
       network: 'mainnet' as Network,
       expected: '00020129530019za.co.ecentric.payment0122RD2HAK3KTI53EC%2Fconfirm%F0%9F%8E%89test520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2@cryptoqr.net',
     },
+    /////////////////
+    {
+      description: 'PnP',
+      qrContent: '00020126260008za.co.mp0110990417643427530023za.co.electrum.picknpay0122/LBatCP+Q/qjr3eBlnqHbA53037105406211.106304F1A7',
+      network: 'mainnet' as Network,
+      expected: '00020126260008za.co.mp0110990417643427530023za.co.electrum.picknpay0122%2FLBatCP%2BQ%2Fqjr3eBlnqHbA53037105406211.106304F1A7@cryptoqr.net',
+    },
+    {
+      description: 'Yoyo',
+      qrContent: 'https://rad2.wigroup.co/bill/125468',
+      network: 'mainnet' as Network,
+      expected: 'https%3A%2F%2Frad2.wigroup.co%2Fbill%2F125468@cryptoqr.net',
+    },
+    {
+      description: 'Yoyo2',
+      qrContent: 'https://rad2.yoyogroup.co/bill/125468',
+      network: 'mainnet' as Network,
+      expected: 'https%3A%2F%2Frad2.yoyogroup.co%2Fbill%2F125468@cryptoqr.net',
+    },
+    {
+      description: 'Zapper',
+      qrContent: 'http://2.zap.pe?t=6&i=40895:49955:7[34|29.99|11,33n|REF12345|10:10[39|ZAR,38|DillonDev',
+      network: 'mainnet' as Network,
+      expected: 'http%3A%2F%2F2.zap.pe%3Ft%3D6%26i%3D40895%3A49955%3A7%5B34%7C29.99%7C11%2C33n%7CREF12345%7C10%3A10%5B39%7CZAR%2C38%7CDillonDev@cryptoqr.net',
+    },
+    {
+      description: 'scantopay',
+      qrContent: 'https%3A%2F%2Fapp.scantopay.io%2Fqr%3Fqrcode%3D8784599487',
+      network: 'mainnet' as Network,
+      expected: 'https%253A%252F%252Fapp.scantopay.io%252Fqr%253Fqrcode%253D8784599487@cryptoqr.net',
+    },
+    {
+      description: 'scantopay2',
+      qrContent: 'https://app.scantopay.io/qr?qrcode=8962148867',
+      network: 'mainnet' as Network,
+      expected: 'https%3A%2F%2Fapp.scantopay.io%2Fqr%3Fqrcode%3D8962148867@cryptoqr.net',
+    },
+    {
+      description: 'scantopay3',
+      qrContent: '0337704903',
+      network: 'mainnet' as Network,
+      expected: '0337704903@cryptoqr.net',
+    },
+    {
+      description: 'Checkers/Shoprite',
+      qrContent: '00020126260008za.co.mp0110847268562627440014za.co.electrum0122+r3YIUYPRcuRzFeKDYRAvA',
+      network: 'mainnet' as Network,
+      expected: '00020126260008za.co.mp0110847268562627440014za.co.electrum0122%2Br3YIUYPRcuRzFeKDYRAvA@cryptoqr.net',
+    },
+    {
+      description: 'Snapscan',
+      qrContent: 'https://pos-staging.snapscan.io/qr/N0utvgph',
+      network: 'mainnet' as Network,
+      expected: 'https%3A%2F%2Fpos-staging.snapscan.io%2Fqr%2FN0utvgph@cryptoqr.net',
+    },
+    {
+      description: 'Ecentric',
+      qrContent:
+        '00020101021233300014za.co.ecentric0108Test12345204123453037105403,455802ZA5920Woolworths Cavendish6010Rondebosch6270011200000000007503150060012005000010708500010000807Payment88081045111591360032C62946E8F0AF4E12B1D7B4E3D4C109F0630486F7',
+      network: 'mainnet' as Network,
+      expected:
+        '00020101021233300014za.co.ecentric0108Test12345204123453037105403%2C455802ZA5920Woolworths%20Cavendish6010Rondebosch6270011200000000007503150060012005000010708500010000807Payment88081045111591360032C62946E8F0AF4E12B1D7B4E3D4C109F0630486F7@cryptoqr.net',
+    },
+    {
+      description: 'Moneybadger',
+      qrContent: 'https://pay.cryptoqr.net/3458967',
+      network: 'mainnet' as Network,
+      expected: 'https%3A%2F%2Fpay.cryptoqr.net%2F3458967@cryptoqr.net',
+    },
   ])('$description', ({ qrContent, network, expected }) => {
     const result = convertMerchantQRToLightningAddress({ qrContent, network });
     expect(result).toBe(expected);
@@ -81,6 +150,11 @@ describe('convertMerchantQRToLightningAddress', () => {
     {
       description: 'invalid merchant identifier in EMV format',
       qrContent: '00020129530023za.co.unknown.merchant0122RD2HAK3KTI53EC/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT63049BE2',
+      network: 'mainnet' as Network,
+    },
+    {
+      description: 'regular ln address',
+      qrContent: 'r1n04h@layerz.me',
       network: 'mainnet' as Network,
     },
   ])('returns null for $description', ({ qrContent, network }) => {


### PR DESCRIPTION
https://docs.google.com/document/d/1A5As1W8PIvOD61P-6Hccl0Rqf1RAp4kZ_WkwGdM-HpU/edit?tab=t.0

https://github.com/GaloyMoney/galoy-client/blob/main/src/parsing/merchants.spec.ts



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extend merchant detection to more SAR POS providers and add corresponding unit tests.
> 
> - **Shared module (`shared/modules/merchants.ts`)**:
>   - Add merchant configs for `yoyo`, `yoyo2`, `zapper`, `scantopay`, `scantopay-numeric`, `Checkers/Shoprite`, `snapscan`, `Ecentric T1/T2 retailers`, and `moneybadger` with regex identifiers and domains.
> - **Tests (`shared/tests/unit-vi/merchants.test.ts`)**:
>   - Add success cases for new merchants and various QR formats (URLs, EMV, numeric IDs, encoded content).
>   - Add invalid case for regular lightning address to return `null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5edac44198bcca8ee94ed15dbd21cd23bdf2cec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->