### PR TITLE
refactor: account-based wallets

### DIFF
--- a/ext/src/pages/Popup/Home.tsx
+++ b/ext/src/pages/Popup/Home.tsx
@@ -63,10 +63,8 @@ const Home: React.FC = () => {
       case NETWORK_SPARK:
       case NETWORK_ARK_MUTINYNET:
       case NETWORK_ARK:
-        navigate('/send-ark');
-        break;
       case NETWORK_STACKS:
-        navigate('/send-ark');
+        navigate('/send-account-based');
         break;
       case NETWORK_LIQUID:
       case NETWORK_LIQUID_TESTNET:

--- a/ext/src/pages/Popup/Popup.tsx
+++ b/ext/src/pages/Popup/Popup.tsx
@@ -30,7 +30,7 @@ import './Popup.css';
 import Receive from './Receive';
 import ReceiveLightning from './ReceiveLightning';
 import SeedBackup from './SeedBackup';
-import SendArk from './SendArk';
+import SendAccountBased from './SendAccountBased';
 import SendBtc from './SendBtc';
 import SendEvm from './SendEvm';
 import SendLightning from './SendLightning';
@@ -102,7 +102,7 @@ const AppContent: React.FC = () => {
             <Route path="/seed-backup" element={<SeedBackup />} />
             <Route path="/send-liquid" element={<SendLiquid />} />
             <Route path="/send-evm" element={<SendEvm />} />
-            <Route path="/send-ark" element={<SendArk />} />
+            <Route path="/send-account-based" element={<SendAccountBased />} />
             <Route path="/send-token-evm" element={<SendTokenEvm />} />
             <Route path="/send-token-spark" element={<SendTokenSpark />} />
             <Route path="/send-token-stacks" element={<SendTokenStacks />} />

--- a/ext/src/pages/Popup/SendAccountBased.tsx
+++ b/ext/src/pages/Popup/SendAccountBased.tsx
@@ -19,9 +19,10 @@ import { SparkWallet } from '@shared/class/wallets/spark-wallet';
 import { StacksWallet } from '@shared/class/wallets/stacks-wallet';
 
 /**
- * This screen is used for both ArkWallet and SparkWallet
+ * This screen is used to send native-coin transactions for all
+ * single-address wallets (Ark, Spark, Stacks)
  */
-const SendArk: React.FC = () => {
+const SendAccountBased: React.FC = () => {
   const scanQr = useScanQR();
   const navigate = useNavigate();
   const [toAddress, setToAddress] = useState<string>('');
@@ -35,7 +36,7 @@ const SendArk: React.FC = () => {
   const { accountNumber } = useContext(AccountNumberContext);
   const { askMnemonic } = useContext(AskMnemonicContext);
   const { balance } = useBalance(network, accountNumber, BackgroundCaller);
-  const arkWallet = useRef<ArkWallet | SparkWallet | StacksWallet | undefined>(undefined);
+  const accountBasedWallet = useRef<ArkWallet | SparkWallet | StacksWallet | undefined>(undefined);
 
   const actualSend = async () => {
     let startTs = Date.now();
@@ -45,15 +46,15 @@ const SendArk: React.FC = () => {
       const satValueBN = new BigNumber(amount);
       const satValue = satValueBN.multipliedBy(new BigNumber(10).pow(getDecimalsByNetwork(network))).toString(10);
 
-      if (!arkWallet) {
-        throw new Error('Internal error: ArkWallet is not set');
+      if (!accountBasedWallet) {
+        throw new Error('Internal error: accountBasedWallet is not set');
       }
 
       console.log('actual value to send:', +satValue);
 
       startTs = Date.now();
-      const transactionId = await arkWallet.current?.pay(toAddress, +satValue);
-      assert(transactionId, 'Internal error: ArkWallet.pay() failed');
+      const transactionId = await accountBasedWallet.current?.pay(toAddress, +satValue);
+      assert(transactionId, 'Internal error: accountBasedWallet.pay() failed');
       console.log('submitted txid:', transactionId);
 
       setIsSuccess(true);
@@ -78,7 +79,7 @@ const SendArk: React.FC = () => {
       let w = await BackgroundCaller.lazyInitWallet(network, accountNumber);
       assert(w instanceof ArkWallet || w instanceof SparkWallet || w instanceof StacksWallet, 'Unexpected wallet type');
 
-      arkWallet.current = w;
+      accountBasedWallet.current = w;
       setIsPrepared(true);
     } catch (error: any) {
       console.error(error.message);
@@ -201,4 +202,4 @@ const SendArk: React.FC = () => {
   );
 };
 
-export default SendArk;
+export default SendAccountBased;

--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -152,7 +152,8 @@ export default function Home() {
       case NETWORK_ARK:
       case NETWORK_SPARK:
       case NETWORK_ARK_MUTINYNET:
-        router.push('/SendArk');
+      case NETWORK_STACKS:
+        router.push('/SendAccountBased');
         break;
       case NETWORK_LIQUID:
       case NETWORK_LIQUID_TESTNET:
@@ -161,9 +162,6 @@ export default function Home() {
       case NETWORK_LIGHTNING:
       case NETWORK_LIGHTNING_TESTNET:
         router.push('/SendLightning');
-        break;
-      case NETWORK_STACKS:
-        router.push('/SendArk');
         break;
       default:
         router.push('/SendEvm');

--- a/mobile/app/SendAccountBased.tsx
+++ b/mobile/app/SendAccountBased.tsx
@@ -20,14 +20,19 @@ import { formatBalance } from '@shared/modules/string-utils';
 import { NETWORK_ARK, NETWORK_ARK_MUTINYNET, NETWORK_SPARK, NETWORK_STACKS } from '@shared/types/networks';
 import { SparkWallet } from '@shared/class/wallets/spark-wallet';
 import { StacksWallet } from '@shared/class/wallets/stacks-wallet';
+import { InterfaceAccountBasedWallet } from '@shared/class/wallets/interface-account-based-wallet';
 
-export type SendArkParams = {
+export type SendAccountBasedParams = {
   toAddress?: string;
   amount?: string;
 };
 
-const SendArk = () => {
-  const params = useLocalSearchParams<SendArkParams>();
+/**
+ * This screen is used to send native-coin transactions for all
+ * single-address wallets (Ark, Spark, Stacks)
+ */
+const SendAccountBased = () => {
+  const params = useLocalSearchParams<SendAccountBasedParams>();
   const router = useRouter();
   const { scanQr } = useContext(ScanQrContext);
 
@@ -41,7 +46,7 @@ const SendArk = () => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
   const { balance } = useBalance(network, accountNumber, BackgroundExecutor);
-  const arkWallet = useRef<ArkWallet | SparkWallet | StacksWallet | undefined>(undefined);
+  const accountBasedWallet = useRef<InterfaceAccountBasedWallet | undefined>(undefined);
 
   const actualSend = async () => {
     let startTs = Date.now();
@@ -51,14 +56,14 @@ const SendArk = () => {
       const satValueBN = new BigNumber(amount);
       const satValue = satValueBN.multipliedBy(new BigNumber(10).pow(getDecimalsByNetwork(network))).toString(10);
 
-      if (!arkWallet) {
-        throw new Error('Internal error: ArkWallet is not set');
+      if (!accountBasedWallet) {
+        throw new Error('Internal error: accountBasedWallet is not set');
       }
       console.log('actual value to send:', +satValue);
 
       startTs = Date.now();
-      const transactionId = await arkWallet.current?.pay(toAddress, +satValue);
-      assert(transactionId, 'Internal error: ArkWallet.pay() failed');
+      const transactionId = await accountBasedWallet.current?.pay(toAddress, +satValue);
+      assert(transactionId, 'Internal error: accountBasedWallet.pay() failed');
       console.log('submitted txid:', transactionId);
 
       setIsSuccess(true);
@@ -83,7 +88,7 @@ const SendArk = () => {
       let w = await BackgroundExecutor.lazyInitWallet(network, accountNumber);
       assert(w instanceof ArkWallet || w instanceof SparkWallet || w instanceof StacksWallet, 'Internal error: incorrect wallet instance');
 
-      arkWallet.current = w;
+      accountBasedWallet.current = w;
       setIsPrepared(true);
     } catch (error: any) {
       console.error(error.message);
@@ -377,4 +382,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default SendArk;
+export default SendAccountBased;

--- a/mobile/components/ProtectedRouteStack.tsx
+++ b/mobile/components/ProtectedRouteStack.tsx
@@ -140,7 +140,7 @@ export function ProtectedRouteStack() {
         <Stack.Screen name="Changelog" options={{ headerShown: false }} />
         <Stack.Screen name="SeedBackup" options={{ headerShown: false }} />
         <Stack.Screen name="selftest" options={{ title: 'Self Test' }} />
-        <Stack.Screen name="SendArk" options={{ title: 'Send ARK' }} />
+        <Stack.Screen name="SendAccountBased" options={{ headerShown: false }} />
         <Stack.Screen name="SendBtc" options={{ title: 'Send BTC' }} />
         <Stack.Screen name="SendEvm" options={{ title: 'Send' }} />
         <Stack.Screen name="Swap" options={{ headerShown: false }} />

--- a/mobile/src/utils/navigationUtils.ts
+++ b/mobile/src/utils/navigationUtils.ts
@@ -10,7 +10,7 @@ const MAIN_APP_SCREENS = [
   'Settings',
   'Swap',
   'Receive',
-  'SendArk',
+  'SendAccountBased',
   'SendBtc',
   'SendEvm',
   'Transactions',

--- a/shared/class/wallets/ark-wallet.ts
+++ b/shared/class/wallets/ark-wallet.ts
@@ -13,10 +13,11 @@ import { CommonTransaction } from '../../types/common-transaction';
 import { NETWORK_ARK, NETWORK_ARK_MUTINYNET } from '../../types/networks';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
 import { createLightningInvoiceResponse, InterfaceLightningWallet, LightningPaymentLimitsResponse } from './interface-lightning-wallet';
+import { InterfaceAccountBasedWallet } from './interface-account-based-wallet';
 
 const bip32 = BIP32Factory(ecc);
 
-export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLightningWallet {
+export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLightningWallet, InterfaceAccountBasedWallet {
   private _wallet: Wallet | undefined = undefined;
   private _arkadeLightning: ArkadeLightning | undefined = undefined;
   private _arkServerUrl: string = 'https://mutinynet.arkade.sh';

--- a/shared/class/wallets/interface-account-based-wallet.ts
+++ b/shared/class/wallets/interface-account-based-wallet.ts
@@ -1,0 +1,11 @@
+/**
+ * represents trait of a wallet: that wallet can have only one address (unlike UTXO-based wallets like bitcoin),
+ * and can do transfers natively on that address
+ */
+export interface InterfaceAccountBasedWallet {
+  getOffchainReceiveAddress(): Promise<string>;
+
+  pay(receiverAddress: string, amountSats: number): Promise<string>;
+
+  getOffchainBalance(): Promise<number>;
+}

--- a/shared/class/wallets/interface-lightning-wallet.ts
+++ b/shared/class/wallets/interface-lightning-wallet.ts
@@ -14,6 +14,9 @@ export interface LightningPaymentLimitsResponse {
   receive: Limits;
 }
 
+/**
+ * represents trait of a wallet: that wallet can pay and receive lightning
+ */
 export interface InterfaceLightningWallet {
   payLightningInvoice(invoice: string): Promise<boolean>;
 

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -10,6 +10,7 @@ import { NETWORK_BITCOIN, NETWORK_SPARK } from '../../types/networks';
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import { CommonSwap } from '../../types/common-swap';
 import { AllNetworkInfos } from '../../models/all-network-infos';
+import { InterfaceAccountBasedWallet } from './interface-account-based-wallet';
 
 // copypasted from `node_modules/@buildonspark/spark-sdk/dist/...` since its not exported
 type Bech32mTokenIdentifier = `btkn1${string}` | `btknrt1${string}` | `btknt1${string}` | `btkns1${string}` | `btknl1${string}`;
@@ -21,7 +22,7 @@ export interface ISparkAdapter {
 // not exposed in the SDK
 export type StaticDepositQuoteOutput = Awaited<ReturnType<SDK['getClaimStaticDepositQuote']>>;
 
-export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
+export class SparkWallet extends ArkWallet implements InterfaceLightningWallet, InterfaceAccountBasedWallet {
   private _sdkWallet: Awaited<ReturnType<typeof SDK.initialize>>['wallet'] | undefined = undefined;
   protected adapter: ISparkAdapter;
 
@@ -100,7 +101,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
     return transfer.id;
   }
 
-  async getOffchainBalance() {
+  async getOffchainBalance(): Promise<number> {
     if (!this._sdkWallet) throw new Error('Spark wallet not initialized');
     const balance = await this._sdkWallet.getBalance();
     this._lastBalanceFetch = Date.now();

--- a/shared/class/wallets/stacks-wallet.ts
+++ b/shared/class/wallets/stacks-wallet.ts
@@ -7,13 +7,14 @@ import { CachedTokenInfo } from '../../types/token-info';
 import { CommonTransaction } from '../../types/common-transaction';
 import { NETWORK_STACKS } from '../../types/networks';
 import { IStorage } from '../../types/IStorage';
+import { InterfaceAccountBasedWallet } from './interface-account-based-wallet';
 
 const sbtcId = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token';
 const baseUrl = 'https://api.mainnet.hiro.so';
 
 const STORAGE_KEY = 'STACKS_TOKEN_METADATA';
 
-export class StacksWallet {
+export class StacksWallet implements InterfaceAccountBasedWallet {
   private _accountNumber: number = 0;
   private _sdkWallet: SdkWallet | undefined = undefined;
   private secret: string = '';
@@ -136,7 +137,7 @@ export class StacksWallet {
   /**
    * returning sBTC balance, which is technically a token, NOT a native balance (STX)
    */
-  public async getBalance() {
+  public async getOffchainBalance(): Promise<number> {
     const address = await this.getOffchainReceiveAddress();
     assert(address, 'Stacks address is missing');
 
@@ -153,7 +154,7 @@ export class StacksWallet {
     // we treat sBTC token as main balance for this wallet
     for (const token of ftBalances?.results || []) {
       if (token.token === sbtcId) {
-        return token.balance;
+        return Number(token.balance);
       }
     }
 

--- a/shared/hooks/useBalance.ts
+++ b/shared/hooks/useBalance.ts
@@ -1,7 +1,8 @@
 import BigNumber from 'bignumber.js';
 import useSWR from 'swr';
 
-import { SparkWallet } from '@shared/class/wallets/spark-wallet';
+import { SparkWallet } from '../class/wallets/spark-wallet';
+import { BreezWallet } from '../class/wallets/breez-wallet';
 import { ArkWallet } from '../class/wallets/ark-wallet';
 import { StacksWallet } from '../class/wallets/stacks-wallet';
 import { getRpcProvider } from '../models/network-getters';
@@ -66,6 +67,7 @@ export const balanceFetcher = async (arg: balanceFetcherArg): Promise<StringNumb
 
   if (network === NETWORK_LIQUID || network === NETWORK_LIQUID_TESTNET) {
     const bw = await backgroundCaller.lazyInitWallet(network, accountNumber);
+    assert(bw instanceof BreezWallet);
     const balance = await bw.getBalance();
     return balance.toString(10);
   }
@@ -94,7 +96,7 @@ export const balanceFetcher = async (arg: balanceFetcherArg): Promise<StringNumb
     const start = +new Date();
     const sw = await backgroundCaller.lazyInitWallet(network, accountNumber);
     assert(sw instanceof StacksWallet);
-    const virtualBalance = await sw.getBalance();
+    const virtualBalance = await sw.getOffchainBalance();
     const end = +new Date();
     console.log('stacks balance took', (end - start) / 1000, 'sec, balance =', virtualBalance.toString(10));
     return virtualBalance.toString(10);

--- a/shared/tests/integration-vi/stacks-wallet.test.ts
+++ b/shared/tests/integration-vi/stacks-wallet.test.ts
@@ -21,7 +21,7 @@ test('stacks wallet can get balance', async (context) => {
   w.setSecret(process.env.TEST_MNEMONIC);
   await w.init(storageMock);
 
-  const balance = await w.getBalance();
+  const balance = await w.getOffchainBalance();
 
   assert(+balance > 0, `unexpected balance: ${balance}`);
 });
@@ -41,7 +41,7 @@ test.skip('stacks send', async (context) => {
   const toAddress = await w.getOffchainReceiveAddress();
   w.setAccountNumber(0);
 
-  const balance = await w.getBalance();
+  const balance = await w.getOffchainBalance();
   await w.fetchTokenBalances();
 
   await w.pay(toAddress, 100);


### PR DESCRIPTION
* tidy up, common interface for some wallets

todo next:

* e2e test to send spark or ark
* common interface for wallets that can have tokens so we can standardize "send-xxx-token.tsx" screen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a common InterfaceAccountBasedWallet and replace Ark-specific send with a generic SendAccountBased for Ark, Spark, and Stacks across extension and mobile, updating routes, balance fetching, and tests.
> 
> - **UI/Navigation (Extension + Mobile)**:
>   - Replace `SendArk` with generic `SendAccountBased` screen and route (`/send-account-based`, `SendAccountBased`).
>   - Update `Home` send handlers to route Ark/Spark/Stacks to `SendAccountBased`.
>   - Adjust protected stack and main app screen lists to include `SendAccountBased`.
> - **Wallet Abstractions**:
>   - Add `InterfaceAccountBasedWallet` (`getOffchainReceiveAddress`, `pay`, `getOffchainBalance`).
>   - Implement interface in `ArkWallet`, `SparkWallet`, and `StacksWallet` (type/signature tweaks; `SparkWallet.getOffchainBalance` returns number).
> - **Send Screens**:
>   - New `SendAccountBased` components (ext/mobile) use unified wallet ref and flow for native-coin transfers on Ark/Spark/Stacks.
> - **Balance Hook**:
>   - `useBalance` now imports wallets locally, uses `BreezWallet` for Liquid, and calls `getOffchainBalance` for Stacks.
> - **Tests**:
>   - Update Stacks tests to use `getOffchainBalance` and maintain token/tx checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2bdf72d05fc01aafd609f217cae4a06d50245ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->