### PR TITLE
refactor: change swap and buy-bitcoin button texts

### DIFF
--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -542,13 +542,13 @@ export default function Home() {
                   <ActionPopupButton actions={usdtSwapActions} title="Choose network to swap">
                     <TouchableOpacity style={styles.swapButtonInner} activeOpacity={0.8} testID="SwapButton">
                       <Ionicons name="swap-horizontal" size={22} color="rgba(255, 255, 255, 0.8)" />
-                      <ThemedText style={styles.navButtonText}>Swap</ThemedText>
+                      <ThemedText style={styles.navButtonText}>Transfer</ThemedText>
                     </TouchableOpacity>
                   </ActionPopupButton>
                 ) : (
                   <TouchableOpacity style={styles.swapButtonInner} onPress={handleSwap} activeOpacity={0.8} testID="SwapButton">
                     <Ionicons name="swap-horizontal" size={22} color="rgba(255, 255, 255, 0.8)" />
-                    <ThemedText style={styles.navButtonText}>Swap</ThemedText>
+                    <ThemedText style={styles.navButtonText}>Transfer</ThemedText>
                   </TouchableOpacity>
                 )}
               </View>

--- a/mobile/app/Swap.tsx
+++ b/mobile/app/Swap.tsx
@@ -163,7 +163,7 @@ export default function Swap() {
       <View style={styles.container}>
         {/* Header */}
         <View style={styles.header}>
-          <ThemedText style={styles.title}>Swap</ThemedText>
+          <ThemedText style={styles.title}>Transfer</ThemedText>
           <TouchableOpacity style={styles.closeButton} onPress={handleClose}>
             <Ionicons name="close" size={20} color="rgba(255, 255, 255, 0.8)" />
           </TouchableOpacity>

--- a/mobile/components/Balance.tsx
+++ b/mobile/components/Balance.tsx
@@ -59,7 +59,7 @@ const Balance = () => {
 
       {canBuyWithFiat && (
         <TouchableOpacity style={styles.buyButton} onPress={handleBuyClick} activeOpacity={0.8}>
-          <ThemedText style={styles.buyButtonText}>Buy Bitcoin</ThemedText>
+          <ThemedText style={styles.buyButtonText}>Fund</ThemedText>
         </TouchableOpacity>
       )}
     </View>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates UI copy: swap-related labels now say "Transfer" and the buy button says "Fund" across Home, Swap, and Balance screens.
> 
> - **UI copy updates**:
>   - **`mobile/app/Home.tsx`**:
>     - Bottom nav swap button label: `Swap` -> `Transfer` (including USDT action variant).
>   - **`mobile/app/Swap.tsx`**:
>     - Header title: `Swap` -> `Transfer`.
>   - **`mobile/components/Balance.tsx`**:
>     - Fiat buy button label: `Buy Bitcoin` -> `Fund`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4f536a9d427ba795661fe56b8c49233b2d2c66a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->