### PR TITLE
feat: homescreen scanner works

### DIFF
--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -48,6 +48,7 @@ import { SwapPlatform } from '@shared/types/swap';
 import { ReceiveTokenProps } from './Receive';
 import { SendLiquidParams } from './SendLiquid';
 import { SendTokenEvmProps } from './SendTokenEvm';
+import { SendLightningProps } from './SendLightning';
 
 const Action = ({ network, text }: { network?: Networks; text: string }) => {
   const networkImage = network ? getNetworkImageAsset(network) : null;
@@ -235,7 +236,8 @@ export default function Home() {
     if (network === NETWORK_LIGHTNING_TESTNET) {
       Alert.alert('Spark does not have a testnet');
     } else {
-      router.push({ pathname: '/SendLightning', params: { network: NETWORK_SPARK } });
+      const params: SendLightningProps = { network: NETWORK_SPARK };
+      router.push({ pathname: '/SendLightning', params });
     }
   };
 
@@ -243,13 +245,15 @@ export default function Home() {
     if (network === NETWORK_LIGHTNING_TESTNET) {
       Alert.alert('Ark lightning does not have a testnet');
     } else {
-      router.push({ pathname: '/SendLightning', params: { network: NETWORK_ARK } });
+      const params: SendLightningProps = { network: NETWORK_ARK };
+      router.push({ pathname: '/SendLightning', params });
     }
   };
 
   const handleSendViaLiquid = () => {
     const n = network === NETWORK_LIGHTNING_TESTNET ? NETWORK_LIQUID_TESTNET : NETWORK_LIQUID;
-    router.push({ pathname: '/SendLightning', params: { network: n } });
+    const params: SendLightningProps = { network: n };
+    router.push({ pathname: '/SendLightning', params });
   };
 
   const handleTransactionDetails = (transaction: CommonTransaction) => {

--- a/mobile/app/SendLightning.tsx
+++ b/mobile/app/SendLightning.tsx
@@ -73,6 +73,7 @@ const SendLightning: React.FC = () => {
         if (Lnurl.isLightningAddress(invoice2use)) {
           try {
             // need to fetch details, like minimum and maximum sat payment
+            invoice2use = encodeURIComponent(invoice2use.split('@')[0]) + '@' + invoice2use.split('@')[1]; // copensating for router automatically urldecoding the ln address in param
             const ln = new Lnurl(invoice2use);
             const response = await ln.callLnurlPayService();
             if (response) {

--- a/mobile/components/StickyHeader.tsx
+++ b/mobile/components/StickyHeader.tsx
@@ -5,6 +5,7 @@ import { ThemedText } from './ThemedText';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AccountItem, AccountNumberContext, accountItems } from '@shared/hooks/AccountNumberContext';
 import { ScanQrContext } from '@/src/hooks/ScanQrContext';
+import { handleQrIntent } from '@/src/modules/scan-routing';
 import { Ionicons, Foundation } from '@expo/vector-icons';
 import PlatformBlurView from './PlatformBlurView';
 import Animated, { useAnimatedStyle, interpolate, SharedValue } from 'react-native-reanimated';
@@ -38,7 +39,16 @@ const StickyHeader: React.FC<StickyHeaderProps> = ({ scrollY, onSettingsPress })
   };
 
   const handleCameraPress = async () => {
-    await scanQr();
+    try {
+      const result = await scanQr();
+      if (!result) {
+        return;
+      }
+
+      handleQrIntent(result, router);
+    } catch (error) {
+      console.error('StickyHeader: QR scan failed', error);
+    }
   };
 
   const IconComponent = accountItem.iconCollection === 'ion' ? Ionicons : Foundation;

--- a/mobile/src/modules/scan-routing.ts
+++ b/mobile/src/modules/scan-routing.ts
@@ -1,0 +1,169 @@
+import * as bip21 from 'bip21';
+import * as bolt11 from 'bolt11';
+import * as bitcoin from 'bitcoinjs-lib';
+import type { Router } from 'expo-router';
+import { NETWORK_SPARK } from '@shared/types/networks';
+import { SendLightningProps } from '@/app/SendLightning';
+import { SendBtcParams } from '@/app/SendBtc';
+import { convertMerchantQRToLightningAddress } from '@shared/modules/merchants';
+
+type LightningIntent = {
+  type: 'lightning';
+  invoice: string;
+  raw: string;
+  hint?: 'bolt11' | 'lnurl' | 'ln-address' | 'bip21';
+};
+
+type BitcoinIntent = {
+  type: 'bitcoin';
+  address: string;
+  amount?: string;
+  raw: string;
+  hint?: 'bip21';
+};
+
+type UnknownIntent = {
+  type: 'unknown';
+  raw: string;
+  reason?: string;
+};
+
+export type QrIntent = LightningIntent | BitcoinIntent | UnknownIntent;
+
+const LIGHTNING_PREFIX_REGEX = /^lightning:/i;
+
+const LIGHTNING_ADDRESS_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const LNURL_REGEX = /^lnurl[a-z0-9]+$/i;
+
+function sanitizeInput(raw: string): string {
+  return raw.trim();
+}
+
+function extractLightningCandidate(raw: string): string {
+  return raw.replace(LIGHTNING_PREFIX_REGEX, '').trim();
+}
+
+function isBolt11Invoice(candidate: string): boolean {
+  if (!candidate || candidate.length < 5) {
+    return false;
+  }
+
+  const lower = candidate.toLowerCase();
+  if (!lower.startsWith('ln')) {
+    return false;
+  }
+
+  try {
+    bolt11.decode(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isValidBitcoinAddress(address: string): boolean {
+  try {
+    bitcoin.address.toOutputScript(address.trim());
+    return true;
+  } catch {}
+  return false;
+}
+
+function detectLightningIntent(raw: string): LightningIntent | undefined {
+  const merchantResult = convertMerchantQRToLightningAddress({ qrContent: raw, network: 'mainnet' });
+
+  const candidate = merchantResult || extractLightningCandidate(raw);
+
+  if (isBolt11Invoice(candidate)) {
+    return { type: 'lightning', invoice: candidate, raw, hint: 'bolt11' };
+  }
+
+  if (LNURL_REGEX.test(candidate) || LIGHTNING_ADDRESS_REGEX.test(candidate)) {
+    const isLnurl = LNURL_REGEX.test(candidate);
+    return { type: 'lightning', invoice: candidate, raw, hint: isLnurl ? 'lnurl' : 'ln-address' };
+  }
+
+  return undefined;
+}
+
+type Bip21Intent = BitcoinIntent | LightningIntent;
+
+function detectBitcoinIntent(raw: string): Bip21Intent | undefined {
+  const sanitized = sanitizeInput(raw);
+
+  const withScheme = sanitized.toLowerCase().startsWith('bitcoin:') ? sanitized : `bitcoin:${sanitized}`;
+
+  try {
+    const decoded = bip21.decode(withScheme);
+
+    // @ts-ignore `.lightning` not defined in bip21 but widely used
+    if (decoded?.options?.lightning && typeof decoded.options.lightning === 'string') {
+      // @ts-ignore `.lightning` not defined in bip21 but widely used
+      return { type: 'lightning', invoice: decoded.options.lightning, raw, hint: 'bip21' };
+    }
+
+    if (decoded?.address && isValidBitcoinAddress(decoded.address)) {
+      const rawAmount = decoded.options?.amount;
+      const amount = typeof rawAmount === 'string' ? rawAmount : typeof rawAmount === 'number' ? String(rawAmount) : undefined;
+      return {
+        type: 'bitcoin',
+        address: decoded.address,
+        amount,
+        raw,
+        hint: 'bip21',
+      };
+    }
+  } catch {
+    // ignore decode failures
+  }
+
+  return undefined;
+}
+
+export function parseQrIntent(rawInput: string): QrIntent {
+  const raw = sanitizeInput(rawInput);
+
+  if (!raw) {
+    return { type: 'unknown', raw, reason: 'empty' };
+  }
+
+  const lightningIntent = detectLightningIntent(raw);
+  if (lightningIntent) {
+    return lightningIntent;
+  }
+
+  const bitcoinIntent = detectBitcoinIntent(raw);
+  if (bitcoinIntent) {
+    return bitcoinIntent;
+  }
+
+  return { type: 'unknown', raw };
+}
+
+export function handleQrIntent(rawInput: string, router: Pick<Router, 'push'>): boolean {
+  const intent = parseQrIntent(rawInput);
+
+  switch (intent.type) {
+    case 'lightning': {
+      const params: SendLightningProps = { network: NETWORK_SPARK, invoice: intent.invoice };
+      router.push({ pathname: '/SendLightning', params });
+      return true;
+    }
+
+    case 'bitcoin': {
+      const params: SendBtcParams = { toAddress: intent.address };
+      if (intent.amount) {
+        params.amount = intent.amount;
+      }
+
+      router.push({ pathname: '/SendBtc', params });
+      return true;
+    }
+
+    case 'unknown':
+    default: {
+      return false;
+    }
+  }
+}

--- a/mobile/src/tests/unit-vi/scan-routing.test.ts
+++ b/mobile/src/tests/unit-vi/scan-routing.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test, vi } from 'vitest';
+import { parseQrIntent, handleQrIntent } from '../../modules/scan-routing';
+import { NETWORK_SPARK } from '@shared/types/networks';
+
+describe('scan-routing parser', () => {
+  test('parses lightning lnurl payloads', () => {
+    const raw = 'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNRDA3K7MRWW4EXCU0';
+    const intent = parseQrIntent(raw);
+
+    expect(intent.type).toBe('lightning');
+    expect(intent).toMatchObject({ invoice: 'LNURL1DP68GURN8GHJ7MRWW4EXCTNRDA3K7MRWW4EXCU0' });
+  });
+
+  test('parses lightning bolt11 payloads', () => {
+    const raw =
+      'lightning:lnbc4u1p5z7y4cpp5vzjkl2svmtyt2d8q9f5clsch5ppemt8320spdj24kve45gq9uvesdqqcqzysxqyz5vqsp5rfv2fel3smq2sxerf664w0mmtnexl6yweenf0dftpujhftcvfayq9qxpqysgqkzlnzf7nrv3qhduf9dkrcc599d04674afkgfewkxtk060h8d92v8zzlwpg3yc7utfkzezvp2geld00fe4ggrmvp6klltkzvkxfal7qcq79eqvg';
+    const intent = parseQrIntent(raw);
+
+    expect(intent.type).toBe('lightning');
+    expect(intent).toMatchObject({
+      invoice:
+        'lnbc4u1p5z7y4cpp5vzjkl2svmtyt2d8q9f5clsch5ppemt8320spdj24kve45gq9uvesdqqcqzysxqyz5vqsp5rfv2fel3smq2sxerf664w0mmtnexl6yweenf0dftpujhftcvfayq9qxpqysgqkzlnzf7nrv3qhduf9dkrcc599d04674afkgfewkxtk060h8d92v8zzlwpg3yc7utfkzezvp2geld00fe4ggrmvp6klltkzvkxfal7qcq79eqvg',
+    });
+  });
+
+  test('parses lightning bolt11 payloads w/o prefix', () => {
+    const raw =
+      'lnbc4u1p5z7y4cpp5vzjkl2svmtyt2d8q9f5clsch5ppemt8320spdj24kve45gq9uvesdqqcqzysxqyz5vqsp5rfv2fel3smq2sxerf664w0mmtnexl6yweenf0dftpujhftcvfayq9qxpqysgqkzlnzf7nrv3qhduf9dkrcc599d04674afkgfewkxtk060h8d92v8zzlwpg3yc7utfkzezvp2geld00fe4ggrmvp6klltkzvkxfal7qcq79eqvg';
+    const intent = parseQrIntent(raw);
+
+    expect(intent.type).toBe('lightning');
+    expect(intent).toMatchObject({
+      invoice:
+        'lnbc4u1p5z7y4cpp5vzjkl2svmtyt2d8q9f5clsch5ppemt8320spdj24kve45gq9uvesdqqcqzysxqyz5vqsp5rfv2fel3smq2sxerf664w0mmtnexl6yweenf0dftpujhftcvfayq9qxpqysgqkzlnzf7nrv3qhduf9dkrcc599d04674afkgfewkxtk060h8d92v8zzlwpg3yc7utfkzezvp2geld00fe4ggrmvp6klltkzvkxfal7qcq79eqvg',
+    });
+  });
+
+  test('parses bitcoin bip21 payloads', () => {
+    const intent = parseQrIntent('bitcoin:bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh?amount=0.001');
+
+    expect(intent.type).toBe('bitcoin');
+    expect(intent).toMatchObject({ address: 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh', amount: '0.001' });
+  });
+
+  test('parses bitcoin bip21 payloads w/o prefix', () => {
+    const intent = parseQrIntent('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh?amount=0.001');
+
+    expect(intent.type).toBe('bitcoin');
+    expect(intent).toMatchObject({ address: 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh', amount: '0.001' });
+  });
+
+  test('parses bitcoin payloads w/o prefix', () => {
+    const intent = parseQrIntent('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
+
+    expect(intent.type).toBe('bitcoin');
+    expect(intent).toMatchObject({ address: 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh' });
+  });
+
+  test('parses malformed payloads ', () => {
+    const intent = parseQrIntent('malformed');
+
+    expect(intent.type).toBe('unknown');
+    expect(intent).toStrictEqual({ raw: 'malformed', type: 'unknown' });
+  });
+
+  test('parses lightning address', () => {
+    const intent = parseQrIntent('r1n04h@layerz.me');
+
+    expect(intent.type).toBe('lightning');
+    expect(intent).toMatchObject({ invoice: 'r1n04h@layerz.me' });
+  });
+
+  test('prefer lightning when several schemes are present', () => {
+    const intent = parseQrIntent(
+      'bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4'
+    );
+
+    expect(intent.type).toBe('lightning');
+    expect(intent).toMatchObject({
+      invoice:
+        'lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4',
+    });
+  });
+
+  test('parses merchant QR code', () => {
+    const intent = parseQrIntent('00020126260008za.co.mp0110248723666427530023za.co.electrum.picknpay0122ydgKJviKSomaVw0297RaZw5303710540571.406304CE9C');
+
+    expect(intent.type).toBe('lightning');
+    expect(intent).toMatchObject({
+      invoice: '00020126260008za.co.mp0110248723666427530023za.co.electrum.picknpay0122ydgKJviKSomaVw0297RaZw5303710540571.406304CE9C@cryptoqr.net',
+    });
+  });
+
+  test('parses merchant QR code 2', () => {
+    const intent = parseQrIntent('https://app.scantopay.io/qr?qrcode=8962148867');
+
+    expect(intent.type).toBe('lightning');
+    expect(intent).toMatchObject({
+      invoice: 'https%3A%2F%2Fapp.scantopay.io%2Fqr%3Fqrcode%3D8962148867@cryptoqr.net',
+    });
+  });
+
+  test('parses merchant QR code 2', () => {
+    const intent = parseQrIntent('0337704903');
+
+    expect(intent.type).toBe('lightning');
+    expect(intent).toMatchObject({
+      invoice: '0337704903@cryptoqr.net',
+    });
+  });
+});
+
+describe('scan-routing handler', () => {
+  test('routes lightning payloads to SendLightning', () => {
+    const push = vi.fn();
+    const router = { push };
+    const invoice = 'lightning:lnurl1dp68gurn8ghj7mrww4exctnrda3k7mrww4excu0';
+
+    const handled = handleQrIntent(invoice, router);
+
+    expect(handled).toBe(true);
+    expect(push).toHaveBeenCalledWith({ pathname: '/SendLightning', params: { network: NETWORK_SPARK, invoice: 'lnurl1dp68gurn8ghj7mrww4exctnrda3k7mrww4excu0' } });
+  });
+
+  test('routes merchant QR code payloads to SendLightning', () => {
+    const push = vi.fn();
+    const router = { push };
+    const invoice = '00020129530023za.co.electrum.picknpay0122D57H4TMHFZ2TEZ/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT6304A440';
+
+    const handled = handleQrIntent(invoice, router);
+
+    expect(handled).toBe(true);
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/SendLightning',
+      params: { network: NETWORK_SPARK, invoice: '00020129530023za.co.electrum.picknpay0122D57H4TMHFZ2TEZ%2Fconfirm520458125303710540115802ZA5916cryptoqrtestscan6002CT6304A440@cryptoqr.net' },
+    });
+  });
+
+  test('routes bitcoin payloads to SendBtc', () => {
+    const push = vi.fn();
+    const router = { push };
+    const handled = handleQrIntent('bitcoin:bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh?amount=0.25', router);
+
+    expect(handled).toBe(true);
+    expect(push).toHaveBeenCalledWith({ pathname: '/SendBtc', params: { toAddress: 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh', amount: '0.25' } });
+  });
+
+  test('routes bitcoin payloads to SendBtc 2', () => {
+    const push = vi.fn();
+    const router = { push };
+    const handled = handleQrIntent('bitcoin:1DzJepHCRD2C9vpFjk11eXJi97juEZ3ftv?amount=0.004&message=wheres the money lebowski', router);
+
+    expect(handled).toBe(true);
+    expect(push).toHaveBeenCalledWith({ pathname: '/SendBtc', params: { toAddress: '1DzJepHCRD2C9vpFjk11eXJi97juEZ3ftv', amount: '0.004' } });
+  });
+
+  test('returns false for malformed/unknown payloads', () => {
+    const push = vi.fn();
+    const router = { push };
+    const handled = handleQrIntent('invalid-qr-code-data', router);
+
+    expect(push).not.toHaveBeenCalled();
+    expect(handled).toBe(false);
+  });
+});

--- a/shared/modules/merchants.ts
+++ b/shared/modules/merchants.ts
@@ -134,6 +134,12 @@ export const convertMerchantQRToLightningAddress = ({ qrContent, network }: { qr
     const match = qrContent.match(merchant.identifierRegex);
     if (match?.groups?.identifier) {
       const domain = merchant.domains[network] || merchant.defaultDomain;
+
+      if (qrContent.includes(`@${domain}`)) {
+        // trying to convert already converted result
+        continue;
+      }
+
       return `${encodeURIComponent(match.groups.identifier)}@${domain}`;
     }
   }

--- a/shared/tests/unit-vi/merchants.test.ts
+++ b/shared/tests/unit-vi/merchants.test.ts
@@ -120,9 +120,19 @@ describe('convertMerchantQRToLightningAddress', () => {
       network: 'mainnet' as Network,
       expected: 'https%3A%2F%2Fpay.cryptoqr.net%2F3458967@cryptoqr.net',
     },
+    {
+      description: 'from demo',
+      qrContent: '00020129530023za.co.electrum.picknpay0122D57H4TMHFZ2TEZ/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT6304A440',
+      network: 'mainnet' as Network,
+      expected: '00020129530023za.co.electrum.picknpay0122D57H4TMHFZ2TEZ%2Fconfirm520458125303710540115802ZA5916cryptoqrtestscan6002CT6304A440@cryptoqr.net',
+    },
   ])('$description', ({ qrContent, network, expected }) => {
     const result = convertMerchantQRToLightningAddress({ qrContent, network });
     expect(result).toBe(expected);
+
+    // must not return the same result for already parsed result
+    const negativeResult = convertMerchantQRToLightningAddress({ qrContent: expected, network });
+    expect(negativeResult).toBe(null);
   });
 
   // Test cases for invalid QR contents


### PR DESCRIPTION
* home screen scanner should now work, detect BIP21, ln invoices, POS terminal qr codes
* in bip21 where theres both lightnign and bitcoin it always uses  lightning - maybe needs a selector (todo later)
* when it detects lightnig it navigates to LightningSend with network spark  - maybe needs a selector (todo later)

i noticed on some send screens qr scanner doesnt work __at all__ - will be fixed separately


cc @lion-dev 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add QR intent parsing (BIP21/bolt11/lnurl/lightning address + merchant) and route from the home scanner to SendLightning/SendBtc; prevent merchant re-conversion and fix lightning address encoding.
> 
> - **Mobile**:
>   - **Scanner routing**: `StickyHeader` camera now parses scan results via `src/modules/scan-routing` and routes to `SendLightning` (Spark) or `SendBtc`.
>   - **Lightning send**: URL-encode local-part of lightning addresses before LNURL fetch in `app/SendLightning.tsx` to compensate for auto-decode.
>   - **Type-safety**: Use typed `SendLightningProps` when pushing from `app/Home.tsx`.
> - **Scan Parsing**:
>   - New `src/modules/scan-routing.ts` to parse `bolt11`, `lnurl`, lightning addresses, and `bip21` (including embedded `lightning`) plus merchant QR conversion; includes `handleQrIntent` helper.
> - **Shared Merchants**:
>   - Avoid double-conversion if QR already contains `@domain` in `shared/modules/merchants.ts`.
> - **Tests**:
>   - Add `mobile/src/tests/unit-vi/scan-routing.test.ts` covering parsing and routing cases.
>   - Extend `shared/tests/unit-vi/merchants.test.ts` with new cases and a negative re-conversion assertion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09437d7821d7f1b2b260246cf602e2b61224540c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->