### PR TITLE
chore: bump spark

### DIFF
--- a/ext/package-lock.json
+++ b/ext/package-lock.json
@@ -13,7 +13,7 @@
         "@arkade-os/sdk": "0.3.4",
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@breeztech/breez-sdk-liquid": "0.11.9",
-        "@buildonspark/spark-sdk": "0.4.3",
+        "@buildonspark/spark-sdk": "0.4.5",
         "@metamask/eth-sig-util": "4.0.1",
         "@noble/hashes": "1.7.1",
         "@noble/secp256k1": "1.6.3",
@@ -2525,12 +2525,11 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@buildonspark/spark-sdk": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.4.3.tgz",
-      "integrity": "sha512-CSV3xI5fBKdy4xeGpl2CgYuKX2Qx2+QU0xpjDM+dGGR7OqOffXNboQRW2YL6e7/siGDWx8w+Aboxp+knQokYRA==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.4.5.tgz",
+      "integrity": "sha512-OWizr7u21f9JYUhorLAaLWAT6cTeznGAJisk5uwBSzSN2uKdWAgw+M1Coof6VWry3uWaXtNFhQjesvQHfk5Acw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bitcoinerlab/secp256k1": "^1.1.1",
         "@bufbuild/protobuf": "^2.2.5",
         "@lightsparkdev/core": "^1.4.4",
         "@noble/curves": "^1.8.0",
@@ -2564,6 +2563,7 @@
         "nice-grpc-opentelemetry": "^0.1.18",
         "nice-grpc-web": "^3.3.7",
         "ts-proto": "^2.6.1",
+        "ua-parser-js": "^2.0.6",
         "uuidv7": "^1.0.2"
       },
       "engines": {
@@ -3131,9 +3131,9 @@
       }
     },
     "node_modules/@ecies/ciphers": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.3.tgz",
-      "integrity": "sha512-tapn6XhOueMwht3E2UzY0ZZjYokdaw9XtL9kEyjhQ/Fb9vL9xTFbOaI+fV0AWvTpYu4BNloC6getKW6NtSg4mA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz",
+      "integrity": "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==",
       "license": "MIT",
       "engines": {
         "bun": ">=1",
@@ -10345,6 +10345,26 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -10873,14 +10893,14 @@
       }
     },
     "node_modules/eciesjs": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.15.tgz",
-      "integrity": "sha512-r6kEJXDKecVOCj2nLMuXK/FCPeurW33+3JRpfXVbjLja3XUYFfD9I/JBreH6sUyzcm3G/YQboBjMla6poKeSdA==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.16.tgz",
+      "integrity": "sha512-dS5cbA9rA2VR4Ybuvhg6jvdmp46ubLn3E+px8cG/35aEDNclrqoCjg6mt0HYZ/M+OoESS3jSkCrqk1kWAEhWAw==",
       "license": "MIT",
       "dependencies": {
-        "@ecies/ciphers": "^0.2.3",
+        "@ecies/ciphers": "^0.2.4",
         "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.1",
+        "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0"
       },
       "engines": {
@@ -10890,9 +10910,9 @@
       }
     },
     "node_modules/eciesjs/node_modules/@noble/curves": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
-      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -14475,6 +14495,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -20927,6 +20967,57 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.6.tgz",
+      "integrity": "sha512-EmaxXfltJaDW75SokrY4/lXMrVyXomE/0FpIIqP2Ctic93gK7rlme55Cwkz8l3YZ6gqf94fCU7AnIkidd/KXPg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {

--- a/ext/package.json
+++ b/ext/package.json
@@ -25,7 +25,7 @@
     "@arkade-os/sdk": "0.3.4",
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@breeztech/breez-sdk-liquid": "0.11.9",
-    "@buildonspark/spark-sdk": "0.4.3",
+    "@buildonspark/spark-sdk": "0.4.5",
     "@metamask/eth-sig-util": "4.0.1",
     "@noble/hashes": "1.7.1",
     "@noble/secp256k1": "1.6.3",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -15,7 +15,7 @@
         "@breeztech/breez-sdk-liquid": "0.11.9",
         "@breeztech/react-native-breez-sdk-liquid": "0.11.9",
         "@bugsnag/expo": "^54.0.0",
-        "@buildonspark/spark-sdk": "0.4.3",
+        "@buildonspark/spark-sdk": "0.4.5",
         "@expo/vector-icons": "^15.0.2",
         "@metamask/eth-sig-util": "8.2.0",
         "@noble/curves": "2.0.0",
@@ -2052,12 +2052,11 @@
       }
     },
     "node_modules/@buildonspark/spark-sdk": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.4.3.tgz",
-      "integrity": "sha512-CSV3xI5fBKdy4xeGpl2CgYuKX2Qx2+QU0xpjDM+dGGR7OqOffXNboQRW2YL6e7/siGDWx8w+Aboxp+knQokYRA==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.4.5.tgz",
+      "integrity": "sha512-OWizr7u21f9JYUhorLAaLWAT6cTeznGAJisk5uwBSzSN2uKdWAgw+M1Coof6VWry3uWaXtNFhQjesvQHfk5Acw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bitcoinerlab/secp256k1": "^1.1.1",
         "@bufbuild/protobuf": "^2.2.5",
         "@lightsparkdev/core": "^1.4.4",
         "@noble/curves": "^1.8.0",
@@ -2091,6 +2090,7 @@
         "nice-grpc-opentelemetry": "^0.1.18",
         "nice-grpc-web": "^3.3.7",
         "ts-proto": "^2.6.1",
+        "ua-parser-js": "^2.0.6",
         "uuidv7": "^1.0.2"
       },
       "engines": {
@@ -2128,6 +2128,37 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@buildonspark/spark-sdk/node_modules/ua-parser-js": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.6.tgz",
+      "integrity": "sha512-EmaxXfltJaDW75SokrY4/lXMrVyXomE/0FpIIqP2Ctic93gK7rlme55Cwkz8l3YZ6gqf94fCU7AnIkidd/KXPg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
@@ -2139,9 +2170,9 @@
       }
     },
     "node_modules/@ecies/ciphers": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.4.tgz",
-      "integrity": "sha512-t+iX+Wf5nRKyNzk8dviW3Ikb/280+aEJAnw9YXvCp2tYGPSkMki+NRY+8aNLmVFv3eNtMdvViPNOPxS8SZNP+w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz",
+      "integrity": "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==",
       "license": "MIT",
       "engines": {
         "bun": ">=1",
@@ -10508,6 +10539,26 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -10737,14 +10788,14 @@
       "license": "MIT"
     },
     "node_modules/eciesjs": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.15.tgz",
-      "integrity": "sha512-r6kEJXDKecVOCj2nLMuXK/FCPeurW33+3JRpfXVbjLja3XUYFfD9I/JBreH6sUyzcm3G/YQboBjMla6poKeSdA==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.16.tgz",
+      "integrity": "sha512-dS5cbA9rA2VR4Ybuvhg6jvdmp46ubLn3E+px8cG/35aEDNclrqoCjg6mt0HYZ/M+OoESS3jSkCrqk1kWAEhWAw==",
       "license": "MIT",
       "dependencies": {
-        "@ecies/ciphers": "^0.2.3",
+        "@ecies/ciphers": "^0.2.4",
         "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.1",
+        "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0"
       },
       "engines": {
@@ -14436,6 +14487,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -22154,6 +22225,26 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.41",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -39,7 +39,7 @@
     "@breeztech/breez-sdk-liquid": "0.11.9",
     "@breeztech/react-native-breez-sdk-liquid": "0.11.9",
     "@bugsnag/expo": "^54.0.0",
-    "@buildonspark/spark-sdk": "0.4.3",
+    "@buildonspark/spark-sdk": "0.4.5",
     "@expo/vector-icons": "^15.0.2",
     "@metamask/eth-sig-util": "8.2.0",
     "@noble/curves": "2.0.0",

--- a/mobile/src/modules/spark-adapter.ts
+++ b/mobile/src/modules/spark-adapter.ts
@@ -1,12 +1,11 @@
-import { ReactNativeSparkSigner, SparkWallet as NativeSDK } from '@buildonspark/spark-sdk/native';
+import { DefaultSparkSigner, SparkWallet as NativeSDK } from '@buildonspark/spark-sdk/native';
 import { ISparkAdapter } from '@shared/class/wallets/spark-wallet';
 
 class SparkAdapter implements ISparkAdapter {
   initialize(...args: Parameters<ISparkAdapter['initialize']>) {
     const sparkWalletProps = args[0];
     return NativeSDK.initialize({
-      // @ts-ignore some types incompatibility between regular signer and RN signer
-      signer: new ReactNativeSparkSigner(),
+      signer: new DefaultSparkSigner(),
       ...sparkWalletProps,
     }) as unknown as ReturnType<ISparkAdapter['initialize']>;
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrades @buildonspark/spark-sdk to 0.4.5 across ext and mobile, updates the mobile spark adapter to use DefaultSparkSigner, and refreshes lockfiles (adding ua-parser-js and bumping crypto libs).
> 
> - **Dependencies**:
>   - Bump `@buildonspark/spark-sdk` to `0.4.5` in `ext/package.json` and `mobile/package.json`.
>   - Lockfile updates: add `ua-parser-js` (and `detect-europe-js`, `is-standalone-pwa`, `ua-is-frozen`); upgrade `eciesjs` and `@ecies/ciphers`; update `@noble/curves`.
> - **Mobile**:
>   - Switch `mobile/src/modules/spark-adapter.ts` to `DefaultSparkSigner` in `NativeSDK.initialize`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caa9effb0befe34b77e31c08bed05051e9c70f97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->