### PR TITLE
refactor: typeguards for ln wallets

### DIFF
--- a/ext/src/pages/Popup/ReceiveLightning.tsx
+++ b/ext/src/pages/Popup/ReceiveLightning.tsx
@@ -10,10 +10,8 @@ import { NETWORK_ARK, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_SPARK } fr
 import { BackgroundCaller } from '../../modules/background-caller';
 import { AddressBubble, Input, WideButton } from './DesignSystem';
 import { TLightningWallet } from '@shared/types/TWallet';
-import { BreezWallet } from '@shared/class/wallets/breez-wallet';
 import assert from 'assert';
-import { SparkWallet } from '@shared/class/wallets/spark-wallet';
-import { ArkWallet } from '@shared/class/wallets/ark-wallet';
+import { walletSupportsLightning } from '@shared/class/wallets/interface-lightning-wallet';
 
 export interface ReceiveLightningProps {
   network: typeof NETWORK_SPARK | typeof NETWORK_LIQUID | typeof NETWORK_LIQUID_TESTNET | typeof NETWORK_ARK;
@@ -110,7 +108,7 @@ const ReceiveLightning: React.FC = () => {
     const initializeWallet = async () => {
       try {
         const w = await BackgroundCaller.lazyInitWallet(network, accountNumber);
-        assert(w instanceof BreezWallet || w instanceof SparkWallet || w instanceof ArkWallet);
+        assert(walletSupportsLightning(w));
         walletRef.current = w;
         setIsWalletInitialized(true);
 

--- a/ext/src/pages/Popup/SendLightning.tsx
+++ b/ext/src/pages/Popup/SendLightning.tsx
@@ -15,11 +15,9 @@ import BigNumber from 'bignumber.js';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { TLightningWallet } from '@shared/types/TWallet';
 import assert from 'assert';
-import { BreezWallet } from '@shared/class/wallets/breez-wallet';
-import { SparkWallet } from '@shared/class/wallets/spark-wallet';
-import { ArkWallet } from '@shared/class/wallets/ark-wallet';
 import Lnurl, { LnurlPayServicePayload } from '@shared/class/lnurl';
 import { convertMerchantQRToLightningAddress } from '@shared/modules/merchants';
+import { walletSupportsLightning } from '@shared/class/wallets/interface-lightning-wallet';
 
 export interface SendLightningProps {
   network: typeof NETWORK_SPARK | typeof NETWORK_LIQUID | typeof NETWORK_LIQUID_TESTNET | typeof NETWORK_ARK;
@@ -118,7 +116,7 @@ const SendLightning: React.FC = () => {
     const initializeWallet = async () => {
       try {
         const w = await BackgroundCaller.lazyInitWallet(network, accountNumber);
-        assert(w instanceof BreezWallet || w instanceof SparkWallet || w instanceof ArkWallet);
+        assert(walletSupportsLightning(w));
         walletRef.current = w;
       } catch (err) {
         console.error('Failed to initialize wallet:', err);

--- a/mobile/app/PosMerchant.tsx
+++ b/mobile/app/PosMerchant.tsx
@@ -8,7 +8,7 @@ import { Ionicons } from '@expo/vector-icons';
 import GradientScreen from '@/components/GradientScreen';
 import ScreenHeader from '@/components/navigation/ScreenHeader';
 import { ThemedText } from '@/components/ThemedText';
-import { queryForMetadata, PosMetadata, initiateScan, ScanRequest } from '@shared/modules/merchants';
+import { initiateScan, PosMetadata, queryForMetadata, ScanRequest } from '@shared/modules/merchants';
 import { getDeviceID } from '@shared/modules/device-id';
 import { SecureStorage } from '@/src/class/secure-storage';
 import { Csprng } from '@/src/class/rng';
@@ -18,9 +18,7 @@ import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { useCachedBalance } from '@shared/hooks/useCachedBalance';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import assert from 'assert';
-import { SparkWallet } from '@shared/class/wallets/spark-wallet';
-import { ArkWallet } from '@shared/class/wallets/ark-wallet';
-import { BreezWallet } from '@shared/class/wallets/breez-wallet';
+import { walletSupportsLightning } from '@shared/class/wallets/interface-lightning-wallet';
 
 const maxFeePercent = 5; // hardcoded at the moment. might give user option to adjust later
 
@@ -367,7 +365,7 @@ const PosMerchant: React.FC = () => {
           // checked that we have enought balance, lets try to pay:
           console.log(`Trying to pay with ${n}...`);
           const wallet = await BackgroundExecutor.lazyInitWallet(n, accountNumber);
-          assert(wallet instanceof SparkWallet || wallet instanceof ArkWallet || wallet instanceof BreezWallet, 'Not a Lightning wallet');
+          assert(walletSupportsLightning(wallet));
           triedAtLeastOnce = true;
           let result: boolean = false;
           try {

--- a/mobile/app/ReceiveLightning.tsx
+++ b/mobile/app/ReceiveLightning.tsx
@@ -15,9 +15,7 @@ import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network
 import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-utils';
 import { NETWORK_ARK, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_SPARK } from '@shared/types/networks';
 import assert from 'assert';
-import { BreezWallet } from '@shared/class/wallets/breez-wallet';
-import { SparkWallet } from '@shared/class/wallets/spark-wallet';
-import { ArkWallet } from '@shared/class/wallets/ark-wallet';
+import { walletSupportsLightning } from '@shared/class/wallets/interface-lightning-wallet';
 
 export type ReceiveLightningProps = {
   network: typeof NETWORK_SPARK | typeof NETWORK_LIQUID | typeof NETWORK_LIQUID_TESTNET | typeof NETWORK_ARK;
@@ -93,7 +91,7 @@ export default function ReceiveLightningScreen() {
     const initializeWallet = async () => {
       try {
         const w = await BackgroundExecutor.lazyInitWallet(network, accountNumber);
-        assert(w instanceof BreezWallet || w instanceof SparkWallet || w instanceof ArkWallet);
+        assert(walletSupportsLightning(w));
         walletRef.current = w;
         setIsWalletInitialized(true);
 

--- a/mobile/app/SendLightning.tsx
+++ b/mobile/app/SendLightning.tsx
@@ -18,11 +18,9 @@ import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network
 import { TLightningWallet } from '@shared/types/TWallet';
 import { Ionicons } from '@expo/vector-icons';
 import assert from 'assert';
-import { BreezWallet } from '@shared/class/wallets/breez-wallet';
-import { SparkWallet } from '@shared/class/wallets/spark-wallet';
-import { ArkWallet } from '@shared/class/wallets/ark-wallet';
 import Lnurl, { LnurlPayServicePayload } from '@shared/class/lnurl';
 import { convertMerchantQRToLightningAddress } from '@shared/modules/merchants';
+import { walletSupportsLightning } from '@shared/class/wallets/interface-lightning-wallet';
 
 export type SendLightningProps = {
   network: typeof NETWORK_SPARK | typeof NETWORK_LIQUID | typeof NETWORK_LIQUID_TESTNET | typeof NETWORK_ARK;
@@ -132,7 +130,7 @@ const SendLightning: React.FC = () => {
     const initializeWallet = async () => {
       try {
         const w = await BackgroundExecutor.lazyInitWallet(network, accountNumber);
-        assert(w instanceof BreezWallet || w instanceof SparkWallet || w instanceof ArkWallet);
+        assert(walletSupportsLightning(w));
         walletRef.current = w;
       } catch (err) {
         console.error('Failed to initialize wallet:', err);

--- a/shared/class/wallets/interface-lightning-wallet.ts
+++ b/shared/class/wallets/interface-lightning-wallet.ts
@@ -28,3 +28,17 @@ export interface InterfaceLightningWallet {
 
   allowLightning(): boolean;
 }
+
+const REQUIRED_METHODS = ['payLightningInvoice', 'createLightningInvoice', 'isInvoicePaid', 'fetchLightningLimits', 'allowLightning'] as const satisfies ReadonlyArray<keyof InterfaceLightningWallet>;
+
+/**
+ * type guard
+ */
+export function walletSupportsLightning(obj: unknown): obj is InterfaceLightningWallet {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+
+  // Check all required methods exist and are functions
+  return REQUIRED_METHODS.every((method) => method in obj && typeof (obj as any)[method] === 'function');
+}


### PR DESCRIPTION
i like typpeguards, but i dont understand why in ts you cant do `something instanceof InterfaceBlaBla`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce walletSupportsLightning type guard and apply it across web and mobile Lightning send/receive/PoS flows to validate Lightning-capable wallets instead of instanceof checks.
> 
> - **Shared**:
>   - **Type Guard**: Add `walletSupportsLightning` in `shared/class/wallets/interface-lightning-wallet.ts` with required method checks for `InterfaceLightningWallet`.
> - **Extension (Popup)**:
>   - Replace `instanceof` assertions with `walletSupportsLightning` in `ReceiveLightning.tsx` and `SendLightning.tsx` during wallet initialization.
> - **Mobile**:
>   - Use `walletSupportsLightning` in `app/ReceiveLightning.tsx`, `app/SendLightning.tsx`, and `app/PosMerchant.tsx` for wallet validation and payments; remove direct references to specific wallet classes.
>   - Minor import order tidy in `PosMerchant.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55b53ed1c28774fce46fcecffae299ad0a6482cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->