### PR TITLE
fix: liquid token history

### DIFF
--- a/shared/class/wallets/breez-wallet.ts
+++ b/shared/class/wallets/breez-wallet.ts
@@ -20,12 +20,18 @@ import * as bip21 from 'bip21';
 
 import { createLightningInvoiceResponse, InterfaceLightningWallet } from './interface-lightning-wallet';
 import { CommonTokenTransfer, CommonTransaction } from '@shared/types/common-transaction';
-import { getTokenList } from '@shared/models/token-list';
+import { getTokenInfo, getTokenList } from '@shared/models/token-list';
 import { NETWORK_LIQUID, NETWORK_LIQUID_TESTNET } from '@shared/types/networks';
 
 export type BreezConnection = {
   mnemonic: string;
   network: LiquidNetwork;
+};
+
+// L-BTC asset IDs for mainnet and testnet
+export const LBTC_ASSET_IDS = {
+  mainnet: '6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d',
+  testnet: '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49',
 };
 
 export interface IBreezAdapter {
@@ -201,55 +207,60 @@ export class BreezWallet implements InterfaceLightningWallet {
 
   async getCommonTransactions(): Promise<CommonTransaction[]> {
     const payments = await this.listPayments({});
+    const txMap = new Map<string, CommonTransaction>();
 
-    // convert to common transaction
-    const commonTransactions: CommonTransaction[] = [];
     for (const p of payments) {
-      let tokenTransfers: CommonTokenTransfer[] = [];
-      // Make sure it is a token transfer
-      if (p.details.type === 'liquid' && !Object.values(LBTC_ASSET_IDS).includes(p.details.assetId)) {
-        const tokenId = p.details.assetId;
-        let amount: number | undefined;
-        let address: string | undefined;
-        if (p.details.assetInfo?.amount) {
-          amount = p.details.assetInfo.amount;
-        }
-        if (p.details.destination) {
-          const urnScheme = this.n === 'mainnet' ? 'liquidnetwork' : 'liquidtestnet';
-
-          // in some cases, the destination is not a valid BIP21 address,
-          // but a Lightning invoice or Liquid address
-          let decoded;
-          try {
-            decoded = bip21.decode(p.details.destination, urnScheme);
-          } catch (e) {}
-
-          if (decoded?.address) {
-            address = decoded.address;
-          }
-          if (amount === undefined && decoded?.options.amount) {
-            amount = Number(decoded.options.amount);
-          }
-        }
-
-        tokenTransfers = [{ address, amount, tokenId }];
+      if (!p.txId) {
+        continue;
       }
 
-      const explorerBase = this.n === 'mainnet' ? 'https://liquid.network' : 'https://liquid.network/testnet';
-      commonTransactions.push({
-        txid: p.txId!,
-        network: NETWORK_LIQUID,
-        timestamp: p.timestamp,
-        direction: p.paymentType,
-        amount: p.amountSat,
-        status: p.status === 'complete' ? 'confirmed' : 'pending',
-        fee: p.feesSat,
-        tokenTransfers,
-        explorerUrl: `${explorerBase}/tx/${p.txId}`,
-      });
+      let newTx = txMap.get(p.txId);
+      if (!newTx) {
+        const explorerBase = this.n === 'mainnet' ? 'https://liquid.network' : 'https://liquid.network/testnet';
+        newTx = {
+          txid: p.txId,
+          network: NETWORK_LIQUID,
+          timestamp: p.timestamp,
+          direction: p.paymentType,
+          amount: undefined,
+          status: p.status === 'complete' ? 'confirmed' : 'pending',
+          fee: p.feesSat,
+          explorerUrl: `${explorerBase}/tx/${p.txId}`,
+        };
+      }
+
+      // liquid transaction
+      if (p.details.type === 'liquid') {
+        if (Object.values(LBTC_ASSET_IDS).includes(p.details.assetId)) {
+          // asset is L-BTC
+          newTx.amount = p.amountSat;
+        } else {
+          // token transfer
+          if (!p.details.assetInfo) {
+            // ignore unknown token transfers
+            continue;
+          }
+          const tokenId = p.details.assetId;
+          const address = p.details.destination;
+          // we need to convert assetInfo.amount to absolute value
+          let amount = p.details.assetInfo.amount;
+          const tokenInfo = getTokenInfo(tokenId);
+          amount = Math.abs(amount * Math.pow(10, tokenInfo.decimals));
+          newTx.tokenTransfers = newTx.tokenTransfers ?? [];
+          newTx.tokenTransfers.push({ amount, tokenId, address });
+        }
+      }
+
+      // lightning transaction
+      if (p.details.type === 'lightning') {
+        newTx.amount = p.amountSat;
+      }
+
+      txMap.set(p.txId, newTx);
     }
 
-    return commonTransactions;
+    // convert map to array and sort by timestamp
+    return Array.from(txMap.values()).sort((a, b) => b.timestamp - a.timestamp);
   }
 
   allowLightning() {
@@ -268,12 +279,6 @@ export const getAssertMetadata = (liquidNetwork: LiquidNetwork): AssetMetadata[]
     ticker: token.symbol,
     precision: token.decimals,
   }));
-};
-
-// L-BTC asset IDs for mainnet and testnet
-export const LBTC_ASSET_IDS = {
-  mainnet: '6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d',
-  testnet: '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49',
 };
 
 // Map our app network to Breez LiquidNetwork type

--- a/shared/models/token-list.ts
+++ b/shared/models/token-list.ts
@@ -28,6 +28,7 @@ function liquidToCommonTokenInfo(token: LiquidTokenInfo): TokenInfo {
     name: token.name,
     decimals: token.decimals,
     symbol: token.symbol,
+    logoURI: token.logoURI,
   };
 }
 

--- a/shared/models/tokenlist-liquid.json
+++ b/shared/models/tokenlist-liquid.json
@@ -39,7 +39,8 @@
     "name": "USDT",
     "symbol": "$",
     "decimals": 8,
-    "chainId": 11
+    "chainId": 11,
+    "logoURI": "https://tether.to/images/tetherTokenWhite.svg"
   },
   {
     "assetId": "3438ecb49fc45c08e687de4749ed628c511e326460ea4336794e1cf02741329e",

--- a/shared/tests/unit-vi/breez-wallet.test.ts
+++ b/shared/tests/unit-vi/breez-wallet.test.ts
@@ -14,7 +14,7 @@ describe('Breez Wallet - getCommonTransactions', () => {
       // BTC
       {
         txId: '095cf834f56cc032708bb2465463ae348164b4d498b181f52fd98d0097c08629',
-        timestamp: 1754383510,
+        timestamp: 6,
         amountSat: 1123,
         feesSat: 0,
         status: 'complete',
@@ -45,7 +45,7 @@ describe('Breez Wallet - getCommonTransactions', () => {
         feesSat: 81,
         paymentType: 'send',
         status: 'complete',
-        timestamp: 1754384530,
+        timestamp: 5,
         txId: 'tx2',
       },
       // Lightning, receive
@@ -65,7 +65,7 @@ describe('Breez Wallet - getCommonTransactions', () => {
         },
         swapperFeesSat: 1,
         txId: 'tx3',
-        timestamp: 1750158910,
+        timestamp: 4,
         amountSat: 53,
       },
       // Unknown asset, send
@@ -79,7 +79,7 @@ describe('Breez Wallet - getCommonTransactions', () => {
         },
         destination:
           'liquidtestnet:tlq1qqt0ms77xycr0c40jz8rtdsp230vmx8yzczrm5d7fjm95wc89pe6667uzw86jt53684mudx3qha50qwuhyqxtsmdfpyh6pfycx?assetid=ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9&amount=0.00000001',
-        timestamp: 1749209827,
+        timestamp: 3,
         amountSat: 1,
         feesSat: 40,
         paymentType: 'send',
@@ -93,7 +93,7 @@ describe('Breez Wallet - getCommonTransactions', () => {
       {
         feesSat: 0,
         paymentType: 'receive',
-        timestamp: 1748430250,
+        timestamp: 2,
         details: {
           payerNote: null,
           description: 'Liquid transfer',
@@ -119,7 +119,7 @@ describe('Breez Wallet - getCommonTransactions', () => {
       },
       // Lightning as a destination, receive
       {
-        timestamp: 1746798970,
+        timestamp: 1,
         status: 'complete',
         paymentType: 'receive',
         amountSat: 1183,
@@ -159,26 +159,25 @@ describe('Breez Wallet - getCommonTransactions', () => {
       {
         txid: '095cf834f56cc032708bb2465463ae348164b4d498b181f52fd98d0097c08629',
         network: NETWORK_LIQUID,
-        timestamp: 1754383510,
+        timestamp: 6,
         direction: 'receive',
         status: 'confirmed',
         fee: 0,
         amount: 1123,
-        tokenTransfers: [],
         explorerUrl: 'https://liquid.network/testnet/tx/095cf834f56cc032708bb2465463ae348164b4d498b181f52fd98d0097c08629',
       },
       {
         txid: 'tx2',
         network: NETWORK_LIQUID,
-        timestamp: 1754384530,
+        timestamp: 5,
         direction: 'send',
         status: 'confirmed',
         fee: 81,
-        amount: 0,
+        amount: undefined,
         tokenTransfers: [
           {
             address: undefined,
-            amount: 0.03,
+            amount: 3000000,
             tokenId: 'ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2',
           },
         ],
@@ -190,39 +189,21 @@ describe('Breez Wallet - getCommonTransactions', () => {
         fee: 48,
         network: NETWORK_LIQUID,
         status: 'confirmed',
-        timestamp: 1750158910,
-        tokenTransfers: [],
+        timestamp: 4,
         txid: 'tx3',
         explorerUrl: 'https://liquid.network/testnet/tx/tx3',
       },
       {
-        amount: 1,
-        direction: 'send',
-        fee: 40,
-        network: 'liquid',
-        status: 'confirmed',
-        timestamp: 1749209827,
-        tokenTransfers: [
-          {
-            address: 'tlq1qqt0ms77xycr0c40jz8rtdsp230vmx8yzczrm5d7fjm95wc89pe6667uzw86jt53684mudx3qha50qwuhyqxtsmdfpyh6pfycx',
-            amount: 1e-8,
-            tokenId: 'ec24f3e4a4993802f901d881ea1bbfc642dfbc25d5fe82af2564ddc59dc025a9',
-          },
-        ],
-        txid: '1d9939da15721adbd021d550286fec9f8476c0218073416966e62ef8f4de1f9b',
-        explorerUrl: 'https://liquid.network/testnet/tx/1d9939da15721adbd021d550286fec9f8476c0218073416966e62ef8f4de1f9b',
-      },
-      {
-        amount: 0,
+        amount: undefined,
         direction: 'receive',
         fee: 0,
         network: 'liquid',
         status: 'confirmed',
-        timestamp: 1748430250,
+        timestamp: 2,
         tokenTransfers: [
           {
-            address: undefined,
-            amount: 1,
+            address: 'lq1qqfy8jhv9px5q0v5v0e2m5jltjhj2wjnq5sdf08r0fgldheas52arv56pptlw85vfmgn4vceuatwce0d4tp2xzqhhdjc89acf6',
+            amount: 100000000,
             tokenId: 'ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2',
           },
         ],
@@ -235,8 +216,7 @@ describe('Breez Wallet - getCommonTransactions', () => {
         fee: 51,
         network: 'liquid',
         status: 'confirmed',
-        timestamp: 1746798970,
-        tokenTransfers: [],
+        timestamp: 1,
         txid: '7968249135073947e2f396b5cf0ad02ca9c22435063dff895bc80faf0ec6e5f4',
         explorerUrl: 'https://liquid.network/testnet/tx/7968249135073947e2f396b5cf0ad02ca9c22435063dff895bc80faf0ec6e5f4',
       },


### PR DESCRIPTION
- ignore unknown tokens, we still can't show there amount properly
- properly calculate amount for known tokens
- fix multiple txs with the same id


Before and After

<img width="200" alt="image" src="https://github.com/user-attachments/assets/8648d12c-4112-4978-9114-6d02bad1a554" />

<img width="200"   alt="image" src="https://github.com/user-attachments/assets/30df5133-3ed2-48a0-b2e7-1688e14a84e7" />

