### PR TITLE
test: android e2e

### DIFF
--- a/mobile/.eas/workflows/e2e-test-android.yml
+++ b/mobile/.eas/workflows/e2e-test-android.yml
@@ -18,10 +18,12 @@ jobs:
   maestro_test:
     needs: [build_android_for_e2e]
     type: maestro
+    runs_on: linux-large-nested-virtualization
     params:
       retries: 5
       shards: 3
       build_id: ${{ needs.build_android_for_e2e.outputs.build_id }}
+      device_identifier: 'pixel_9'
       flow_path:
         - .maestro/home.yml
         - .maestro/wallet-creation-and-selftest.yml
@@ -30,6 +32,7 @@ jobs:
         - .maestro/browser.yml
         - .maestro/swap.yml
         - .maestro/biometric-toggle-test.yml
+
   upload_build_to_appetize:
     needs: [build_android_for_e2e]
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Android E2E workflow to run maestro tests on linux-large-nested-virtualization using a Pixel 9 device.
> 
> - **CI/CD (EAS Workflow)**:
>   - **Maestro test job** (`mobile/.eas/workflows/e2e-test-android.yml`):
>     - Set `runs_on` to `linux-large-nested-virtualization`.
>     - Specify `device_identifier: 'pixel_9'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ade8bba4320edbc58d0bc2fc9bda828d5300152. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->