### PR TITLE
fix: add scroll to seed backup screen

### DIFF
--- a/mobile/app/SeedBackup.tsx
+++ b/mobile/app/SeedBackup.tsx
@@ -224,7 +224,7 @@ export default function SeedBackupScreen() {
 
   if (verificationComplete) {
     return (
-      <GradientScreen variant={network}>
+      <GradientScreen variant={network} scroll={true}>
         <ScreenHeader title="Recovery Phrase" onBackPress={handleBackFromVerification} />
         <View style={styles.verificationCompleteContainer}>
           <View style={styles.successIconContainer}>
@@ -242,7 +242,7 @@ export default function SeedBackupScreen() {
 
   if (isVerifying) {
     return (
-      <GradientScreen variant={network}>
+      <GradientScreen variant={network} scroll={true}>
         <ScreenHeader title="Verify Recovery Phrase" onBackPress={handleBackFromVerification} />
         <View style={styles.verificationContainer}>
           <View style={styles.verificationHeader}>
@@ -271,7 +271,7 @@ export default function SeedBackupScreen() {
   }
 
   return (
-    <GradientScreen variant={network}>
+    <GradientScreen variant={network} scroll={true}>
       <ScreenHeader title="Recovery Phrase" />
       <View style={styles.container}>
         <View style={styles.warningSection}>


### PR DESCRIPTION
Without scrolling, the seed phrase will be cut off on small screens

Before and After:

<img width="300"  alt="Simulator Screenshot - iPhone 16 - 2025-11-20 at 11 51 53" src="https://github.com/user-attachments/assets/0934bcff-0dbe-45ef-b4ca-ec67141c4952" />

<img width="300"  alt="Simulator Screenshot - iPhone 16 - 2025-11-20 at 11 52 17" src="https://github.com/user-attachments/assets/e184bccd-f422-4503-ac2a-8a598279117d" />
