### PR TITLE
feat: nfts on stacks

### DIFF
--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -35,11 +35,12 @@ import { capitalizeFirstLetter } from '@shared/modules/string-utils';
 import { CommonTransaction } from '@shared/types/common-transaction';
 import { NETWORK_ARK, NETWORK_LIGHTNING, NETWORK_LIGHTNING_TESTNET, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_ROOTSTOCK, NETWORK_SPARK, NETWORK_USDT, Networks } from '@shared/types/networks';
 import { SO_LIQUID_USDT, SO_ROOTSTOCK_USDT, SwapPlatform } from '@shared/types/swap';
-import { CachedTokenInfo } from '@shared/types/token-info';
+import { CachedTokenInfo, NftInfo } from '@shared/types/token-info';
 import { ReceiveTokenProps } from './Receive';
 import { SendTokenEvmProps } from './SendTokenEvm';
 import { SwapParams } from './Swap';
 import { SendParams } from './send';
+import NftsView from '@/components/NftsView';
 
 const Action = ({ network, text }: { network?: Networks; text: string }) => {
   const networkImage = network ? getNetworkImageAsset(network) : null;
@@ -78,6 +79,7 @@ export default function Home() {
   const riveRef = useRef<RiveRef>(null); // Ref for Rive animation
   const balanceRef = useRef<{ refresh: () => void }>(null);
   const tokensViewRef = useRef<{ refresh: () => void }>(null);
+  const nftsViewRef = useRef<{ refresh: () => void }>(null);
   const swapListRef = useRef<{ refresh: () => void }>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [refreshOptions, setRefreshOptions] = useState<Partial<RefreshControlProps>>({});
@@ -259,6 +261,7 @@ export default function Home() {
       balanceRef.current?.refresh();
       tokensViewRef.current?.refresh();
       swapListRef.current?.refresh();
+      nftsViewRef.current?.refresh();
       mutateTransactions();
       await sleep(3000); // wait for 3 seconds to simulate a refresh
     } finally {
@@ -425,6 +428,9 @@ export default function Home() {
 
             {/* Tokens Section */}
             <TokensView ref={tokensViewRef} onTokenPress={handleTokenPress} />
+
+            {/* NFTs Section */}
+            <NftsView ref={nftsViewRef} />
 
             {/* Seed Backup Warning */}
             {hasBackedUpSeed === false && (

--- a/mobile/app/Nft.tsx
+++ b/mobile/app/Nft.tsx
@@ -1,0 +1,238 @@
+import React, { useContext, useMemo } from 'react';
+import { Linking, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Stack, useLocalSearchParams } from 'expo-router';
+import * as Clipboard from 'expo-clipboard';
+import { MaterialIcons } from '@expo/vector-icons';
+
+import GradientScreen from '@/components/GradientScreen';
+import NftImage from '@/components/NftImage';
+import ScreenHeader from '@/components/navigation/ScreenHeader';
+import { ThemedText } from '@/components/ThemedText';
+import { NetworkContext } from '@shared/hooks/NetworkContext';
+import { getTokenIconColor } from '@shared/models/token-list';
+import { NftInfo } from '@shared/types/token-info';
+
+export type NftScreenParams = {
+  nft: string;
+};
+
+function truncateMiddle(value: string, head = 6, tail = 4) {
+  if (!value) return value;
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+function parseNftParam(nftParam: string): NftInfo | null {
+  try {
+    return JSON.parse(nftParam) as NftInfo;
+  } catch (_) {
+    return null;
+  }
+}
+
+function buildExplorerUrl(nft: NftInfo): string {
+  return `https://gamma.io/collections/${nft.contractAddress}/${nft.tokenId}`;
+}
+
+export default function Nft() {
+  const params = useLocalSearchParams<NftScreenParams>();
+  const { network } = useContext(NetworkContext);
+
+  const nft = useMemo(() => parseNftParam(params.nft), [params.nft]);
+
+  const title = useMemo(() => {
+    if (!nft) return '';
+    if (nft.name) return nft.name;
+    const base = nft.collectionName || 'NFT';
+    return nft.tokenId ? `${base}-#${nft.tokenId}` : base;
+  }, [nft]);
+
+  const description = useMemo(() => (nft as NftInfo | null)?.description ?? '', [nft]);
+
+  const iconColor = useMemo(() => getTokenIconColor(nft?.name), [nft?.name]);
+
+  const handleCopy = async (text?: string) => {
+    if (!text) return;
+    await Clipboard.setStringAsync(text);
+  };
+
+  const handleOpenInExplorer = () => {
+    if (!nft) return;
+    const url = buildExplorerUrl(nft);
+    Linking.openURL(url);
+  };
+
+  if (!nft) {
+    return (
+      <GradientScreen variant={network}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.root}>
+          <ScreenHeader />
+          <View style={styles.center}>
+            <ThemedText style={styles.errorText}>NFT not found</ThemedText>
+          </View>
+        </View>
+      </GradientScreen>
+    );
+  }
+
+  return (
+    <GradientScreen variant={network}>
+      <Stack.Screen options={{ headerShown: false }} />
+
+      <View style={styles.root}>
+        <ScreenHeader />
+
+        <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+          <View style={styles.imageWrapper}>
+            <View style={[styles.imageBg, { backgroundColor: iconColor }]}>{nft.image ? <NftImage source={{ uri: nft.image }} style={styles.image} resizeMode="cover" /> : null}</View>
+          </View>
+
+          <ThemedText style={styles.title} numberOfLines={2}>
+            {title}
+          </ThemedText>
+
+          {description ? <ThemedText style={styles.description}>{description}</ThemedText> : null}
+
+          <View style={styles.details}>
+            <View style={styles.detailRow}>
+              <ThemedText style={styles.detailLabel}>Contract</ThemedText>
+              <View style={styles.detailValueWrap}>
+                <TouchableOpacity onPress={() => handleCopy(nft.contractAddress)} accessibilityLabel="Copy contract address">
+                  <MaterialIcons name="content-copy" size={16} color="rgba(255, 255, 255, 0.8)" />
+                </TouchableOpacity>
+                <ThemedText style={styles.detailValue} numberOfLines={1} ellipsizeMode="middle">
+                  {truncateMiddle(nft.contractAddress.split('.')[0], 5, 4)}
+                </ThemedText>
+              </View>
+            </View>
+
+            <View style={styles.detailRow}>
+              <ThemedText style={styles.detailLabel}>Token ID</ThemedText>
+              <View style={styles.detailValueWrap}>
+                <TouchableOpacity onPress={() => handleCopy(nft.tokenId)} accessibilityLabel="Copy token id">
+                  <MaterialIcons name="content-copy" size={16} color="rgba(255, 255, 255, 0.8)" />
+                </TouchableOpacity>
+                <ThemedText style={styles.detailValue}>{nft.tokenId}</ThemedText>
+              </View>
+            </View>
+          </View>
+
+          {/* Spacer so content doesn't hide behind bottom button */}
+          <View style={{ height: 90 }} />
+        </ScrollView>
+
+        <View style={styles.bottomButtonWrap}>
+          <TouchableOpacity style={styles.explorerButton} onPress={handleOpenInExplorer} activeOpacity={0.85}>
+            <ThemedText style={styles.explorerButtonText}>View on explorer</ThemedText>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </GradientScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  errorText: {
+    color: 'rgba(255, 255, 255, 0.8)',
+  },
+  scrollContent: {
+    paddingHorizontal: 18,
+    paddingTop: 8,
+    paddingBottom: 0,
+  },
+  imageWrapper: {
+    width: '100%',
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  imageBg: {
+    width: '100%',
+    aspectRatio: 1,
+    borderRadius: 18,
+    overflow: 'hidden',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  title: {
+    marginTop: 16,
+    fontSize: 22,
+    fontWeight: '700',
+    color: 'rgba(255, 255, 255, 0.95)',
+  },
+  chipsRow: {
+    flexDirection: 'row',
+    gap: 10,
+    marginTop: 12,
+  },
+  chip: {
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  chipText: {
+    fontSize: 12,
+    color: 'rgba(255, 255, 255, 0.85)',
+    fontWeight: '500',
+  },
+  description: {
+    marginTop: 14,
+    fontSize: 13,
+    lineHeight: 18,
+    color: 'rgba(255, 255, 255, 0.7)',
+  },
+  details: {
+    marginTop: 18,
+    gap: 14,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  detailLabel: {
+    fontSize: 12,
+    color: 'rgba(255, 255, 255, 0.55)',
+  },
+  detailValueWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    maxWidth: '70%',
+  },
+  detailValue: {
+    fontSize: 14,
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontWeight: '600',
+  },
+  bottomButtonWrap: {
+    position: 'absolute',
+    left: 18,
+    right: 18,
+    bottom: 22,
+  },
+  explorerButton: {
+    backgroundColor: 'rgba(255, 255, 255, 0.35)',
+    borderRadius: 14,
+    paddingVertical: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  explorerButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: 'rgba(255, 255, 255, 0.95)',
+  },
+});

--- a/mobile/app/NftGallery.tsx
+++ b/mobile/app/NftGallery.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback, useContext, useMemo } from 'react';
+import { ActivityIndicator, FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+
+import GradientScreen from '@/components/GradientScreen';
+import NftImage from '@/components/NftImage';
+import ScreenHeader from '@/components/navigation/ScreenHeader';
+import { ThemedText } from '@/components/ThemedText';
+import { LayerzStorage } from '@/src/class/layerz-storage';
+import { BackgroundExecutor } from '@/src/modules/background-executor';
+import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
+import { NetworkContext } from '@shared/hooks/NetworkContext';
+import { useNftDiscovery } from '@shared/hooks/useNftDiscovery';
+import { getTokenIconColor } from '@shared/models/token-list';
+import { NftInfo } from '@shared/types/token-info';
+import { NftScreenParams } from './Nft';
+
+const ITEM_GAP = 14;
+
+function keyForNft(nft: NftInfo) {
+  return `${nft.contractAddress}:${nft.tokenId}`;
+}
+
+const NftTile = ({ nft, onPress }: { nft: NftInfo; onPress: (nft: NftInfo) => void }) => {
+  const iconColor = getTokenIconColor(nft?.name);
+
+  return (
+    <TouchableOpacity style={styles.tileOuter} onPress={() => onPress(nft)} activeOpacity={0.85} accessibilityLabel="Open NFT">
+      <View style={[styles.tileInner, { backgroundColor: iconColor }]}>{nft.image ? <NftImage source={{ uri: nft.image }} style={styles.image} resizeMode="cover" /> : null}</View>
+    </TouchableOpacity>
+  );
+};
+
+export default function NftGallery() {
+  const router = useRouter();
+  const { network } = useContext(NetworkContext);
+  const { accountNumber } = useContext(AccountNumberContext);
+  const { nftList, isLoading, error } = useNftDiscovery(network, accountNumber, BackgroundExecutor, LayerzStorage);
+
+  const data = useMemo(() => nftList ?? [], [nftList]);
+  const handleOpenNft = useCallback(
+    (nft: NftInfo) => {
+      const params: NftScreenParams = { nft: JSON.stringify(nft) };
+      router.push({ pathname: '/Nft', params });
+    },
+    [router]
+  );
+
+  return (
+    <GradientScreen variant={network}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={styles.root}>
+        <ScreenHeader title="NFTs" />
+
+        {error ? (
+          <View style={styles.center}>
+            <ThemedText style={styles.errorText}>Error: {error.message}</ThemedText>
+          </View>
+        ) : isLoading && data.length === 0 ? (
+          <View style={styles.center}>
+            <ActivityIndicator size="large" color="rgba(255, 255, 255, 0.8)" />
+          </View>
+        ) : data.length === 0 ? (
+          <View style={styles.center}>
+            <ThemedText style={styles.emptyText}>No NFTs</ThemedText>
+          </View>
+        ) : (
+          <FlatList
+            data={data}
+            numColumns={2}
+            keyExtractor={keyForNft}
+            renderItem={({ item }) => <NftTile nft={item} onPress={handleOpenNft} />}
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.listContent}
+            columnWrapperStyle={styles.columnWrapper}
+          />
+        )}
+      </View>
+    </GradientScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  errorText: {
+    color: 'rgba(255, 100, 100, 0.9)',
+    textAlign: 'center',
+  },
+  emptyText: {
+    color: 'rgba(255, 255, 255, 0.75)',
+    textAlign: 'center',
+  },
+  listContent: {
+    paddingHorizontal: 18,
+    paddingTop: 12,
+    paddingBottom: 24,
+  },
+  columnWrapper: {
+    gap: ITEM_GAP,
+    marginBottom: ITEM_GAP,
+  },
+  tileOuter: {
+    flex: 1,
+  },
+  tileInner: {
+    width: '100%',
+    aspectRatio: 1,
+    borderRadius: 18,
+    overflow: 'hidden',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+});

--- a/mobile/components/NftImage.tsx
+++ b/mobile/components/NftImage.tsx
@@ -1,0 +1,67 @@
+import React, { memo, useMemo } from 'react';
+import { Image, type ImageProps, type ImageSourcePropType } from 'react-native';
+
+const DEFAULT_IPFS_PROXY_BASE_URL = 'https://gamma.mypinata.cloud/ipfs/';
+
+function joinUrl(base: string, path: string) {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  const p = path.startsWith('/') ? path.slice(1) : path;
+  return `${b}${p}`;
+}
+
+function resolveIpfsImageUri(uri: string) {
+  const trimmed = uri.trim();
+  const lower = trimmed.toLowerCase();
+
+  // ipfs://<cid>/... or ipfs://ipfs/<cid>/...
+  if (lower.startsWith('ipfs://')) {
+    let rest = trimmed.slice('ipfs://'.length);
+    if (rest.toLowerCase().startsWith('ipfs/')) rest = rest.slice('ipfs/'.length);
+    return joinUrl(DEFAULT_IPFS_PROXY_BASE_URL, rest);
+  }
+
+  // https://<gateway>/ipfs/<cid>/...
+  const idx = lower.indexOf('/ipfs/');
+  if (idx !== -1) {
+    const rest = trimmed.slice(idx + '/ipfs/'.length);
+    if (!rest) return trimmed;
+    return joinUrl(DEFAULT_IPFS_PROXY_BASE_URL, rest);
+  }
+
+  return trimmed;
+}
+
+export type NftImageProps = ImageProps;
+
+const NftImage = memo(({ source, ...props }: NftImageProps) => {
+  const resolvedSource = useMemo<ImageSourcePropType | undefined>(() => {
+    if (!source) return source;
+
+    // local require(...)
+    if (typeof source === 'number') return source;
+
+    // ImageSourcePropType can be an array (e.g. multiple densities)
+    if (Array.isArray(source)) {
+      return source.map((s) => {
+        if (s && typeof s === 'object' && 'uri' in s && typeof s.uri === 'string') {
+          const rewritten = resolveIpfsImageUri(s.uri);
+          return rewritten === s.uri ? s : { ...s, uri: rewritten };
+        }
+        return s;
+      });
+    }
+
+    if (typeof source === 'object' && 'uri' in source && typeof source.uri === 'string') {
+      const rewritten = resolveIpfsImageUri(source.uri);
+      return rewritten === source.uri ? source : { ...source, uri: rewritten };
+    }
+
+    return source;
+  }, [source]);
+
+  return <Image {...props} source={resolvedSource} />;
+});
+
+NftImage.displayName = 'NftImage';
+
+export default NftImage;

--- a/mobile/components/NftsView.tsx
+++ b/mobile/components/NftsView.tsx
@@ -1,0 +1,194 @@
+import React, { useCallback, useContext, useEffect, useImperativeHandle, useMemo, useState, forwardRef } from 'react';
+import { StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { ThemedText } from '@/components/ThemedText';
+import NftImage from '@/components/NftImage';
+import { LayerzStorage } from '@/src/class/layerz-storage';
+import { BackgroundExecutor } from '@/src/modules/background-executor';
+import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
+import { NetworkContext } from '@shared/hooks/NetworkContext';
+import { getTokenIconColor } from '@shared/models/token-list';
+import { NftInfo } from '@shared/types/token-info';
+import { useNftDiscovery } from '@shared/hooks/useNftDiscovery';
+import { NftScreenParams } from '@/app/Nft';
+
+const MAX_PREVIEW_ITEMS = 4;
+
+const NftPreviewItem: React.FC<{
+  nft: NftInfo;
+  onPress: (nft: NftInfo) => void;
+  selected: boolean;
+  style?: StyleProp<ViewStyle>;
+}> = ({ nft, onPress, selected, style }) => {
+  const iconColor = getTokenIconColor(nft?.name);
+
+  return (
+    <TouchableOpacity
+      style={[styles.nftPreviewItem, style, selected && styles.selectedNftPreviewItem]}
+      onPress={() => onPress(nft)}
+      activeOpacity={0.8}
+      testID={`nft-preview-${nft.tokenId}`}
+      accessibilityLabel={nft?.name ? `NFT ${nft.name}` : 'NFT'}
+    >
+      <View style={[styles.nftPreviewImageWrapper, { backgroundColor: iconColor }]}>
+        {nft.image ? (
+          <NftImage source={{ uri: nft.image }} style={styles.nftPreviewImage} resizeMode="cover" />
+        ) : (
+          <ThemedText style={styles.nftPreviewFallbackText}>{nft?.name?.charAt(0) || '?'}</ThemedText>
+        )}
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+const NftsView = forwardRef<{ refresh: () => void }, { selectedNft?: string; onViewGalleryPress?: () => void }>(({ selectedNft, onViewGalleryPress }, ref) => {
+  const router = useRouter();
+  const { network } = useContext(NetworkContext);
+  const { accountNumber } = useContext(AccountNumberContext);
+  const { nftList, error, mutate } = useNftDiscovery(network, accountNumber, BackgroundExecutor, LayerzStorage);
+  const [show, setShow] = useState(false);
+  const handleViewGalleryPress = useCallback(() => {
+    if (onViewGalleryPress) return onViewGalleryPress();
+    router.push('/NftGallery');
+  }, [onViewGalleryPress, router]);
+
+  const handleNftPress = useCallback(
+    (nft: NftInfo) => {
+      const params: NftScreenParams = { nft: JSON.stringify(nft) };
+      router.push({ pathname: '/Nft', params });
+    },
+    [router]
+  );
+
+  useEffect(() => {
+    if (nftList.length > 0) setShow(true);
+  }, [nftList.length]);
+
+  useImperativeHandle(ref, () => ({
+    refresh: () => {
+      mutate();
+    },
+  }));
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <ThemedText style={styles.title}>NFT</ThemedText>
+        <ThemedText style={styles.errorText}>Error: {error.message}</ThemedText>
+      </View>
+    );
+  }
+
+  if (nftList.length === 0) {
+    return null;
+  }
+
+  const previewNfts = nftList.slice(0, MAX_PREVIEW_ITEMS);
+  const hasMoreThanPreview = nftList.length > MAX_PREVIEW_ITEMS;
+
+  return (
+    <View style={[styles.container, !show && styles.hiddenContainer]}>
+      <ThemedText style={styles.title}>NFTs</ThemedText>
+      <View style={styles.previewRow}>
+        {previewNfts.map((nft, idx) => (
+          <NftPreviewItem
+            key={nft.tokenId}
+            nft={nft}
+            onPress={handleNftPress}
+            selected={selectedNft === nft.tokenId}
+            style={idx !== previewNfts.length - 1 ? styles.nftPreviewItemSpacing : undefined}
+          />
+        ))}
+      </View>
+
+      {hasMoreThanPreview && (
+        <TouchableOpacity
+          style={styles.viewGalleryButton}
+          onPress={handleViewGalleryPress}
+          activeOpacity={0.85}
+          testID="view-gallery-button"
+          accessibilityRole="button"
+          accessibilityLabel="View NFT Gallery"
+        >
+          <ThemedText style={styles.viewGalleryButtonText}>View Gallery</ThemedText>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+});
+
+NftsView.displayName = 'NftsView';
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'rgba(0, 0, 0, 0.15)',
+    borderRadius: 20,
+    overflow: 'hidden',
+    marginBottom: 20,
+    paddingVertical: 16,
+  },
+  hiddenContainer: {
+    display: 'none',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '500',
+    color: 'white',
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  errorText: {
+    fontSize: 16,
+    color: 'rgba(255, 100, 100, 0.8)',
+    textAlign: 'center',
+  },
+  previewRow: {
+    flexDirection: 'row',
+    alignSelf: 'center',
+    justifyContent: 'center',
+  },
+  nftPreviewItem: {
+    flexGrow: 0,
+    flexShrink: 0,
+  },
+  nftPreviewItemSpacing: {
+    marginRight: 20,
+  },
+  selectedNftPreviewItem: {
+    opacity: 0.9,
+  },
+  nftPreviewImageWrapper: {
+    width: 64,
+    height: 64,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  nftPreviewImage: {
+    width: '100%',
+    height: '100%',
+  },
+  nftPreviewFallbackText: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: 'white',
+  },
+  viewGalleryButton: {
+    marginTop: 18,
+    marginHorizontal: 16,
+    backgroundColor: 'rgba(0, 0, 0, 0.18)',
+    borderRadius: 18,
+    paddingVertical: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  viewGalleryButtonText: {
+    fontSize: 18,
+    fontWeight: '500',
+    color: 'rgba(255, 255, 255, 0.9)',
+  },
+});
+
+export default NftsView;

--- a/shared/class/wallets/stacks-wallet.ts
+++ b/shared/class/wallets/stacks-wallet.ts
@@ -3,7 +3,7 @@ import { generateNewAccount, generateWallet, getStxAddress, Wallet as SdkWallet 
 import { createClient } from '@stacks/blockchain-api-client';
 import { broadcastTransaction, makeContractCall, makeSTXTokenTransfer, noneCV, SignedTokenTransferOptions, standardPrincipalCV, uintCV, validateStacksAddress } from '@stacks/transactions';
 
-import { CachedTokenInfo } from '../../types/token-info';
+import { CachedTokenInfo, NftInfo } from '../../types/token-info';
 import { CommonTransaction } from '../../types/common-transaction';
 import { NETWORK_STACKS } from '../../types/networks';
 import { IStorage } from '../../types/IStorage';
@@ -14,6 +14,7 @@ const sbtcId = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token
 const baseUrl = 'https://api.mainnet.hiro.so';
 
 const STORAGE_KEY = 'STACKS_TOKEN_METADATA';
+const STORAGE_KEY_NFT = 'STACKS_NFT_METADATA_V2';
 
 export class StacksWallet implements InterfaceAccountBasedWallet, InterfaceCanHaveTokens {
   private _accountNumber: number = 0;
@@ -128,6 +129,56 @@ export class StacksWallet implements InterfaceAccountBasedWallet, InterfaceCanHa
     });
 
     this._tokenBalances = tokens;
+  }
+
+  public async fetchNfts(): Promise<NftInfo[]> {
+    const address = await this.getOffchainReceiveAddress();
+    assert(address, 'Stacks address is missing');
+
+    const client = createClient({ baseUrl });
+
+    const { data: nftBalances } = await client.GET('/extended/v1/tokens/nft/holdings', {
+      params: {
+        query: { limit: 100, offset: 0, principal: address, tx_metadata: false },
+      },
+    });
+
+    const nfts: NftInfo[] = [];
+    for (const token of nftBalances?.results || []) {
+      const contractAddress = token.asset_identifier.split('::')[0];
+      const tokenId = token.value.repr.replace('u', '');
+
+      let tokenMetadata: any = undefined;
+
+      try {
+        const cacheKey = `${STORAGE_KEY_NFT}-${contractAddress}-${tokenId}`;
+        const cachedTokenMetadata = await this._storage?.getItem(cacheKey);
+        if (cachedTokenMetadata) {
+          tokenMetadata = JSON.parse(cachedTokenMetadata) as unknown;
+        } else {
+          const response = await fetch(`https://stacks.gamma.io/api/v1/collections/${contractAddress}/${tokenId}`);
+          tokenMetadata = await response.json();
+          await this._storage?.setItem(cacheKey, JSON.stringify(tokenMetadata));
+        }
+      } catch (error) {
+        console.error('Failed to fetch NFT metadata from Gamma:', error);
+      }
+
+      const name = tokenMetadata?.data?.token_metadata?.name ?? '';
+      const image = tokenMetadata?.data?.token_metadata?.image_url ?? '';
+      const description = tokenMetadata?.data?.token_metadata?.description ?? '';
+
+      nfts.push({
+        contractAddress,
+        tokenId,
+        collectionName: '',
+        name,
+        image,
+        description,
+      });
+    }
+
+    return nfts;
   }
 
   public getTokenBalances() {

--- a/shared/hooks/useNftDiscovery.ts
+++ b/shared/hooks/useNftDiscovery.ts
@@ -1,0 +1,82 @@
+import assert from 'assert';
+import useSWR from 'swr';
+
+import { StacksWallet } from '../class/wallets/stacks-wallet';
+import { IBackgroundCaller } from '../types/IBackgroundCaller';
+import { IStorage } from '../types/IStorage';
+import { NETWORK_SPARK, NETWORK_STACKS, Networks } from '../types/networks';
+import { CachedTokenInfo, NftInfo } from '../types/token-info';
+
+const STORAGE_KEY_CACHED_NFT = 'STORAGE_KEY_CACHED_NFT';
+
+interface nftDiscoveryFetcherArg {
+  cacheKey: string;
+  network: Networks;
+  accountNumber: number;
+  backgroundCaller: IBackgroundCaller;
+  storage: IStorage;
+}
+
+/**
+ * returns cached nfts from storage if present, null otherwise
+ */
+async function restoreCachedNfts(cacheKey: string, storage: IStorage): Promise<NftInfo[] | null> {
+  try {
+    const cachedTokensString = await storage.getItem(cacheKey);
+    const cachedTokens = JSON.parse(cachedTokensString);
+    if (Array.isArray(cachedTokens) && cachedTokens.length > 0) {
+      return cachedTokens;
+    }
+  } catch (_) {}
+  return null;
+}
+
+export const nftDiscoveryFetcher = async (arg: nftDiscoveryFetcherArg): Promise<NftInfo[]> => {
+  const { network, accountNumber, backgroundCaller, storage } = arg;
+
+  if (network === NETWORK_STACKS) {
+    const cacheKey = STORAGE_KEY_CACHED_NFT + network + accountNumber;
+
+    if (!backgroundCaller.lazyInitWalletReady(network, accountNumber)) {
+      // wallet not ready, definitely can use cached nfts (if any)
+      const cachedNfts = await restoreCachedNfts(cacheKey, storage);
+      if (cachedNfts) return cachedNfts;
+    }
+
+    const wallet = await backgroundCaller.lazyInitWallet(network, accountNumber);
+    assert(wallet instanceof StacksWallet, 'Not a Stacks wallet');
+
+    const nfts = await wallet.fetchNfts();
+    await storage.setItem(cacheKey, JSON.stringify(nfts));
+    return nfts;
+  }
+
+  // for unsupported networks, return empty array
+  return [];
+};
+
+export function useNftDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, storage: IStorage, refreshInterval = 5_000) {
+  // Only enable refresh interval for NETWORK_SPARK & NETWORK_STACKS
+  const shouldRefresh = network === NETWORK_SPARK || network === NETWORK_STACKS;
+
+  const arg: nftDiscoveryFetcherArg = {
+    cacheKey: 'nftDiscoveryFetcher',
+    network,
+    accountNumber,
+    backgroundCaller,
+    storage,
+  };
+
+  const { data, error, isLoading, mutate } = useSWR(arg, nftDiscoveryFetcher, {
+    refreshInterval: shouldRefresh ? refreshInterval : undefined,
+    refreshWhenHidden: false,
+    keepPreviousData: true,
+  });
+
+  return {
+    nftList: data ?? [],
+    isLoading,
+    error: error instanceof Error ? error : error ? new Error('Unknown error') : null,
+    mutate,
+  };
+}

--- a/shared/tests/integration-vi/stacks-wallet.test.ts
+++ b/shared/tests/integration-vi/stacks-wallet.test.ts
@@ -76,6 +76,21 @@ test('stacks wallet can get tokens', async (context) => {
   ]);
 });
 
+test('stacks wallet can get nfts', async (context) => {
+  if (!process.env.TEST_MNEMONIC) {
+    console.warn('TEST_MNEMONIC not set, skipping');
+    context.skip();
+    return;
+  }
+
+  const w = new StacksWallet();
+  w.setSecret(process.env.TEST_MNEMONIC);
+  await w.init(storageMock);
+
+  const nfts = await w.fetchNfts();
+  assert.ok(nfts.length > 0);
+});
+
 test('stacks wallet can get common txs', async (context) => {
   if (!process.env.TEST_MNEMONIC) {
     console.warn('TEST_MNEMONIC not set, skipping');

--- a/shared/types/token-info.ts
+++ b/shared/types/token-info.ts
@@ -23,3 +23,15 @@ export interface EVMTokenInfo extends Omit<TokenInfo, 'id'> {
 export interface LiquidTokenInfo extends Omit<TokenInfo, 'id'> {
   readonly assetId: string;
 }
+
+export interface NftInfo {
+  readonly contractAddress: string;
+
+  /* actual token number inside contract */
+  readonly tokenId: string;
+
+  readonly collectionName: string;
+  readonly name: string;
+  readonly description: string;
+  readonly image: string;
+}


### PR DESCRIPTION
vibecoded screens, but they are pretty close to figma.

most importantly, we now have extensible code to display nfts for other networks

* using stacks api to discover nfts
* using gamma api to get nft metadata (some nft marketplace)
* using gamma to proxy ipfs images

(mobile only, was to lazy to port to ext)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Stacks NFT discovery with cached metadata plus new mobile NFT gallery/detail UIs and IPFS image proxying.
> 
> - **Mobile**
>   - **Home**: Integrates `NftsView` and ties into pull-to-refresh.
>   - **UI**: Adds `app/Nft` (detail) and `app/NftGallery` (grid) screens.
>   - **Components**: Adds `NftsView` (preview row) and `NftImage` (IPFS URL rewriting via Gamma proxy).
> - **Shared**
>   - **StacksWallet**: Implements `fetchNfts()` using Hiro holdings and Gamma metadata with storage caching.
>   - **Data Hook**: Introduces `useNftDiscovery` (SWR-based, cached, background-initialized; refresh for Stacks/Spark).
>   - **Types**: Adds `NftInfo`.
>   - **Tests**: Adds integration test for `fetchNfts()` and updates Stacks tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed6950cab693c1e6d1222be4e9fc9679525758b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->