### PR TITLE
feat: tokens exchange rate

### DIFF
--- a/mobile/components/Balance.tsx
+++ b/mobile/components/Balance.tsx
@@ -60,7 +60,7 @@ const Balance = forwardRef<{ refresh: () => void }>((props, ref) => {
         <ThemedText style={styles.balanceAmount} adjustsFontSizeToFit={true} numberOfLines={1} testID="LayerActualBalance">
           {displayBalance} <ThemedText style={styles.balanceTicker}>{ticker}</ThemedText>
         </ThemedText>
-        <ThemedText style={styles.balanceUsd}>{displaySubBalance} USD</ThemedText>
+        <ThemedText style={styles.balanceUsd}>${displaySubBalance}</ThemedText>
       </View>
 
       {canBuyWithFiat && (
@@ -186,7 +186,7 @@ const BalanceLightning = forwardRef<{ refresh: () => void }>((props, ref) => {
             <ThemedText style={styles.listBalanceAmount}>
               {formattedBalance} {ticker}
             </ThemedText>
-            <ThemedText style={styles.listBalanceFiat}>{formattedFiatBalance} USD</ThemedText>
+            <ThemedText style={styles.listBalanceFiat}>{formattedFiatBalance}</ThemedText>
           </View>
         </View>
       );
@@ -200,7 +200,7 @@ const BalanceLightning = forwardRef<{ refresh: () => void }>((props, ref) => {
           <ThemedText style={styles.balanceAmount} adjustsFontSizeToFit={true} numberOfLines={1} testID="LayerActualBalance">
             {displayBalance} <ThemedText style={styles.balanceTicker}>{ticker}</ThemedText>
           </ThemedText>
-          <ThemedText style={styles.balanceUsd}>{displaySubBalance} USD</ThemedText>
+          <ThemedText style={styles.balanceUsd}>${displaySubBalance}</ThemedText>
         </View>
 
         <View style={styles.balanceNetworkIcons}>{icons}</View>

--- a/mobile/components/TokensView.tsx
+++ b/mobile/components/TokensView.tsx
@@ -9,13 +9,15 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useTokenBalance } from '@shared/hooks/useTokenBalance';
 import { useTokenDiscovery } from '@shared/hooks/useTokenDiscovery';
 import { getTokenIconColor } from '@shared/models/token-list';
-import { formatBalance } from '@shared/modules/string-utils';
+import { formatBalance, formatFiatBalance } from '@shared/modules/string-utils';
 import { CachedTokenInfo } from '@shared/types/token-info';
+import { useTokenExchangeRate } from '@shared/hooks/useTokenExchangeRate';
 
 const TokenRow: React.FC<{ token: CachedTokenInfo; onPress: (token: CachedTokenInfo) => void; selected: boolean; setShow: (show: boolean) => void }> = ({ token, onPress, selected, setShow }) => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
   const { balance } = useTokenBalance(network, accountNumber, token.id, BackgroundExecutor);
+  const { tokenExchangeRate } = useTokenExchangeRate(network, token.id, 'USD');
 
   useEffect(() => {
     if ((!balance || balance === '0') && (!token.balance || token.balance === '0')) return;
@@ -60,7 +62,7 @@ const TokenRow: React.FC<{ token: CachedTokenInfo; onPress: (token: CachedTokenI
         <ThemedText style={styles.tokenAmount} testID={`token-amount-${token.id}`}>
           {formattedBalance} {token?.symbol}
         </ThemedText>
-        <ThemedText style={styles.tokenPrice}>$TODO</ThemedText>
+        <ThemedText style={styles.tokenPrice}>{balance && tokenExchangeRate && tokenExchangeRate > 0 ? '$' + formatFiatBalance(balance, token.decimals, tokenExchangeRate) : null}</ThemedText>
       </View>
     </TouchableOpacity>
   );

--- a/mobile/components/Transaction.tsx
+++ b/mobile/components/Transaction.tsx
@@ -64,9 +64,9 @@ export default function Transaction({ transaction, onPress }: TransactionProps) 
 
     if (transaction.amount !== undefined && exchangeRate) {
       const usdAmount = formatFiatBalance(Math.abs(transaction.amount).toString(), decimals, exchangeRate);
-      return `${usdAmount} USD`;
+      return `$${usdAmount}`;
     }
-    return '0.00 USD';
+    return '$0.00';
   }, [isZeroAmountWithSingleToken, transaction.amount, exchangeRate, decimals]);
 
   const formattedTransactionDate = useMemo(() => {

--- a/mobile/hooks/withAsset.tsx
+++ b/mobile/hooks/withAsset.tsx
@@ -11,6 +11,7 @@ import { useTokenDiscovery } from '@shared/hooks/useTokenDiscovery';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { StringNumber } from '@shared/types/string-number';
 import { TokenInfo } from '@shared/types/token-info';
+import { useTokenExchangeRate } from '@shared/hooks/useTokenExchangeRate';
 
 export interface SendAssetProps {
   balance: StringNumber | undefined;
@@ -29,22 +30,14 @@ export const withAsset = <P extends object>(Component: React.ComponentType<P & S
     const { accountNumber } = useContext(AccountNumberContext);
     const { balance: tokenBalance } = useTokenBalance(network, accountNumber, token!, BackgroundExecutor);
     const { tokenList } = useTokenDiscovery(network, accountNumber, BackgroundExecutor, LayerzStorage);
+    const { tokenExchangeRate } = useTokenExchangeRate(network, token ?? '', 'USD');
     const tokenInfo = tokenList.find((t) => t.id === token);
 
     if (!tokenInfo) {
       return null;
     }
 
-    return (
-      <Component
-        {...props}
-        balance={tokenBalance}
-        exchangeRate={undefined} // TODO: get exchange rate for token
-        ticker={tokenInfo.symbol}
-        token={tokenInfo}
-        decimals={tokenInfo.decimals}
-      />
-    );
+    return <Component {...props} balance={tokenBalance} exchangeRate={tokenExchangeRate} ticker={tokenInfo.symbol} token={tokenInfo} decimals={tokenInfo.decimals} />;
   };
 
   const WithoutTokenWrapper = (props: P) => {

--- a/shared/hooks/useExchangeRate.ts
+++ b/shared/hooks/useExchangeRate.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 import { useMemo } from 'react';
-import { NETWORK_ARK, NETWORK_BITCOIN, NETWORK_BOTANIX, NETWORK_LIQUID, NETWORK_ROOTSTOCK, NETWORK_SPARK, NETWORK_USDT, Networks } from '../types/networks';
+import { NETWORK_ARK, NETWORK_BITCOIN, NETWORK_BOTANIX, NETWORK_LIQUID, NETWORK_ROOTSTOCK, NETWORK_SPARK, NETWORK_STACKS, NETWORK_USDT, Networks } from '../types/networks';
 import { getFiatRate } from '../models/fiatUnit';
 import { getIsTestnet } from '../models/network-getters';
 
@@ -48,6 +48,7 @@ export function useExchangeRate(network: Networks, fiat: TFiat) {
     case NETWORK_LIQUID:
     case NETWORK_BOTANIX:
     case NETWORK_ROOTSTOCK:
+    case NETWORK_STACKS:
       network2use = NETWORK_BITCOIN;
   }
   //

--- a/shared/hooks/useTokenExchangeRate.ts
+++ b/shared/hooks/useTokenExchangeRate.ts
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { getIsTestnet } from '../models/network-getters';
+import { NETWORK_STACKS, NETWORK_USDT, Networks } from '../types/networks';
+
+export type TFiat = 'USD';
+
+interface tokenExchangeRateFetcherArg {
+  cacheKey: string;
+  network: Networks;
+  tokenId: string;
+  fiat: TFiat;
+}
+
+function middleware(useSWRNext: any) {
+  return (key: any, fetcher: any, config: any) => {
+    console.log(`useTokenExchangeRate(${JSON.stringify(key)})`); // logging
+
+    return useSWRNext(key, () => fetcher(key), config);
+  };
+}
+
+export const tokenExchangeRateFetcher = async (arg: tokenExchangeRateFetcherArg): Promise<number> => {
+  const { network, tokenId, fiat } = arg;
+
+  if (getIsTestnet(network)) {
+    return 0;
+  }
+
+  if (network === NETWORK_USDT) {
+    return 1;
+  }
+
+  // Handle STX token on Stacks network
+  if (tokenId === 'STX' && network === NETWORK_STACKS) {
+    try {
+      const response = await fetch('https://api.kraken.com/0/public/Ticker?pair=STXUSD');
+      const data = await response.json();
+
+      if (data.error && data.error.length > 0) {
+        console.error('Kraken API error:', data.error);
+        return 0;
+      }
+
+      // Kraken returns the ticker data under the pair name key
+      const tickerData = data.result?.STXUSD;
+      if (tickerData && tickerData.c && tickerData.c[0]) {
+        // 'c' is the last trade closed array [price, lot volume]
+        return parseFloat(tickerData.c[0]);
+      }
+
+      return 0;
+    } catch (error) {
+      console.error('Error fetching STX exchange rate:', error);
+      return 0;
+    }
+  }
+
+  console.log(`dont know how to get exchange rate for token ${tokenId} on ${network}`);
+  return 0;
+};
+
+export function useTokenExchangeRate(network: Networks, tokenId: string, fiat: TFiat) {
+  let refreshInterval = 60_000;
+
+  const arg: tokenExchangeRateFetcherArg = useMemo(
+    () => ({
+      cacheKey: 'exchangeRateFetcher',
+      network,
+      tokenId,
+      fiat,
+    }),
+    [network, tokenId, fiat]
+  );
+
+  const { data, error, isLoading } = useSWR(arg, tokenExchangeRateFetcher, {
+    use: [middleware],
+    refreshInterval,
+    refreshWhenHidden: false,
+  });
+
+  return {
+    tokenExchangeRate: data,
+    isLoading,
+    error,
+  };
+}


### PR DESCRIPTION
* token exchange rate hoot
* fetcher for only 1 token (STX)
* change display of fiat to have leading `$`


<img width="320" height="710" alt="image" src="https://github.com/user-attachments/assets/8cac2131-72af-4e1d-b048-a9db5c7498cf" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds token exchange rate fetching (STX) and updates balances, transactions, and tokens UI to show fiat values with a leading $.
> 
> - **Hooks**:
>   - **`useTokenExchangeRate`**: New SWR hook to fetch token->fiat rates (supports STX on Stacks via Kraken; testnets return 0; USDT pegged to 1).
>   - **`useExchangeRate`**: Treats `NETWORK_STACKS` like Bitcoin for caching.
> - **Mobile UI**:
>   - **Tokens** (`mobile/components/TokensView.tsx`): Show per-token fiat value using `useTokenExchangeRate`; replace placeholder with formatted `$` value.
>   - **Send Flow HOC** (`mobile/hooks/withAsset.tsx`): Supplies token exchange rate to wrapped components.
>   - **Balances** (`mobile/components/Balance.tsx`): Change fiat display from `X USD` to `$X` in main and per-network rows.
>   - **Transactions** (`mobile/components/Transaction.tsx`): Change fiat display from `X USD`/`0.00 USD` to `$X`/`$0.00`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bfb6141d4f1d8919887ed9d68645dd22f458fd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->