### PR TITLE
chore: bump ark dep

### DIFF
--- a/ext/package-lock.json
+++ b/ext/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.0-alpha.8",
-        "@arkade-os/sdk": "0.3.0-alpha.8",
+        "@arkade-os/boltz-swap": "0.2.1-alpha.2",
+        "@arkade-os/sdk": "0.3.1-alpha.2",
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@breeztech/breez-sdk-liquid": "0.11.5",
         "@buildonspark/spark-sdk": "0.3.9",
@@ -133,12 +133,12 @@
       }
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.0-alpha.8.tgz",
-      "integrity": "sha512-LQakb3KlLGbFhACnZE0X8ALNw/zGIk0vjpTEJmOPMSH3PU0wz4NFMuNhIXB+cNc7lHHzrXvKnYQQu7tnxk3j9g==",
+      "version": "0.2.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.1-alpha.2.tgz",
+      "integrity": "sha512-lRlQM4IirvlKZrvGzMGCvgh5P8ej/EWYrAtQ4dHlwwmN9Q3rrT042zK9h3dJbYZIHvD+cO78Oo3Av8RQ1Hgz2w==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.0-alpha.8",
+        "@arkade-os/sdk": "0.3.1-alpha.2",
         "@noble/hashes": "2.0.0",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -227,14 +227,13 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.0-alpha.8.tgz",
-      "integrity": "sha512-FrR71u/IEYxpfrYkR0uXNpbixjxDx1iG/ZtmSg2kAR/Hrft0ABtiWfsUzAj01nM+IYOFfox7mKgAZhyMB2YysA==",
+      "version": "0.3.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.1-alpha.2.tgz",
+      "integrity": "sha512-JGmsXQeJKM3+OFyRrChFHGqW+dMjfFxB9BbzYsOE2+0S5lt15ACed1JOcWVUjFdOvK3mbBgJrR3VmN4amPmHew==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "2.0.0",
-        "@noble/hashes": "2.0.0",
         "@noble/secp256k1": "3.0.0",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",

--- a/ext/package.json
+++ b/ext/package.json
@@ -21,8 +21,8 @@
     "prepare": "cd .. && husky ext/.husky"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.0-alpha.8",
-    "@arkade-os/sdk": "0.3.0-alpha.8",
+    "@arkade-os/boltz-swap": "0.2.1-alpha.2",
+    "@arkade-os/sdk": "0.3.1-alpha.2",
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@breeztech/breez-sdk-liquid": "0.11.5",
     "@buildonspark/spark-sdk": "0.3.9",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.0-alpha.8",
-        "@arkade-os/sdk": "0.3.0-alpha.8",
+        "@arkade-os/boltz-swap": "0.2.1-alpha.2",
+        "@arkade-os/sdk": "0.3.1-alpha.2",
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@breeztech/breez-sdk-liquid": "0.11.5",
         "@breeztech/react-native-breez-sdk-liquid": "0.11.5",
@@ -137,12 +137,12 @@
       "license": "MIT"
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.0-alpha.8.tgz",
-      "integrity": "sha512-LQakb3KlLGbFhACnZE0X8ALNw/zGIk0vjpTEJmOPMSH3PU0wz4NFMuNhIXB+cNc7lHHzrXvKnYQQu7tnxk3j9g==",
+      "version": "0.2.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.1-alpha.2.tgz",
+      "integrity": "sha512-lRlQM4IirvlKZrvGzMGCvgh5P8ej/EWYrAtQ4dHlwwmN9Q3rrT042zK9h3dJbYZIHvD+cO78Oo3Av8RQ1Hgz2w==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.0-alpha.8",
+        "@arkade-os/sdk": "0.3.1-alpha.2",
         "@noble/hashes": "2.0.0",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -204,14 +204,13 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.0-alpha.8.tgz",
-      "integrity": "sha512-FrR71u/IEYxpfrYkR0uXNpbixjxDx1iG/ZtmSg2kAR/Hrft0ABtiWfsUzAj01nM+IYOFfox7mKgAZhyMB2YysA==",
+      "version": "0.3.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.1-alpha.2.tgz",
+      "integrity": "sha512-JGmsXQeJKM3+OFyRrChFHGqW+dMjfFxB9BbzYsOE2+0S5lt15ACed1JOcWVUjFdOvK3mbBgJrR3VmN4amPmHew==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "2.0.0",
-        "@noble/hashes": "2.0.0",
         "@noble/secp256k1": "3.0.0",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -222,9 +221,9 @@
       }
     },
     "node_modules/@arkade-os/sdk/node_modules/@noble/hashes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.0.tgz",
-      "integrity": "sha512-h8VUBlE8R42+XIDO229cgisD287im3kdY6nbNZJFjc6ZvKIXPYXe6Vc/t+kyjFdMFyt5JpapzTsEg8n63w5/lw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -33,8 +33,8 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.0-alpha.8",
-    "@arkade-os/sdk": "0.3.0-alpha.8",
+    "@arkade-os/boltz-swap": "0.2.1-alpha.2",
+    "@arkade-os/sdk": "0.3.1-alpha.2",
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@breeztech/breez-sdk-liquid": "0.11.5",
     "@breeztech/react-native-breez-sdk-liquid": "0.11.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `@arkade-os/boltz-swap` to `0.2.1-alpha.2` and `@arkade-os/sdk` to `0.3.1-alpha.2` in `ext` and `mobile` packages.
> 
> - **Dependencies**:
>   - `ext/package.json`:
>     - Upgrade `@arkade-os/boltz-swap` → `0.2.1-alpha.2`
>     - Upgrade `@arkade-os/sdk` → `0.3.1-alpha.2`
>   - `mobile/package.json`:
>     - Upgrade `@arkade-os/boltz-swap` → `0.2.1-alpha.2`
>     - Upgrade `@arkade-os/sdk` → `0.3.1-alpha.2`
>   - Lockfiles (`ext/package-lock.json`, `mobile/package-lock.json`) updated accordingly, including transitive updates (e.g., `@noble/hashes` in `@arkade-os/sdk`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 638005feb433f341f1bd2d32b5c988e7476d40ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->