### PR TITLE
fix: sending stacks stx now has memo input (closes #452)

### DIFF
--- a/ext/src/pages/Popup/SendTokenStacks.tsx
+++ b/ext/src/pages/Popup/SendTokenStacks.tsx
@@ -37,14 +37,16 @@ const SendTokenStacks: React.FC = () => {
   const { accountNumber } = useContext(AccountNumberContext);
   const scanQr = useScanQR();
   const { tokenPublicKey } = location.state as SendTokenStacksProps;
+  const allowMemo = tokenPublicKey === 'STX';
   const { balance: balanceNative } = useBalance(network, accountNumber, BackgroundCaller);
   const { balance } = useTokenBalance(network, accountNumber, tokenPublicKey, BackgroundCaller);
 
   const [toAddress, setToAddress] = useState<string>('');
+  const [memo, setMemo] = useState<string>('');
   const [amountToSend, setAmountToSend] = useState<string>('');
   const [error, setError] = useState<string>('');
   const [token, setToken] = useState<CachedTokenInfo>();
-  // const [tokenIdentifier, setTokenIdentifier] = useState<string>('');
+
   const { askMnemonic } = useContext(AskMnemonicContext);
 
   // loading token
@@ -86,7 +88,7 @@ const SendTokenStacks: React.FC = () => {
 
       const satValueToSend = new BigNumber(amountToSend).multipliedBy(new BigNumber(10).pow(token.decimals)).toFixed(0);
 
-      const transactionId = await wallet.transferTokens(token.id, BigInt(satValueToSend), toAddress);
+      const transactionId = await wallet.transferTokens(token.id, BigInt(satValueToSend), toAddress, memo);
 
       if (transactionId) {
         setStep(SendTokenStacksStep.Sent);
@@ -165,17 +167,22 @@ const SendTokenStacks: React.FC = () => {
               </Button>
             </div>
           </div>
-          <hr />
           <div style={{ textAlign: 'left' }}>
             <b>Amount</b>
             <div style={{ marginBottom: '10px' }}></div>
             <Input type="numbers" data-testid="amount-input" placeholder="0.00" onChange={(event) => setAmountToSend(event.target.value)} />
             <div style={{ color: 'gray', width: '100%', marginBottom: '15px' }}>
               <span style={{ fontSize: 16 }}>
-                Available balance: {token?.symbol} {balance ? formatBalance(balance, token?.decimals ?? 0, 2) : ''}
+                Available balance: {token?.symbol} {balance ? formatBalance(balance, token?.decimals ?? 2, token?.decimals ?? 2) : ''}
               </span>
             </div>
           </div>
+          {allowMemo ? (
+            <div style={{ textAlign: 'left' }}>
+              <div style={{ marginBottom: '10px' }}></div>
+              <Input data-testid="memo-input" placeholder="memo" onChange={(event) => setMemo(event.target.value)} />
+            </div>
+          ) : null}
         </>
       ) : null}
 

--- a/mobile/app/SendTokenStacks.tsx
+++ b/mobile/app/SendTokenStacks.tsx
@@ -20,6 +20,13 @@ import { ThemedText } from '@/components/ThemedText';
 import { StacksWallet } from '@shared/class/wallets/stacks-wallet';
 import { CachedTokenInfo } from '@shared/types/token-info';
 
+export type SendTokenStacksParams = {
+  tokenId: string;
+  tokenSymbol: string;
+  tokenName: string;
+  tokenDecimals: string;
+};
+
 // Enum for the different steps in the send token flow
 export enum SendTokenStacksStep {
   Init,
@@ -31,12 +38,8 @@ export enum SendTokenStacksStep {
 }
 
 export default function SendTokenStacksScreen() {
-  const params = useLocalSearchParams<{
-    tokenId: string;
-    tokenSymbol: string;
-    tokenName: string;
-    tokenDecimals: string;
-  }>();
+  const params = useLocalSearchParams<SendTokenStacksParams>();
+  const allowMemo = params.tokenId === 'STX';
 
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
@@ -45,10 +48,10 @@ export default function SendTokenStacksScreen() {
   // State management
   const [step, setStep] = useState<SendTokenStacksStep>(SendTokenStacksStep.Init);
   const [toAddress, setToAddress] = useState<string>('');
+  const [memo, setMemo] = useState<string>('');
   const [amountToSend, setAmountToSend] = useState<string>('');
   const [error, setError] = useState<string>('');
   const [token, setToken] = useState<CachedTokenInfo>();
-  // const [tokenIdentifier, setTokenIdentifier] = useState<string>('');
 
   const tokenPublicKey = params.tokenId || '';
   const { balance: balanceNative } = useBalance(network, accountNumber, BackgroundExecutor);
@@ -102,7 +105,7 @@ export default function SendTokenStacksScreen() {
 
       const satValueToSend = new BigNumber(amountToSend).multipliedBy(new BigNumber(10).pow(token.decimals)).toFixed(0);
 
-      const transactionId = await wallet.transferTokens(token.id, BigInt(satValueToSend), toAddress);
+      const transactionId = await wallet.transferTokens(token.id, BigInt(satValueToSend), toAddress, memo);
 
       if (transactionId) {
         setStep(SendTokenStacksStep.Sent);
@@ -238,9 +241,33 @@ export default function SendTokenStacksScreen() {
                   />
                   {/* Available Balance */}
                   <Text style={[styles.balanceText, { color: textColor, opacity: 0.8, marginTop: 8 }]}>
-                    {`Available balance: ${token?.symbol} ${balance ? formatBalance(balance, token?.decimals ?? 0, 2) : ''}`}
+                    {`Available balance: ${token?.symbol} ${balance ? formatBalance(balance, token?.decimals ?? 2, token?.decimals ?? 2) : ''}`}
                   </Text>
                 </View>
+
+                {/* Memo */}
+                {allowMemo ? (
+                  <View style={styles.section}>
+                    <View style={styles.amountHeader}>
+                      <Text style={[styles.label, { color: textColor }]}>Memo</Text>
+                    </View>
+                    <TextInput
+                      style={[
+                        styles.input,
+                        {
+                          color: textColor,
+                          borderColor: borderColor,
+                          backgroundColor: 'rgba(0, 0, 0, 0.2)',
+                        },
+                      ]}
+                      value={memo}
+                      onChangeText={setMemo}
+                      placeholder=""
+                      placeholderTextColor="rgba(255, 255, 255, 0.6)"
+                      editable={step === SendTokenStacksStep.Init}
+                    />
+                  </View>
+                ) : null}
               </>
             )}
 

--- a/shared/class/wallets/stacks-wallet.ts
+++ b/shared/class/wallets/stacks-wallet.ts
@@ -209,16 +209,17 @@ export class StacksWallet implements InterfaceAccountBasedWallet {
   /**
    * sending native coin (STX)
    */
-  async payStx(address: string, amount: number): Promise<string> {
+  async payStx(address: string, amount: number, memo?: string): Promise<string> {
     assert(this._sdkWallet, 'Stacks wallet is not initialized');
     assert(this._sdkWallet.accounts[this._accountNumber], 'Stacks account not found');
 
+    console.warn('paying STX with memo:', memo);
     const txOptions: SignedTokenTransferOptions = {
       recipient: address,
       amount: BigInt(amount),
       senderKey: this._sdkWallet.accounts[this._accountNumber].stxPrivateKey,
       network: 'mainnet',
-      // memo: '',
+      memo,
       // nonce: 0n, // set a nonce manually if you don't want builder to fetch from a Stacks node
       // fee: 200n, // set a tx fee if you don't want the builder to estimate
     };
@@ -309,7 +310,7 @@ export class StacksWallet implements InterfaceAccountBasedWallet {
     return txs;
   }
 
-  async transferTokens(tokenId: string, amount: bigint, address: string): Promise<string> {
+  async transferTokens(tokenId: string, amount: bigint, address: string, memo?: string): Promise<string> {
     assert(this._sdkWallet, 'Stacks wallet is not initialized');
     assert(this._sdkWallet.accounts[this._accountNumber], 'Stacks account not found');
     assert(address, 'Recipient address is required');
@@ -317,7 +318,7 @@ export class StacksWallet implements InterfaceAccountBasedWallet {
 
     if (tokenId === 'STX') {
       // its actually a native token
-      return this.payStx(address, Number(amount));
+      return this.payStx(address, Number(amount), memo);
     }
 
     // Ensure cached balance is sufficient

--- a/shared/hooks/useTokenDiscovery.ts
+++ b/shared/hooks/useTokenDiscovery.ts
@@ -10,7 +10,7 @@ import { StacksWallet } from '../class/wallets/stacks-wallet';
 
 const STORAGE_KEY_CACHED_TOKEN_LIST = 'STORAGE_KEY_CACHED_TOKEN_LIST';
 
-export function useTokenDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, storage: IStorage, refreshInterval = 2_000) {
+export function useTokenDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, storage: IStorage, refreshInterval = 3_000) {
   const [tokenList, setTokenList] = useState<CachedTokenInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds memo input for STX sends (web and mobile) and passes memo through wallet transfers; also refines balance formatting and token discovery refresh interval.
> 
> - **Stacks STX Transfers**
>   - **Web (`ext/src/pages/Popup/SendTokenStacks.tsx`)**:
>     - Add conditional memo input when sending `STX` and include memo in `transferTokens` call.
>     - Improve available balance display to use `token.decimals` for precision.
>   - **Mobile (`mobile/app/SendTokenStacks.tsx`)**:
>     - Add `memo` field for `STX` sends; plumb to `transferTokens`.
>     - Extract `SendTokenStacksParams` type.
>     - Improve available balance formatting precision.
> - **Wallet (`shared/class/wallets/stacks-wallet.ts`)**
>   - Extend `payStx` and `transferTokens` to accept and forward optional `memo` in STX transfers.
> - **Misc**
>   - Increase token discovery refresh interval in `useTokenDiscovery` to `3000ms`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba912c5e16e2b05947e6593d6805f16d83d2adc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->