### PR TITLE
refactor: swap minor

### DIFF
--- a/mobile/app/Swap.tsx
+++ b/mobile/app/Swap.tsx
@@ -101,7 +101,7 @@ export default function Swap() {
     assert(provider, 'No provider found for the selected networks');
 
     let destinationAddress = '';
-    if (option === SO_LIQUID_USDT) {
+    if (option === SO_LIQUID_USDT || option === SO_ROOTSTOCK_USDT) {
       destinationAddress = await BackgroundExecutor.getAddress(NETWORK_LIQUID, accountNumber);
     } else if (option === SO_STACKS_STX) {
       destinationAddress = await BackgroundExecutor.getAddress(NETWORK_STACKS, accountNumber);

--- a/shared/class/wallets/stacks-wallet.ts
+++ b/shared/class/wallets/stacks-wallet.ts
@@ -213,7 +213,6 @@ export class StacksWallet implements InterfaceAccountBasedWallet {
     assert(this._sdkWallet, 'Stacks wallet is not initialized');
     assert(this._sdkWallet.accounts[this._accountNumber], 'Stacks account not found');
 
-    console.warn('paying STX with memo:', memo);
     const txOptions: SignedTokenTransferOptions = {
       recipient: address,
       amount: BigInt(amount),


### PR DESCRIPTION
a followup after https://github.com/layerztec/layerzwallet/pull/459

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `SO_ROOTSTOCK_USDT` to swap destination routing (uses `NETWORK_LIQUID` address); removes a debug log in Stacks STX transfer.
> 
> - **Swap flow (`mobile/app/Swap.tsx`)**
>   - Destination address selection: handle `SO_ROOTSTOCK_USDT` like `SO_LIQUID_USDT`, fetching address from `NETWORK_LIQUID`.
> - **Stacks wallet (`shared/class/wallets/stacks-wallet.ts`)**
>   - Remove debug `console.warn` in `payStx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05bd700a482109eac0649b9feded8249e37f0635. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->