### PR TITLE
chore: bump ark

### DIFF
--- a/ext/package-lock.json
+++ b/ext/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.6",
-        "@arkade-os/sdk": "0.3.3",
+        "@arkade-os/boltz-swap": "0.2.7",
+        "@arkade-os/sdk": "0.3.4",
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@breeztech/breez-sdk-liquid": "0.11.9",
         "@buildonspark/spark-sdk": "0.4.3",
@@ -136,12 +136,12 @@
       }
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.6.tgz",
-      "integrity": "sha512-lqDZpngGHm1JaJm9e1D0XMmCKyGrnn2dKhod2rFpkFlrYmlaATy6NM2clL5G8EWTlW8knMCLyKmqR3U/HZMxBg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.7.tgz",
+      "integrity": "sha512-EwimxPeOpFtY4rnvdcOLTtkKXVkeX9odeTNavENm6qNH+7NgMnGA/rjnl1gcFPS0srlmS6er6dCsM2aIMi2cKQ==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.3",
+        "@arkade-os/sdk": "0.3.4",
         "@noble/hashes": "2.0.0",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.3.tgz",
-      "integrity": "sha512-WUvUF+3HR5Emc+wY88DvYifXYVQTqedzUy8bCYF/7/bHLlz+YoCxtrse0sPjKyDMJ/mq5+aNghQxynpi6YXkiA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.4.tgz",
+      "integrity": "sha512-44/TM/+C37VMBdSKqVEWBFup8KRzYIfTrrxL5+jc4z23pBL1GXhMM24mHwfNRCpTtFEM0Lgkc1C7zuC9d0Uxag==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/ext/package.json
+++ b/ext/package.json
@@ -21,8 +21,8 @@
     "prepare": "cd .. && husky ext/.husky"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.6",
-    "@arkade-os/sdk": "0.3.3",
+    "@arkade-os/boltz-swap": "0.2.7",
+    "@arkade-os/sdk": "0.3.4",
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@breeztech/breez-sdk-liquid": "0.11.9",
     "@buildonspark/spark-sdk": "0.4.3",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.6",
-        "@arkade-os/sdk": "0.3.3",
+        "@arkade-os/boltz-swap": "0.2.7",
+        "@arkade-os/sdk": "0.3.4",
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@breeztech/breez-sdk-liquid": "0.11.9",
         "@breeztech/react-native-breez-sdk-liquid": "0.11.9",
@@ -143,12 +143,12 @@
       "license": "MIT"
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.6.tgz",
-      "integrity": "sha512-lqDZpngGHm1JaJm9e1D0XMmCKyGrnn2dKhod2rFpkFlrYmlaATy6NM2clL5G8EWTlW8knMCLyKmqR3U/HZMxBg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.7.tgz",
+      "integrity": "sha512-EwimxPeOpFtY4rnvdcOLTtkKXVkeX9odeTNavENm6qNH+7NgMnGA/rjnl1gcFPS0srlmS6er6dCsM2aIMi2cKQ==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.3",
+        "@arkade-os/sdk": "0.3.4",
         "@noble/hashes": "2.0.0",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.3.tgz",
-      "integrity": "sha512-WUvUF+3HR5Emc+wY88DvYifXYVQTqedzUy8bCYF/7/bHLlz+YoCxtrse0sPjKyDMJ/mq5+aNghQxynpi6YXkiA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.4.tgz",
+      "integrity": "sha512-44/TM/+C37VMBdSKqVEWBFup8KRzYIfTrrxL5+jc4z23pBL1GXhMM24mHwfNRCpTtFEM0Lgkc1C7zuC9d0Uxag==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -33,8 +33,8 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.6",
-    "@arkade-os/sdk": "0.3.3",
+    "@arkade-os/boltz-swap": "0.2.7",
+    "@arkade-os/sdk": "0.3.4",
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@breeztech/breez-sdk-liquid": "0.11.9",
     "@breeztech/react-native-breez-sdk-liquid": "0.11.9",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade @arkade-os/boltz-swap to 0.2.7 and @arkade-os/sdk to 0.3.4 across ext and mobile, updating lockfiles.
> 
> - **Dependencies**:
>   - **ext/**:
>     - Bump `@arkade-os/boltz-swap` `0.2.6 -> 0.2.7`.
>     - Bump `@arkade-os/sdk` `0.3.3 -> 0.3.4`.
>   - **mobile/**:
>     - Bump `@arkade-os/boltz-swap` `0.2.6 -> 0.2.7`.
>     - Bump `@arkade-os/sdk` `0.3.3 -> 0.3.4`.
>   - Update corresponding `package-lock.json` entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c0b639653e5042d43f5eee5c9b8ce264dd1b73b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->