### PR TITLE
fix: explore button on each network (closes #407)

### DIFF
--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -198,17 +198,7 @@ export default function Home() {
   };
 
   const handleExplorer = () => {
-    if (isEVM) {
-      router.push('/DAppBrowser');
-    } else {
-      const explorerUrl = getExplorerUrlByNetwork(network);
-      if (explorerUrl) {
-        const params: DappBrowserProps = { url: explorerUrl };
-        router.push({ pathname: '/DAppBrowser', params });
-      } else {
-        Alert.alert('Explorer', 'Explorer not available for this network');
-      }
-    }
+    router.push('/DAppBrowser');
   };
 
   const handleTokenPress = (token: CachedTokenInfo) => {
@@ -445,8 +435,8 @@ export default function Home() {
             {/* Balance Section */}
             <Balance ref={balanceRef} />
 
-            {/* Explorer Button for EVM networks */}
-            {isEVM && <Button title="🔍 Explore" onPress={handleExplorer} variant="dark" style={styles.explorerButton} testID="ExplorerButton" />}
+            {/* Explorer Button */}
+            <Button title="🔍 Explore" onPress={handleExplorer} variant="dark" style={styles.explorerButton} testID="ExplorerButton" />
 
             {/* Swap List Section */}
             <SwapList ref={swapListRef} />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Always render the Explore button and route to in-app DAppBrowser for every network.
> 
> - **Home (`mobile/app/Home.tsx`)**:
>   - **Explorer behavior**:
>     - Simplify `handleExplorer` to always `router.push('/DAppBrowser')`, removing network-specific logic and alerts.
>     - Render "Explore" button unconditionally (removed `isEVM` check).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c5d0ee900633e7e5b5b1d0d2596908b048cea8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->