### PR TITLE
fix: use screen dimensions

### DIFF
--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -52,7 +52,7 @@ const Action = ({ network, text }: { network?: Networks; text: string }) => {
   );
 };
 
-const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+const { height: SCREEN_HEIGHT } = Dimensions.get('screen');
 const MODAL_MIN_HEIGHT = 120; // Height when dragged down (header + some content)
 const MODAL_MAX_HEIGHT = SCREEN_HEIGHT; // Full height modal
 


### PR DESCRIPTION
On Android they are different

Before / After
<img width="200"  alt="Screenshot_1764080811" src="https://github.com/user-attachments/assets/564c7cf9-14b2-49db-9108-51c0bcdcd4a0" /> <img width="200"  alt="Screenshot_1764080819" src="https://github.com/user-attachments/assets/c31f04a8-9ac5-4b4f-9f5f-cd16c4c61be1" />
