### PR TITLE
feat: new send flow for account based wallet

### DIFF
--- a/mobile/.maestro/send-spark.yml
+++ b/mobile/.maestro/send-spark.yml
@@ -35,19 +35,22 @@ jsEngine: graaljs
 - tapOn:
     id: 'SendButton'
 - tapOn:
-    id: 'recipient-address-input'
+    id: 'send-address-input'
 - inputText: 'spark1pgssyjcyyypuufme5g6n4rg7avcxkx029am5ccpfn63d5ryr6d308m0j4akqhx'
 - tapOn:
-    id: 'amount-input'
+    id: 'send-address-next-button'
+- waitForAnimationToEnd
+- tapOn:
+    id: 'send-amount-acc-input'
 - inputText: '0.00000001'
 - tapOn:
-    id: 'send-screen-send-button'
+    id: 'send-amount-acc-next-button'
 - tapOn:
-    id: 'send-screen-send-button'
-- longPressOn: 'Hold to confirm send'
-- waitForAnimationToEnd:
+    id: 'send-confirm-button'
+- extendedWaitUntil:
+    visible:
+      id: 'send-success-text'
     timeout: 29000
-- assertVisible: 'Transaction Sent!'
 - tapOn: 'Back to Wallet'
 - runFlow: # sleeping till balance updates
     file: subflows/sleep.yml

--- a/mobile/.maestro/send-token.yml
+++ b/mobile/.maestro/send-token.yml
@@ -35,19 +35,22 @@ jsEngine: graaljs
 - tapOn:
     id: 'token-row-btkn1mjpzcvak0mk9xv4kjdztwl6udk5rkgzetyz4qdz8375mk0wpvpqqe0alhv'
 - tapOn:
-    id: 'recipient-address-input'
+    id: 'send-address-input'
 - inputText: 'spark1pgssyjcyyypuufme5g6n4rg7avcxkx029am5ccpfn63d5ryr6d308m0j4akqhx'
 - tapOn:
-    id: 'amount-input'
+    id: 'send-address-next-button'
+- waitForAnimationToEnd
+- tapOn:
+    id: 'send-amount-acc-input'
 - inputText: '1'
 - tapOn:
-    id: 'send-screen-send-button'
+    id: 'send-amount-acc-next-button'
 - tapOn:
-    id: 'send-screen-send-button'
-- longPressOn: 'Hold to confirm send'
-- waitForAnimationToEnd:
+    id: 'send-confirm-button'
+- extendedWaitUntil:
+    visible:
+      id: 'send-success-text'
     timeout: 29000
-- assertVisible: 'Transaction Sent!'
 - tapOn: 'Back to Wallet'
 - runFlow: # sleeping till balance updates
     file: subflows/sleep.yml

--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -154,7 +154,7 @@ export default function Home() {
       case NETWORK_SPARK:
       case NETWORK_ARK_MUTINYNET:
       case NETWORK_STACKS:
-        router.push('/SendAccountBased');
+        router.push('/send');
         break;
       case NETWORK_LIQUID:
       case NETWORK_LIQUID_TESTNET:
@@ -233,18 +233,7 @@ export default function Home() {
   };
 
   const handleTokenPress = (token: CachedTokenInfo) => {
-    if (network === NETWORK_SPARK || network === NETWORK_STACKS) {
-      router.push({
-        pathname: '/SendTokenStacks',
-        params: {
-          tokenId: token.id,
-          tokenSymbol: token.symbol,
-          tokenName: token.name,
-          tokenDecimals: token.decimals.toString(),
-        },
-      });
-      return;
-    } else if (network === NETWORK_LIQUID || network === NETWORK_LIQUID_TESTNET) {
+    if (network === NETWORK_LIQUID || network === NETWORK_LIQUID_TESTNET) {
       router.push({
         pathname: '/SendLiquid',
         params: { assetId: token.id },

--- a/mobile/app/send/_layout.tsx
+++ b/mobile/app/send/_layout.tsx
@@ -40,6 +40,7 @@ export interface SendFlowContextData {
   amount: string;
   token?: string;
   denomination: Denomination;
+  memo: string;
 
   // Bitcoin-specific data
   bitcoin: BitcoinNetworkData | undefined;
@@ -53,6 +54,7 @@ export interface SendFlowContextData {
   setAmount: (amount: string) => void;
   setToken: (token?: string) => void;
   setDenomination: (denomination: Denomination) => void;
+  setMemo: (memo: string) => void;
   setCreatedTransaction: (transaction: CreatedTransaction | undefined) => void;
   reset: () => void;
 }
@@ -79,6 +81,7 @@ function SendFlowProvider({ children, initialNetwork }: SendFlowProviderProps) {
   const [amount, setAmount] = useState<string>('');
   const [token, setToken] = useState<string | undefined>(undefined);
   const [denomination, setDenomination] = useState<Denomination>('Native');
+  const [memo, setMemo] = useState<string>('');
 
   // Bitcoin-specific state
   const [btcSendData, setBtcSendData] = useState<BtcSendData | undefined>(undefined);
@@ -140,6 +143,7 @@ function SendFlowProvider({ children, initialNetwork }: SendFlowProviderProps) {
     setAmount('');
     setToken(undefined);
     setDenomination('Native');
+    setMemo('');
     setCreatedTransaction(undefined);
   };
 
@@ -164,6 +168,7 @@ function SendFlowProvider({ children, initialNetwork }: SendFlowProviderProps) {
         amount,
         token,
         denomination,
+        memo,
         bitcoin: bitcoinData,
         createdTransaction,
         setNetwork,
@@ -171,6 +176,7 @@ function SendFlowProvider({ children, initialNetwork }: SendFlowProviderProps) {
         setAmount,
         setToken,
         setDenomination,
+        setMemo,
         setCreatedTransaction,
         reset,
       }}
@@ -197,6 +203,7 @@ export default function SendLayout() {
         <Stack.Screen name="send-address" />
         <Stack.Screen name="send-amount-btc" />
         <Stack.Screen name="send-amount-evm" />
+        <Stack.Screen name="send-amount-acc" />
         <Stack.Screen name="send-confirm" />
       </Stack>
     </SendFlowProvider>

--- a/mobile/app/send/send-address.tsx
+++ b/mobile/app/send/send-address.tsx
@@ -9,15 +9,16 @@ import ScreenSendHeader from '@/components/navigation/ScreenSendHeader';
 import { ThemedText } from '@/components/ThemedText';
 import TokensView from '@/components/TokensView';
 import { ScanQrContext } from '@/src/hooks/ScanQrContext';
-import { getIsEVM, getTickerByNetwork } from '@shared/models/network-getters';
-import { CachedTokenInfo } from '@shared/types/token-info';
+import { getIsAccountBased, getIsEVM, getTickerByNetwork } from '@shared/models/network-getters';
 import { validateAddress } from '@shared/modules/wallet-utils';
+import { NETWORK_BITCOIN } from '@shared/types/networks';
+import { CachedTokenInfo } from '@shared/types/token-info';
 import { useSendFlow } from './_layout';
 
 const SendAddress: React.FC = () => {
   const { scanQr } = useContext(ScanQrContext);
   const router = useRouter();
-  const { network, address: contextAddress, setAddress: setContextAddress, token, setToken, setAmount } = useSendFlow();
+  const { network, address: contextAddress, setAddress: setContextAddress, token, setToken, setAmount, setDenomination, setMemo } = useSendFlow();
 
   const [localAddress, setLocalAddress] = useState(contextAddress);
   const [errorMessage, setErrorMessage] = useState<string>('');
@@ -49,16 +50,18 @@ const SendAddress: React.FC = () => {
     setErrorMessage('');
 
     try {
-      const isValid = validateAddress(network, localAddress);
-      if (isValid) {
-        setContextAddress(localAddress);
-        if (getIsEVM(network)) {
-          router.push('/send/send-amount-evm');
-        } else {
-          router.push('/send/send-amount-btc');
-        }
+      if (!validateAddress(network, localAddress)) {
+        throw new Error('Invalid address');
+      }
+      setContextAddress(localAddress);
+      if (getIsEVM(network)) {
+        router.push('/send/send-amount-evm');
+      } else if (getIsAccountBased(network)) {
+        router.push('/send/send-amount-acc');
+      } else if (network === NETWORK_BITCOIN) {
+        router.push('/send/send-amount-btc');
       } else {
-        setErrorMessage('Invalid address');
+        throw new Error('Invalid network');
       }
     } catch (error: any) {
       setErrorMessage(error.message || 'Failed to validate address');
@@ -70,8 +73,10 @@ const SendAddress: React.FC = () => {
   };
 
   const handleTokenPress = (clickedToken: CachedTokenInfo) => {
-    setToken(token ? undefined : clickedToken.id);
+    setToken(token === clickedToken.id ? undefined : clickedToken.id);
     setAmount('');
+    setDenomination('Native');
+    setMemo('');
   };
 
   return (
@@ -83,7 +88,7 @@ const SendAddress: React.FC = () => {
         <View style={styles.container}>
           <View style={styles.inputSection}>
             <View style={styles.inputContainer}>
-              <TouchableOpacity style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1}>
+              <TouchableOpacity style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-address-input">
                 <ThemedText style={styles.inputLabel}>To</ThemedText>
                 <TextInput
                   ref={inputRef}
@@ -111,7 +116,7 @@ const SendAddress: React.FC = () => {
 
           <TokensView onTokenPress={handleTokenPress} selectedToken={token} />
 
-          <TouchableOpacity style={[styles.continueButton, !localAddress.trim() && styles.disabledButton]} onPress={handleContinue} disabled={!localAddress.trim()}>
+          <TouchableOpacity style={[styles.continueButton, !localAddress.trim() && styles.disabledButton]} onPress={handleContinue} disabled={!localAddress.trim()} testID="send-address-next-button">
             <ThemedText style={styles.continueButtonText}>Next</ThemedText>
           </TouchableOpacity>
         </View>

--- a/mobile/app/send/send-amount-acc.tsx
+++ b/mobile/app/send/send-amount-acc.tsx
@@ -1,0 +1,203 @@
+import { Ionicons } from '@expo/vector-icons';
+import BigNumber from 'bignumber.js';
+import { Stack, useRouter } from 'expo-router';
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+
+import AmountInput from '@/components/AmountInput';
+import GradientScreen from '@/components/GradientScreen';
+import ScreenSendHeader from '@/components/navigation/ScreenSendHeader';
+import { ThemedText } from '@/components/ThemedText';
+import { SendAssetProps, withAsset } from '@/hooks/withAsset';
+import { formatBalance } from '@shared/modules/string-utils';
+import { validateAddress } from '@shared/modules/wallet-utils';
+import { useSendFlow } from './_layout';
+
+const SendAmountAcc: React.FC<SendAssetProps> = ({ balance, exchangeRate, ticker, token, decimals }) => {
+  const router = useRouter();
+  const { network, address: recipientAddress, amount: contextAmount, setAmount: setContextAmount, denomination, setDenomination, memo: contextMemo, setMemo: setContextMemo } = useSendFlow();
+
+  const [localAmount, setLocalAmount] = useState(contextAmount);
+  const [localMemo, setLocalMemo] = useState(contextMemo);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const formattedBalance = formatBalance(balance || '0', decimals);
+
+  const handleDenominationSwitch = () => {
+    if (exchangeRate) {
+      setDenomination(denomination === 'Native' ? 'Fiat' : 'Native');
+    }
+  };
+
+  const handleAmountChange = (text: string) => {
+    const normalized = text.replace(',', '.');
+    if (normalized === '' || /^\d*\.?\d*$/.test(normalized)) {
+      setLocalAmount(normalized);
+      setErrorMessage(null);
+    }
+  };
+
+  const handleMaxPress = () => {
+    if (!balance) return;
+    setLocalAmount(formattedBalance);
+  };
+
+  const validate = () => {
+    if (!recipientAddress?.trim()) return 'Recipient address is required';
+
+    try {
+      const isValid = validateAddress(network, recipientAddress);
+      if (!isValid) return 'Invalid recipient address';
+    } catch (error: any) {
+      return error.message || 'Invalid recipient address';
+    }
+
+    if (!localAmount) return 'Please enter an amount';
+    if (localAmount.includes('.') && localAmount.split('.')[1]?.length > decimals) {
+      return `Maximum ${decimals} decimal place${decimals !== 1 ? 's' : ''} allowed`;
+    }
+
+    const amt = parseFloat(localAmount);
+    if (isNaN(amt) || amt <= 0) return 'Amount must be greater than 0';
+    if (!balance) return 'Balance not loaded';
+
+    const amountInBase = new BigNumber(amt).multipliedBy(new BigNumber(10).pow(decimals));
+    if (amountInBase.isNaN() || amountInBase.lte(0)) return 'Invalid amount';
+    if (new BigNumber(balance).lt(amountInBase)) return 'Insufficient balance';
+    return null;
+  };
+
+  const handleNext = async () => {
+    // For account-based wallets, we don't create a transaction hex
+    // Instead, we store the amount and let send-confirm handle the actual payment
+    const err = validate();
+    if (err) {
+      setErrorMessage(err);
+      return;
+    }
+    setErrorMessage(null);
+    setContextAmount(localAmount);
+    setContextMemo(localMemo || '');
+    router.push('/send/send-confirm');
+  };
+
+  const buttonDisabled = !localAmount || !!errorMessage;
+
+  return (
+    <GradientScreen variant={network} scroll={true}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <ScreenSendHeader network={network} title={`Send ${ticker}`} />
+
+      <KeyboardAvoidingView style={styles.keyboardAvoidingView} behavior={Platform.OS === 'ios' ? 'padding' : 'height'} keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}>
+        <View style={styles.container}>
+          <View style={styles.inputSection}>
+            <AmountInput
+              value={localAmount}
+              onChangeText={handleAmountChange}
+              ticker={ticker}
+              balance={formattedBalance}
+              exchangeRate={exchangeRate !== undefined ? String(exchangeRate) : undefined}
+              denomination={denomination}
+              decimals={decimals}
+              onDenominationSwitch={handleDenominationSwitch}
+              onMaxPress={handleMaxPress}
+              onBalancePress={handleMaxPress}
+              testID="send-amount-acc-input"
+            />
+
+            {errorMessage && (
+              <View style={styles.errorContainer}>
+                <Ionicons name="close" size={16} color="white" />
+                <ThemedText style={styles.errorText}>{errorMessage}</ThemedText>
+              </View>
+            )}
+
+            {/* Memo field - only shown for Stacks STX token */}
+            {token?.id === 'STX' && (
+              <View style={styles.memoSection}>
+                <ThemedText style={styles.memoLabel}>Memo (optional)</ThemedText>
+                <TextInput
+                  style={styles.memoInput}
+                  value={localMemo}
+                  onChangeText={setLocalMemo}
+                  placeholder="Enter memo"
+                  placeholderTextColor="rgba(255, 255, 255, 0.6)"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  multiline={false}
+                />
+              </View>
+            )}
+          </View>
+
+          <TouchableOpacity style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleNext} disabled={buttonDisabled} testID="send-amount-acc-next-button">
+            <ThemedText style={styles.continueButtonText}>Next</ThemedText>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </GradientScreen>
+  );
+};
+
+export default withAsset(SendAmountAcc);
+
+const styles = StyleSheet.create({
+  keyboardAvoidingView: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+    justifyContent: 'space-between',
+  },
+  inputSection: {
+    marginBottom: 16,
+  },
+  errorContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+    gap: 6,
+  },
+  errorText: {
+    color: 'white',
+    fontSize: 14,
+  },
+  continueButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.3)',
+    paddingVertical: 16,
+    borderRadius: 16,
+    gap: 8,
+    marginTop: 'auto',
+  },
+  continueButtonText: {
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+  memoSection: {
+    marginTop: 24,
+  },
+  memoLabel: {
+    color: 'rgba(255, 255, 255, 0.8)',
+    fontSize: 14,
+    fontWeight: '500',
+    marginBottom: 8,
+  },
+  memoInput: {
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontSize: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.2)',
+  },
+});

--- a/mobile/app/send/send-amount-btc.tsx
+++ b/mobile/app/send/send-amount-btc.tsx
@@ -140,6 +140,7 @@ const SendAmountBtc: React.FC = () => {
     const normalized = text.replace(',', '.');
     if (normalized === '' || /^\d*\.?\d*$/.test(normalized)) {
       setLocalAmount(normalized);
+      setValidationError(null);
     }
   };
 
@@ -171,11 +172,16 @@ const SendAmountBtc: React.FC = () => {
 
   const validateAmount = () => {
     if (!localAmount || !balance) return { isValid: false, error: 'Please enter an amount' };
+    const networkDecimals = getDecimalsByNetwork(network);
+    if (localAmount.includes('.') && localAmount.split('.')[1]?.length > networkDecimals) {
+      return { isValid: false, error: `Maximum ${networkDecimals} decimal place${networkDecimals !== 1 ? 's' : ''} allowed` };
+    }
+
     const amt = parseFloat(localAmount);
     if (isNaN(amt) || amt <= 0) return { isValid: false, error: 'Amount must be greater than 0' };
 
     const satValueBN = new BigNumber(amt);
-    const satValue = satValueBN.multipliedBy(new BigNumber(10).pow(getDecimalsByNetwork(network))).toString(10);
+    const satValue = satValueBN.multipliedBy(new BigNumber(10).pow(networkDecimals)).toString(10);
     if (!new BigNumber(balance).gte(satValue)) {
       return { isValid: false, error: 'Insufficient balance' };
     }

--- a/mobile/app/send/send-amount-evm.tsx
+++ b/mobile/app/send/send-amount-evm.tsx
@@ -9,11 +9,11 @@ import AmountInput from '@/components/AmountInput';
 import GradientScreen from '@/components/GradientScreen';
 import ScreenSendHeader from '@/components/navigation/ScreenSendHeader';
 import { ThemedText } from '@/components/ThemedText';
+import { SendAssetProps, withAsset } from '@/hooks/withAsset';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { EvmWallet } from '@shared/class/evm-wallet';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { formatBalance } from '@shared/modules/string-utils';
-import { withAsset, SendAssetProps } from '@/hooks/withAsset';
 import { useSendFlow } from './_layout';
 
 const SendAmountEvm: React.FC<SendAssetProps> = ({ balance, exchangeRate, ticker, token, decimals }) => {
@@ -51,6 +51,9 @@ const SendAmountEvm: React.FC<SendAssetProps> = ({ balance, exchangeRate, ticker
     if (!recipientAddress?.trim()) return 'Recipient address is required';
     if (!EvmWallet.isAddressValid(recipientAddress)) return 'Invalid recipient address';
     if (!localAmount) return 'Please enter an amount';
+    if (localAmount.includes('.') && localAmount.split('.')[1]?.length > decimals) {
+      return `Maximum ${decimals} decimal place${decimals !== 1 ? 's' : ''} allowed`;
+    }
     const amt = parseFloat(localAmount);
     if (isNaN(amt) || amt <= 0) return 'Amount must be greater than 0';
     if (!balance) return 'Balance not loaded';

--- a/mobile/app/send/send-confirm.tsx
+++ b/mobile/app/send/send-confirm.tsx
@@ -1,7 +1,8 @@
 import { Ionicons } from '@expo/vector-icons';
+import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import { Redirect, Stack, useRouter } from 'expo-router';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { Alert, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import Animated, { Easing, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import Rive, { RiveRef } from 'rive-react-native';
@@ -9,19 +10,26 @@ import Rive, { RiveRef } from 'rive-react-native';
 import GradientScreen from '@/components/GradientScreen';
 import ScreenSendHeader from '@/components/navigation/ScreenSendHeader';
 import { ThemedText } from '@/components/ThemedText';
+import { SendAssetProps, withAsset } from '@/hooks/withAsset';
+import { BackgroundExecutor } from '@/src/modules/background-executor';
+import { walletCanHaveTokens } from '@/src/shared-link/class/wallets/interface-can-have-tokens';
 import * as BlueElectrum from '@shared/blue_modules/BlueElectrum';
 import { EvmWallet } from '@shared/class/evm-wallet';
+import { ArkWallet } from '@shared/class/wallets/ark-wallet';
+import { SparkWallet } from '@shared/class/wallets/spark-wallet';
+import { StacksWallet } from '@shared/class/wallets/stacks-wallet';
 import { getNetworkGradient } from '@shared/constants/Colors';
+import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { useCachedExchangeRate } from '@shared/hooks/useCachedExchangeRate';
-import { getDecimalsByNetwork, getIsEVM, getTickerByNetwork } from '@shared/models/network-getters';
+import { getDecimalsByNetwork, getIsAccountBased, getIsEVM, getTickerByNetwork } from '@shared/models/network-getters';
 import { formatBalance } from '@shared/modules/string-utils';
-import { NETWORK_BITCOIN } from '@shared/types/networks';
-import { withAsset, SendAssetProps } from '@/hooks/withAsset';
+import { NETWORK_ARK, NETWORK_ARK_MUTINYNET, NETWORK_BITCOIN, NETWORK_SPARK, NETWORK_STACKS } from '@shared/types/networks';
 import { useSendFlow } from './_layout';
 
 const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
   const router = useRouter();
-  const { network, address, amount, createdTransaction } = useSendFlow();
+  const { network, address, amount, createdTransaction, memo } = useSendFlow();
+  const { accountNumber } = useContext(AccountNumberContext);
   const { exchangeRate } = useCachedExchangeRate(network, 'USD');
 
   const [error, setError] = useState<string>('');
@@ -82,12 +90,12 @@ const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
   }, [isSuccess, detailsOpacity, sendToOpacity, totalTop]);
 
   // Redirect back in case no transaction is available
-  if (!createdTransaction) {
+  if (!getIsAccountBased(network) && !createdTransaction) {
     Alert.alert('No transaction available');
     return <Redirect href="/Home" />;
   }
 
-  const { txhex, actualFee } = createdTransaction;
+  const { txhex, actualFee } = createdTransaction ?? { txhex: undefined, actualFee: 0 };
   const networkDecimals = getDecimalsByNetwork(network);
   const nativeTicker = getTickerByNetwork(network);
   const feeInNative = formatBalance(String(actualFee), networkDecimals, 8);
@@ -112,7 +120,7 @@ const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
   } else {
     const totalAmount = BigNumber(amount).plus(feeInNativeUnits);
     totalUsd = exchangeRate ? `$${totalAmount.multipliedBy(Number(exchangeRate)).toFixed(2)}` : '';
-    totalDisplay = `${totalAmount.toString()} ${ticker}`;
+    totalDisplay = `${totalAmount.toFixed()} ${ticker}`;
   }
 
   const broadcast = async () => {
@@ -120,16 +128,38 @@ const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
     setError('');
 
     try {
-      if (network === NETWORK_BITCOIN) {
+      if (network === NETWORK_ARK || network === NETWORK_ARK_MUTINYNET || network === NETWORK_SPARK || network === NETWORK_STACKS) {
+        const wallet = await BackgroundExecutor.lazyInitWallet(network, accountNumber);
+        assert(wallet instanceof ArkWallet || wallet instanceof SparkWallet || wallet instanceof StacksWallet, 'Internal error: incorrect wallet instance');
+
+        // Check if we're sending a token and the wallet supports tokens
+        if (token && walletCanHaveTokens(wallet)) {
+          const tokenDecimals = token.decimals;
+          const amountInBase = BigInt(new BigNumber(amount).multipliedBy(new BigNumber(10).pow(tokenDecimals)).toString(10));
+          const transactionId = await wallet.transferToken(token.id, amountInBase, address, memo || undefined);
+          if (!transactionId) {
+            throw new Error('Transaction failed');
+          }
+        } else {
+          // Native coin transfer
+          const networkDecimals = getDecimalsByNetwork(network);
+          const amountInBase = new BigNumber(amount).multipliedBy(new BigNumber(10).pow(networkDecimals)).toString(10);
+          const transactionId = await wallet.pay(address, Number(amountInBase));
+          if (!transactionId) {
+            throw new Error('Transaction failed');
+          }
+        }
+      } else if (network === NETWORK_BITCOIN) {
+        assert(txhex, 'Transaction hex is required');
         if (!BlueElectrum.mainConnected) {
           await BlueElectrum.connectMain();
         }
-
         const result = await BlueElectrum.broadcastV2(txhex);
         if (!result) {
           throw new Error('Transaction broadcast failed');
         }
       } else if (getIsEVM(network)) {
+        assert(txhex, 'Transaction hex is required');
         const e = new EvmWallet();
         const txid = await e.broadcastTransaction(network, txhex);
         if (!txid || typeof txid !== 'string') {
@@ -169,7 +199,6 @@ const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
 
     return (
       <View style={styles.addressContainer}>
-        {/* First line - contains first 4 chars */}
         <ThemedText style={styles.addressDisplay} allowFontScaling={false}>
           <ThemedText style={[styles.addressHighlight, styles.addressLetterSpacing]} allowFontScaling={false}>
             {first4}
@@ -179,7 +208,6 @@ const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
             {firstHalf.substring(4)}
           </ThemedText>
         </ThemedText>
-        {/* Second line - contains last 4 chars */}
         <ThemedText style={styles.addressDisplay} allowFontScaling={false}>
           <ThemedText style={[styles.addressDisplay, styles.addressLetterSpacing]} allowFontScaling={false}>
             {secondHalf.substring(0, secondHalf.length - 4)}
@@ -202,7 +230,6 @@ const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
         <KeyboardAvoidingView style={styles.keyboardAvoidingView} behavior={Platform.OS === 'ios' ? 'padding' : 'height'} keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}>
           <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
             <View style={styles.container}>
-              {/* Rive Success Animation */}
               {showRiveAnimation && (
                 <View style={styles.riveContainer}>
                   <Rive
@@ -282,8 +309,10 @@ const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
           </ScrollView>
         </KeyboardAvoidingView>
         {!error && (
-          <TouchableOpacity style={[styles.sendButton, isBroadcasting && styles.disabledButton]} onPress={isSuccess ? handleHome : broadcast} disabled={isBroadcasting}>
-            <ThemedText style={styles.sendButtonText}>{isSuccess ? 'Back to Wallet' : isBroadcasting ? 'Sending...' : 'Confirm Send'}</ThemedText>
+          <TouchableOpacity style={[styles.sendButton, isBroadcasting && styles.disabledButton]} onPress={isSuccess ? handleHome : broadcast} disabled={isBroadcasting} testID="send-confirm-button">
+            <ThemedText style={styles.sendButtonText} testID={isSuccess ? 'send-success-text' : undefined}>
+              {isSuccess ? 'Back to Wallet' : isBroadcasting ? 'Sending...' : 'Confirm Send'}
+            </ThemedText>
           </TouchableOpacity>
         )}
       </View>

--- a/mobile/hooks/withAsset.tsx
+++ b/mobile/hooks/withAsset.tsx
@@ -1,14 +1,16 @@
 import React, { useContext } from 'react';
+
+import { useSendFlow } from '@/app/send/_layout';
+import { LayerzStorage } from '@/src/class/layerz-storage';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { useExchangeRate } from '@shared/hooks/useExchangeRate';
 import { useTokenBalance } from '@shared/hooks/useTokenBalance';
+import { useTokenDiscovery } from '@shared/hooks/useTokenDiscovery';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
-import { getTokenInfo } from '@shared/models/token-list';
-import { TokenInfo } from '@shared/types/token-info';
 import { StringNumber } from '@shared/types/string-number';
-import { useSendFlow } from '@/app/send/_layout';
+import { TokenInfo } from '@shared/types/token-info';
 
 export interface SendAssetProps {
   balance: StringNumber | undefined;
@@ -26,7 +28,12 @@ export const withAsset = <P extends object>(Component: React.ComponentType<P & S
     const { network, token } = useSendFlow();
     const { accountNumber } = useContext(AccountNumberContext);
     const { balance: tokenBalance } = useTokenBalance(network, accountNumber, token!, BackgroundExecutor);
-    const tokenInfo = getTokenInfo(token!);
+    const { tokenList } = useTokenDiscovery(network, accountNumber, BackgroundExecutor, LayerzStorage);
+    const tokenInfo = tokenList.find((t) => t.id === token);
+
+    if (!tokenInfo) {
+      return null;
+    }
 
     return (
       <Component

--- a/shared/hooks/useTokenDiscovery.ts
+++ b/shared/hooks/useTokenDiscovery.ts
@@ -1,122 +1,115 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { Networks, NETWORK_SPARK, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_STACKS } from '../types/networks';
-import { CachedTokenInfo } from '../types/token-info';
+import assert from 'assert';
+import useSWR from 'swr';
+
+import { SparkWallet } from '../class/wallets/spark-wallet';
+import { StacksWallet } from '../class/wallets/stacks-wallet';
 import { getTokenList } from '../models/token-list';
 import { IBackgroundCaller } from '../types/IBackgroundCaller';
-import { SparkWallet } from '../class/wallets/spark-wallet';
-import assert from 'assert';
 import { IStorage } from '../types/IStorage';
-import { StacksWallet } from '../class/wallets/stacks-wallet';
+import { NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_SPARK, NETWORK_STACKS, Networks } from '../types/networks';
+import { CachedTokenInfo } from '../types/token-info';
 
 const STORAGE_KEY_CACHED_TOKEN_LIST = 'STORAGE_KEY_CACHED_TOKEN_LIST_V2';
 
+interface tokenDiscoveryFetcherArg {
+  cacheKey: string;
+  network: Networks;
+  accountNumber: number;
+  backgroundCaller: IBackgroundCaller;
+  storage: IStorage;
+}
+
+/**
+ * returns cached tokens from storage if present, null otherwise
+ */
+async function restoreCachedTokens(cacheKey: string, storage: IStorage): Promise<CachedTokenInfo[] | null> {
+  try {
+    const cachedTokensString = await storage.getItem(cacheKey);
+    const cachedTokens = JSON.parse(cachedTokensString);
+    if (Array.isArray(cachedTokens) && cachedTokens.length > 0) {
+      return cachedTokens;
+    }
+  } catch (_) {}
+  return null;
+}
+
+export const tokenDiscoveryFetcher = async (arg: tokenDiscoveryFetcherArg): Promise<CachedTokenInfo[]> => {
+  const { network, accountNumber, backgroundCaller, storage } = arg;
+
+  if (network === NETWORK_SPARK) {
+    const cacheKey = STORAGE_KEY_CACHED_TOKEN_LIST + network + accountNumber;
+
+    if (!backgroundCaller.lazyInitWalletReady(network, accountNumber)) {
+      // wallet not ready, definitely can use cached tokens (if any)
+      const cachedTokens = await restoreCachedTokens(cacheKey, storage);
+      if (cachedTokens) return cachedTokens;
+    }
+
+    // Lazy initialize Spark wallet
+    const wallet = await backgroundCaller.lazyInitWallet(network, accountNumber);
+    assert(wallet instanceof SparkWallet, 'Not a Spark wallet');
+
+    // we do NOT fetch from network, we rely on cached value inside wallet internals
+    if (!wallet._lastBalanceFetch) {
+      // balance never fetched yet, so we can use cached tokens (if any)
+      const cachedTokens = await restoreCachedTokens(cacheKey, storage);
+      if (cachedTokens) return cachedTokens;
+    }
+
+    const tokenInfos: CachedTokenInfo[] = wallet.getTokenBalances();
+    if (tokenInfos.length > 0) {
+      await storage.setItem(cacheKey, JSON.stringify(tokenInfos)); // saving to cache
+    }
+    return tokenInfos;
+  } else if (network === NETWORK_STACKS) {
+    const wallet = await backgroundCaller.lazyInitWallet(network, accountNumber);
+    assert(wallet instanceof StacksWallet, 'Not a Stacks wallet');
+
+    await wallet.fetchTokenBalances();
+    const tokenInfos: CachedTokenInfo[] = [];
+    for (const token of wallet.getTokenBalances()) {
+      tokenInfos.push(token);
+    }
+
+    return tokenInfos;
+  } else if (network === NETWORK_LIQUID || network === NETWORK_LIQUID_TESTNET) {
+    const tokens = getTokenList(network).map((token) => ({
+      ...token,
+      balance: undefined,
+    }));
+    return tokens;
+  } else {
+    // For all other networks, return the standard token list
+    // Adapt TokenInfo[] to CachedTokenInfo[] by adding a default balance
+    const tokens = getTokenList(network).map((token) => ({
+      ...token,
+      balance: undefined,
+    }));
+    return tokens;
+  }
+};
+
 export function useTokenDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, storage: IStorage, refreshInterval = 5_000) {
-  const [tokenList, setTokenList] = useState<CachedTokenInfo[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-  const intervalRef = useRef<NodeJS.Timeout | number | null>(null);
+  // Only enable refresh interval for NETWORK_SPARK & NETWORK_STACKS
+  const shouldRefresh = network === NETWORK_SPARK || network === NETWORK_STACKS;
 
-  /**
-   * returns true if cached tokens are present, and successfully restored to state, false otherwise
-   */
-  const restoreCachedTokens = useCallback(
-    async (cacheKey: string) => {
-      try {
-        const cachedTokensString = await storage.getItem(cacheKey);
-        const cachedTokens = JSON.parse(cachedTokensString);
-        if (Array.isArray(cachedTokens) && cachedTokens.length > 0) {
-          setTokenList(cachedTokens);
-          return true;
-        }
-      } catch (_) {}
-      return false;
-    },
-    [storage]
-  );
+  const arg: tokenDiscoveryFetcherArg = {
+    cacheKey: 'tokenDiscoveryFetcher',
+    network,
+    accountNumber,
+    backgroundCaller,
+    storage,
+  };
 
-  const fetchTokens = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      setError(null);
-
-      if (network === NETWORK_SPARK) {
-        const cacheKey = STORAGE_KEY_CACHED_TOKEN_LIST + network + accountNumber;
-
-        if (!backgroundCaller.lazyInitWalletReady(network, accountNumber)) {
-          // wallet not ready, definately can use cached tokens (if any)
-          if (await restoreCachedTokens(cacheKey)) return;
-        }
-
-        // Lazy initialize Spark wallet
-        const wallet = await backgroundCaller.lazyInitWallet(network, accountNumber);
-        assert(wallet instanceof SparkWallet, 'Not a Spark wallet');
-
-        // we do NOT fetch from network, we rely on cached value inside wallet internals
-
-        if (!wallet._lastBalanceFetch) {
-          // balance never fetched yet, so we can use cached tokens (if any)
-          if (await restoreCachedTokens(cacheKey)) return;
-        }
-
-        const tokenInfos: CachedTokenInfo[] = wallet.getTokenBalances();
-
-        if (tokenInfos.length > 0) await storage.setItem(cacheKey, JSON.stringify(tokenInfos)); // saving to cache
-
-        setTokenList(tokenInfos);
-      } else if (network === NETWORK_STACKS) {
-        const wallet = await backgroundCaller.lazyInitWallet(network, accountNumber);
-        assert(wallet instanceof StacksWallet, 'Not a Stacks wallet');
-
-        await wallet.fetchTokenBalances();
-        const tokenInfos: CachedTokenInfo[] = [];
-        for (const token of wallet.getTokenBalances()) {
-          tokenInfos.push(token);
-        }
-
-        setTokenList(tokenInfos);
-      } else if (network === NETWORK_LIQUID || network === NETWORK_LIQUID_TESTNET) {
-        const tokens = getTokenList(network).map((token) => ({
-          ...token,
-          balance: undefined,
-        }));
-        setTokenList(tokens);
-      } else {
-        // For all other networks, return the standard token list
-        // Adapt TokenInfo[] to CachedTokenInfo[] by adding a default balance
-        const tokens = getTokenList(network).map((token) => ({
-          ...token,
-          balance: undefined,
-        }));
-        setTokenList(tokens);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error('Unknown error'));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [network, accountNumber, backgroundCaller, restoreCachedTokens, storage]);
-
-  useEffect(() => {
-    // Initial fetch
-    fetchTokens();
-
-    // Set up periodic refresh only for NETWORK_SPARK & NETWORK_STACKS
-    if (network === NETWORK_SPARK || network === NETWORK_STACKS) {
-      intervalRef.current = setInterval(fetchTokens, refreshInterval);
-    }
-
-    // Cleanup
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    };
-  }, [fetchTokens, refreshInterval, network]);
+  const { data, error, isLoading } = useSWR(arg, tokenDiscoveryFetcher, {
+    refreshInterval: shouldRefresh ? refreshInterval : undefined,
+    refreshWhenHidden: false,
+    keepPreviousData: true,
+  });
 
   return {
-    tokenList,
+    tokenList: data ?? [],
     isLoading,
-    error,
+    error: error instanceof Error ? error : error ? new Error('Unknown error') : null,
   };
 }

--- a/shared/models/network-getters.ts
+++ b/shared/models/network-getters.ts
@@ -1,8 +1,8 @@
 import BigNumber from 'bignumber.js';
 import { ethers } from 'ethers';
 
-import { getAvailableNetworks, NETWORK_BITCOIN, Networks } from '../types/networks';
 import { hexStr } from '../modules/string-utils';
+import { getAvailableNetworks, NETWORK_ARK, NETWORK_ARK_MUTINYNET, NETWORK_BITCOIN, NETWORK_SPARK, NETWORK_STACKS, Networks } from '../types/networks';
 import { AllNetworkInfos } from './all-network-infos';
 
 /**
@@ -93,4 +93,8 @@ export function getIsEVM(network: Networks): boolean {
   }
 
   return Boolean(AllNetworkInfos[network].isEVM);
+}
+
+export function getIsAccountBased(network: Networks): boolean {
+  return network === NETWORK_ARK || network === NETWORK_ARK_MUTINYNET || network === NETWORK_SPARK || network === NETWORK_STACKS;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a unified account-based send flow (Ark/Spark/Stacks) with new amount screen and memo, updates confirm to broadcast native/token sends, refactors token discovery to SWR, and updates routing and Maestro tests.
> 
> - **Send Flow (mobile/app/send)**:
>   - Add account-based amount screen `send-amount-acc` with validation, MAX, denomination toggle, optional memo for STX, and testIDs.
>   - Extend context `_layout.tsx` with `memo`, new setters, reset logic, and register `send-amount-acc` route.
>   - Update `send-address` to validate, add testIDs, reset state on token toggle, and route by network (`EVM`/`account-based`/`BTC`).
>   - Enhance `send-amount-btc`/`send-amount-evm` validation (decimal limits) and minor UX tweaks.
>   - Update `send-confirm` to handle broadcasting for `ARK/SPARK/STACKS` (native and token via `walletCanHaveTokens`), BTC via Electrum, EVM via `EvmWallet`; add testIDs for confirm/success.
> - **Navigation & Home (mobile/app/Home.tsx)**:
>   - Route all supported networks’ Send to unified `/send`; token taps navigate to `/send` except Liquid which keeps `/SendLiquid`.
> - **Testing (mobile/.maestro)**:
>   - Adjust Spark and token send flows to new testIDs and step order; wait for animations and success text.
> - **Asset/Token plumbing**:
>   - Refactor `withAsset` to use `useTokenDiscovery` and runtime token list; remove static token getter.
>   - Rewrite `useTokenDiscovery` to SWR-based fetcher with caching and periodic refresh (Spark/Stacks), plus Liquid static list handling.
> - **Network utils**:
>   - Add `getIsAccountBased` to `shared/models/network-getters` for routing/logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc7c6021a49e4bab5d3ef26db879d22387e671b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->