### PR TITLE
refactor: send POS

### DIFF
--- a/mobile/app/PosMerchant.tsx
+++ b/mobile/app/PosMerchant.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, KeyboardAvoidingView, Platform, ScrollView, StyleShe
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import * as Crypto from 'expo-crypto';
 import bolt11lib from 'bolt11';
+import { Ionicons } from '@expo/vector-icons';
 
 import GradientScreen from '@/components/GradientScreen';
 import ScreenHeader from '@/components/navigation/ScreenHeader';
@@ -326,21 +327,6 @@ const PosMerchant: React.FC = () => {
     );
   }
 
-  if (success) {
-    return (
-      <GradientScreen variant={NETWORK_LIGHTNING}>
-        <Stack.Screen options={{ headerShown: false }} />
-        <ScreenHeader title="POS Payment" />
-        <View style={styles.centered}>
-          <ThemedText style={styles.centeredText}>Payment sent!</ThemedText>
-          <TouchableOpacity style={styles.secondaryButton} onPress={() => router.back()}>
-            <ThemedText style={[styles.secondaryButtonText, { paddingLeft: 10, paddingRight: 10 }]}>Back</ThemedText>
-          </TouchableOpacity>
-        </View>
-      </GradientScreen>
-    );
-  }
-
   if (error) {
     return (
       <GradientScreen variant={NETWORK_LIGHTNING}>
@@ -523,7 +509,7 @@ const PosMerchant: React.FC = () => {
             </TouchableOpacity>
           ) : null}
 
-          {bolt11 && !isSending ? (
+          {bolt11 && !isSending && !success ? (
             <View>
               <LongPressButton onLongPressComplete={actuallySend} title="Hold to confirm send" progressColor="#FFFFFF" backgroundColor="#000000" />
             </View>
@@ -533,6 +519,16 @@ const PosMerchant: React.FC = () => {
             <View style={styles.centered}>
               <ThemedText style={styles.centeredText}>Sending payment...</ThemedText>
               <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" />
+            </View>
+          ) : null}
+
+          {success ? (
+            <View style={styles.centered}>
+              <Ionicons name="checkmark-circle" size={80} color="#4CAF50" />
+              <ThemedText style={styles.centeredText}>Payment sent!</ThemedText>
+              <TouchableOpacity style={styles.secondaryButton} onPress={() => router.back()}>
+                <ThemedText style={[styles.secondaryButtonText, { paddingLeft: 10, paddingRight: 10 }]}>Done</ThemedText>
+              </TouchableOpacity>
             </View>
           ) : null}
         </ScrollView>

--- a/mobile/src/modules/scan-routing.ts
+++ b/mobile/src/modules/scan-routing.ts
@@ -180,10 +180,11 @@ export function handleQrIntent(rawInput: string, router: Pick<Router, 'push'>): 
       return true;
     }
 
-    case 'posMerchant':
+    case 'posMerchant': {
       const params: PosMerchantParams = { raw: intent.raw };
       router.push({ pathname: '/PosMerchant', params });
       return true;
+    }
 
     case 'unknown':
     default: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Inline the POS payment success state with a checkmark icon and hide send controls after success, removing the separate success screen.
> 
> - **POS Payment UI (`mobile/app/PosMerchant.tsx`)**:
>   - Replace separate success screen with in-view success state (checkmark icon via `Ionicons`, "Payment sent!", and Done button).
>   - Update send flow: hide `LongPressButton` when `success` is true and show sending indicator while processing.
>   - Remove early success-return render path; success is now handled within the main ScrollView layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a51ddacd77701e394e9f39f2eec63e7bb19ed819. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->