### PR TITLE
fix: scan qr on send screen

### DIFF
--- a/mobile/components/ScanQrComponent.tsx
+++ b/mobile/components/ScanQrComponent.tsx
@@ -132,8 +132,8 @@ export default function ScanQrComponent() {
   function onBarcodeScanned(scanningResult: BarcodeScanningResult): void {
     if (!hasCalledDismiss.current) {
       hasCalledDismiss.current = true;
-      handleQrScanned(scanningResult.data);
       router.back();
+      setTimeout(() => handleQrScanned(scanningResult.data), 100); // important! propagate, otherwise the parent screen wont be able to set its data via `setParam()`
     }
   }
 


### PR DESCRIPTION
nasty, unobvious bug.
basically screen wont update with `setParam` if router thinks youre on some other screen

idk if theres a better way to fix it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Navigate back first, then invoke `handleQrScanned` after a 100ms delay to ensure parent screen updates via `setParam`.
> 
> - **Scan flow update**:
>   - In `mobile/components/ScanQrComponent.tsx`, update `onBarcodeScanned` to `router.back()` first, then call `handleQrScanned` via `setTimeout(..., 100)` to ensure parent can update with `setParam` after navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d43608ee88067a1e5fa5b02d4986bb35875f04d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->