### PR TITLE
fix: send bitcoin for large wallets

### DIFF
--- a/ext/src/modules/background-message-controller.ts
+++ b/ext/src/modules/background-message-controller.ts
@@ -15,6 +15,7 @@ import { SecureStorage } from '../class/secure-storage';
 import { encrypt } from '../modules/encryption';
 import { ArkWallet } from '@shared/class/wallets/ark-wallet';
 import { StacksWallet } from '@shared/class/wallets/stacks-wallet';
+import { HDSegwitBech32Wallet } from '@shared/class/wallets/hd-segwit-bech32-wallet';
 
 // All possible background messages with their params
 type TBackgroundMessage = { [K in keyof MessageTypeMap]: { type: K; params: MessageTypeMap[K]['params'] } }[keyof MessageTypeMap];
@@ -173,8 +174,18 @@ export const BackgroundExtensionExecutor: Pick<IBackgroundCaller, TMethods> = {
     const changeAddress = await wallet.getChangeAddressAsync();
     const utxos = wallet.getUtxo();
     await saveWalletState(LayerzStorage, wallet, NETWORK_BITCOIN, accountNumber);
+    assert(wallet._hdWalletInstance instanceof HDSegwitBech32Wallet, 'Internal error: not an instance of HDSegwitBech32Wallet');
 
-    return { utxos, changeAddress };
+    return {
+      utxos,
+      changeAddress,
+      extraProperties: {
+        internal_addresses_cache: wallet._hdWalletInstance.internal_addresses_cache,
+        external_addresses_cache: wallet._hdWalletInstance.external_addresses_cache,
+        next_free_address_index: wallet._hdWalletInstance.next_free_address_index,
+        next_free_change_address_index: wallet._hdWalletInstance.next_free_change_address_index,
+      },
+    };
   },
 
   async clear() {

--- a/ext/src/pages/Popup/SendBtc.tsx
+++ b/ext/src/pages/Popup/SendBtc.tsx
@@ -8,7 +8,7 @@ import { useNavigate, useLocation } from 'react-router';
 import * as BlueElectrum from '@shared/blue_modules/BlueElectrum';
 import { TFeeEstimate } from '@shared/blue_modules/BlueElectrum';
 import { HDSegwitBech32Wallet } from '@shared/class/wallets/hd-segwit-bech32-wallet';
-import { CreateTransactionTarget, CreateTransactionUtxo } from '@shared/class/wallets/types';
+import { CreateTransactionTarget } from '@shared/class/wallets/types';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { NETWORK_SPARK, Networks } from '@shared/types/networks';
@@ -22,6 +22,7 @@ import { useScanQR } from '../../hooks/ScanQrContext';
 import { BackgroundCaller } from '../../modules/background-caller';
 import { Button, HodlButton, Input, Modal, RadioButton, WideButton } from './DesignSystem';
 import ClipboardBackdoor from './components/ClipboardBackdoor';
+import { GetBtcSendDataResponse } from '@shared/types/IBackgroundCaller';
 
 type TFeeRateOptions = { [rate: number]: number };
 
@@ -43,7 +44,7 @@ const SendBtc: React.FC = () => {
   const [sendState, setSendState] = useState<'idle' | 'preparing' | 'prepared' | 'success'>('idle');
   const [customFeeRate, setCustomFeeRate] = useState<number | undefined>(); // fee rate that user selected
   const [estimateFees, setEstimateFees] = useState<undefined | TFeeEstimate>(); // estimated fees that we are loading from electrum
-  const [sendData, setSendData] = useState<undefined | { utxos: CreateTransactionUtxo[]; changeAddress: string }>(undefined);
+  const [sendData, setSendData] = useState<undefined | GetBtcSendDataResponse>(undefined);
   const [txhex, setTxhex] = useState<string>('');
   const [actualFee, setActualFee] = useState<number>();
   const { network, setNetwork } = useContext(NetworkContext);
@@ -204,6 +205,12 @@ const SendBtc: React.FC = () => {
           value: Number(satValue),
         },
       ];
+
+      // setting up internals of a wallet to properly function:
+      for (const [key, value] of Object.entries(sendData.extraProperties)) {
+        (w as any)[key] = value;
+      }
+
       const { tx, fee } = w.createTransaction(sendData.utxos, targets, feeRate, sendData.changeAddress);
       assert(tx, 'Internal error: Wallet.createTransaction failed');
       setTxhex(tx.toHex());

--- a/mobile/app/send/_layout.tsx
+++ b/mobile/app/send/_layout.tsx
@@ -9,12 +9,10 @@ import { HDSegwitBech32Wallet } from '@shared/class/wallets/hd-segwit-bech32-wal
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { NETWORK_BITCOIN, Networks } from '@shared/types/networks';
+import { GetBtcSendDataResponse } from '@shared/types/IBackgroundCaller';
 
 // Bitcoin-specific data types
-export interface BtcSendData {
-  utxos: any[];
-  changeAddress: string;
-}
+export type BtcSendData = GetBtcSendDataResponse;
 
 export interface CreatedTransaction {
   txhex: string;

--- a/mobile/app/send/send-amount-btc.tsx
+++ b/mobile/app/send/send-amount-btc.tsx
@@ -242,6 +242,11 @@ const SendAmountBtc: React.FC = () => {
           },
         ];
 
+        // setting up internals of a wallet to properly function:
+        for (const [key, value] of Object.entries(sendData.extraProperties)) {
+          (wallet as any)[key] = value;
+        }
+
         const { tx, fee } = wallet.createTransaction(sendData.utxos, targets, feeRate, sendData.changeAddress);
 
         if (!tx) {

--- a/mobile/src/modules/background-executor.ts
+++ b/mobile/src/modules/background-executor.ts
@@ -27,6 +27,7 @@ import { SecureStorage } from '../class/secure-storage';
 import { decrypt, encrypt } from '../modules/encryption';
 import { ArkWallet } from '@shared/class/wallets/ark-wallet';
 import { StacksWallet } from '@shared/class/wallets/stacks-wallet';
+import { HDSegwitBech32Wallet } from '@shared/class/wallets/hd-segwit-bech32-wallet';
 
 /**
  * A drop-in replacement for BackgroundCaller in `ext` project. Since we have only one js context on mobile,
@@ -242,9 +243,16 @@ export const BackgroundExecutor: IBackgroundCaller = {
     const changeAddress = await wallet.getChangeAddressAsync();
     const utxos = wallet.getUtxo();
     await saveWalletState(LayerzStorage, wallet, NETWORK_BITCOIN, accountNumber);
+    assert(wallet._hdWalletInstance instanceof HDSegwitBech32Wallet, 'Internal error: not an instance of HDSegwitBech32Wallet');
     return {
       utxos,
       changeAddress,
+      extraProperties: {
+        internal_addresses_cache: wallet._hdWalletInstance.internal_addresses_cache,
+        external_addresses_cache: wallet._hdWalletInstance.external_addresses_cache,
+        next_free_address_index: wallet._hdWalletInstance.next_free_address_index,
+        next_free_change_address_index: wallet._hdWalletInstance.next_free_change_address_index,
+      },
     };
   },
 

--- a/shared/modules/wallet-serializer.ts
+++ b/shared/modules/wallet-serializer.ts
@@ -60,7 +60,8 @@ export class WalletSerializer {
     'next_free_address_index',
     'next_free_change_address_index',
     'unconfirmed_balance',
-    'unconfirmed_balance',
+    'external_addresses_cache',
+    'internal_addresses_cache',
   ];
 
   // Properties specific to WatchOnlyWallet

--- a/shared/types/IBackgroundCaller.ts
+++ b/shared/types/IBackgroundCaller.ts
@@ -93,7 +93,20 @@ export type LogRequest = [data: string];
 export type OpenPopupRequest = [method: string, params: any, id: number, from: string];
 
 export type GetBtcSendDataRequest = [accountNumber: number];
-export type GetBtcSendDataResponse = { utxos: CreateTransactionUtxo[]; changeAddress: string };
+export type GetBtcSendDataResponse = {
+  utxos: CreateTransactionUtxo[];
+  changeAddress: string;
+  /**
+   * those properties need to be set-up so the freshly-instantiated wallet object will
+   * be able to craft the transaction
+   */
+  extraProperties: {
+    internal_addresses_cache: Record<number, string>;
+    external_addresses_cache: Record<number, string>;
+    next_free_address_index: number;
+    next_free_change_address_index: number;
+  };
+};
 
 export type GetCommonTransactionsRequest = [network: Networks, accountNumber: number, afterTxid?: string, limit?: number];
 export type GetCommonTransactionsResponse = CommonTransaction[];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> BTC send flow now passes address caches and index metadata from background to UI and injects them into the HD wallet before building transactions, fixing failures on large wallets (ext + mobile).
> 
> - **Bitcoin send flow**
>   - Background `getBtcSendData` now returns `extraProperties` with `internal_addresses_cache`, `external_addresses_cache`, `next_free_address_index`, `next_free_change_address_index` alongside `utxos` and `changeAddress`.
>   - Added assertion that underlying `_hdWalletInstance` is `HDSegwitBech32Wallet`.
> - **Extension UI (`SendBtc.tsx`)**
>   - Switched to `GetBtcSendDataResponse` type.
>   - Before `createTransaction`, injects `extraProperties` into the `HDSegwitBech32Wallet` instance.
> - **Mobile**
>   - `BackgroundExecutor.getBtcSendData` mirrors background changes and returns `extraProperties`.
>   - Send flow (`_layout.tsx`, `send-amount-btc.tsx`) adopts new type and injects `extraProperties` prior to transaction creation.
> - **Serialization**
>   - `wallet-serializer` now includes `external_addresses_cache` and `internal_addresses_cache` in HD wallet properties.
> - **Types**
>   - `shared/types/IBackgroundCaller` updated with new `GetBtcSendDataResponse` shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fff70be296cb722b2ceaa2faab890a80c98ca0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->