### PR TITLE
feat: nfts on ext

### DIFF
--- a/ext/src/components/NftImage.tsx
+++ b/ext/src/components/NftImage.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+const DEFAULT_IPFS_PROXY_BASE_URL = 'https://gamma.mypinata.cloud/ipfs/';
+
+function joinUrl(base: string, path: string) {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  const p = path.startsWith('/') ? path.slice(1) : path;
+  return `${b}${p}`;
+}
+
+/**
+ * Matches `mobile/components/NftImage.tsx` behavior.
+ */
+function resolveIpfsImageUri(uri: string) {
+  const trimmed = uri.trim();
+  const lower = trimmed.toLowerCase();
+
+  // ipfs://<cid>/... or ipfs://ipfs/<cid>/...
+  if (lower.startsWith('ipfs://')) {
+    let rest = trimmed.slice('ipfs://'.length);
+    if (rest.toLowerCase().startsWith('ipfs/')) rest = rest.slice('ipfs/'.length);
+    return joinUrl(DEFAULT_IPFS_PROXY_BASE_URL, rest);
+  }
+
+  // https://<gateway>/ipfs/<cid>/...
+  const idx = lower.indexOf('/ipfs/');
+  if (idx !== -1) {
+    const rest = trimmed.slice(idx + '/ipfs/'.length);
+    if (!rest) return trimmed;
+    return joinUrl(DEFAULT_IPFS_PROXY_BASE_URL, rest);
+  }
+
+  return trimmed;
+}
+
+export type NftImageProps = Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'src'> & {
+  src?: string | null;
+  fallbackText?: string;
+  backgroundColor?: string;
+};
+
+/**
+ * Minimal web equivalent of mobile's NftImage.
+ * - Renders an <img> with object-fit cover when src is valid
+ * - Falls back to a colored block with text on error / missing src
+ */
+const NftImage: React.FC<NftImageProps> = ({ src, fallbackText = '?', backgroundColor = 'rgba(0,0,0,0.12)', style, ...rest }) => {
+  const [failed, setFailed] = useState(false);
+
+  const resolvedSrc = useMemo(() => {
+    if (!src) return src;
+    return resolveIpfsImageUri(src);
+  }, [src]);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [resolvedSrc]);
+
+  if (!resolvedSrc || failed) {
+    return (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundColor,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'rgba(255,255,255,0.9)',
+          fontWeight: 700,
+          userSelect: 'none',
+          ...((style as React.CSSProperties) ?? {}),
+        }}
+        aria-label="NFT image fallback"
+      >
+        {fallbackText}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      {...rest}
+      src={resolvedSrc}
+      onError={(e) => {
+        setFailed(true);
+        rest.onError?.(e);
+      }}
+      style={{
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+        display: 'block',
+        ...((style as React.CSSProperties) ?? {}),
+      }}
+      alt={rest.alt ?? 'NFT image'}
+      loading={rest.loading ?? 'lazy'}
+      referrerPolicy={rest.referrerPolicy ?? 'no-referrer'}
+    />
+  );
+};
+
+export default NftImage;

--- a/ext/src/pages/Popup/Home.tsx
+++ b/ext/src/pages/Popup/Home.tsx
@@ -29,6 +29,7 @@ import { SO_LIQUID_USDT, SO_ROOTSTOCK_USDT, SwapPair, SwapPlatform } from '@shar
 
 import { BackgroundCaller } from '../../modules/background-caller';
 import Balance from './components/Balance';
+import NftsView from './components/NftsView';
 import PartnersView from './components/PartnersView';
 import SwapInterfaceView from './components/SwapInterfaceView';
 import SwapListView from './components/SwapListView';
@@ -49,6 +50,7 @@ const Home: React.FC = () => {
   const { mutate: mutateTransactions } = useTransactions(network, accountNumber, BackgroundCaller);
   const balanceRef = useRef<{ refresh: () => void }>(null);
   const tokensViewRef = useRef<{ refresh: () => void }>(null);
+  const nftsViewRef = useRef<{ refresh: () => void }>(null);
   const swapListRef = useRef<{ refresh: () => void }>(null);
   const [refreshing, setRefreshing] = useState(false);
 
@@ -185,6 +187,7 @@ const Home: React.FC = () => {
     try {
       balanceRef.current?.refresh();
       tokensViewRef.current?.refresh();
+      nftsViewRef.current?.refresh();
       swapListRef.current?.refresh();
       mutateTransactions();
       await sleep(3000); // wait for 3 seconds to simulate a refresh
@@ -247,6 +250,7 @@ const Home: React.FC = () => {
         <div>
           <PartnersView />
           <TokensView ref={tokensViewRef} />
+          <NftsView ref={nftsViewRef} />
         </div>
       )}
 

--- a/ext/src/pages/Popup/Nft.tsx
+++ b/ext/src/pages/Popup/Nft.tsx
@@ -1,0 +1,166 @@
+import React, { useContext, useMemo, useState } from 'react';
+import { ExternalLink, Copy } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router';
+
+import { NetworkContext } from '@shared/hooks/NetworkContext';
+import { getTokenIconColor } from '@shared/models/token-list';
+import { NftInfo } from '@shared/types/token-info';
+
+import NftImage from '../../components/NftImage';
+import { ThemedText } from '../../components/ThemedText';
+import { WideButton } from './DesignSystem';
+
+function truncateMiddle(value: string, head = 6, tail = 4) {
+  if (!value) return value;
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+function parseNftParam(nftParam: string | null): NftInfo | null {
+  if (!nftParam) return null;
+  try {
+    return JSON.parse(decodeURIComponent(nftParam)) as NftInfo;
+  } catch (_) {
+    return null;
+  }
+}
+
+function buildExplorerUrl(nft: NftInfo): string {
+  // Matches mobile behavior for stacks NFTs
+  return `https://gamma.io/collections/${nft.contractAddress}/${nft.tokenId}`;
+}
+
+const Nft: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { network } = useContext(NetworkContext);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const nft = useMemo(() => parseNftParam(params.get('nft')), [params]);
+
+  const title = useMemo(() => {
+    if (!nft) return '';
+    if (nft.name) return nft.name;
+    const base = nft.collectionName || 'NFT';
+    return nft.tokenId ? `${base}-#${nft.tokenId}` : base;
+  }, [nft]);
+
+  const description = useMemo(() => (nft as NftInfo | null)?.description ?? '', [nft]);
+  const iconColor = useMemo(() => getTokenIconColor(nft?.name), [nft?.name]);
+
+  const handleCopy = async (text?: string, key?: string) => {
+    if (!text) return;
+    await navigator.clipboard.writeText(text);
+    setCopiedKey(key ?? text);
+    setTimeout(() => setCopiedKey(null), 1200);
+  };
+
+  const handleOpenInExplorer = () => {
+    if (!nft) return;
+    const url = buildExplorerUrl(nft);
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  if (!nft) {
+    return (
+      <div style={{ position: 'relative' }}>
+        <ThemedText type="headline">NFT</ThemedText>
+        <div style={{ textAlign: 'center', padding: 20, color: '#666' }}>NFT not found</div>
+        <WideButton onClick={() => navigate('/')} style={{ marginTop: 6 }}>
+          Back to Wallet
+        </WideButton>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <ThemedText type="headline">NFT</ThemedText>
+
+      <div style={{ padding: '12px 18px 0 18px' }}>
+        <div
+          style={{
+            width: 'min(100%, 240px)',
+            margin: '0 auto',
+            borderRadius: 18,
+            overflow: 'hidden',
+            backgroundColor: iconColor,
+            aspectRatio: '1 / 1',
+          }}
+        >
+          <NftImage src={nft.image} backgroundColor={iconColor} fallbackText={nft?.name?.charAt(0) || '?'} />
+        </div>
+
+        <div style={{ marginTop: 12 }}>
+          <ThemedText style={{ fontSize: 18, fontWeight: 800, color: '#222' }}>{title}</ThemedText>
+        </div>
+
+        {description ? (
+          <div style={{ marginTop: 10 }}>
+            <ThemedText style={{ fontSize: 13, lineHeight: '18px', color: 'rgba(0,0,0,0.7)' }}>{description}</ThemedText>
+          </div>
+        ) : null}
+
+        <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <ThemedText style={{ fontSize: 12, color: 'rgba(0,0,0,0.55)' }}>Contract</ThemedText>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, maxWidth: '70%' }}>
+              <button
+                onClick={() => handleCopy(nft.contractAddress, 'contract')}
+                style={{ border: 'none', background: 'transparent', cursor: 'pointer', padding: 0 }}
+                aria-label="Copy contract address"
+                title="Copy contract address"
+              >
+                <Copy size={16} color={copiedKey === 'contract' ? '#4BB543' : 'rgba(0,0,0,0.65)'} />
+              </button>
+              <ThemedText style={{ fontSize: 14, fontWeight: 700, color: 'rgba(0,0,0,0.9)' }}>{truncateMiddle(nft.contractAddress.split('.')[0], 5, 4)}</ThemedText>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <ThemedText style={{ fontSize: 12, color: 'rgba(0,0,0,0.55)' }}>Token ID</ThemedText>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, maxWidth: '70%' }}>
+              <button
+                onClick={() => handleCopy(nft.tokenId, 'tokenId')}
+                style={{ border: 'none', background: 'transparent', cursor: 'pointer', padding: 0 }}
+                aria-label="Copy token id"
+                title="Copy token id"
+              >
+                <Copy size={16} color={copiedKey === 'tokenId' ? '#4BB543' : 'rgba(0,0,0,0.65)'} />
+              </button>
+              <ThemedText style={{ fontSize: 14, fontWeight: 700, color: 'rgba(0,0,0,0.9)' }}>{nft.tokenId}</ThemedText>
+            </div>
+          </div>
+        </div>
+
+        <div style={{ height: 14 }} />
+      </div>
+
+      <WideButton
+        onClick={handleOpenInExplorer}
+        style={{
+          marginTop: 12,
+          backgroundColor: 'rgba(0, 0, 0, 0.8)',
+          borderColor: 'rgba(0,0,0,0.8)',
+          display: 'flex',
+          gap: 8,
+          justifyContent: 'center',
+        }}
+      >
+        <ExternalLink size={18} />
+        View on explorer
+      </WideButton>
+
+      <div style={{ height: 10 }} />
+      <WideButton onClick={() => navigate('/')} style={{ backgroundColor: 'white', color: '#222', borderColor: '#ddd' }}>
+        Back to Wallet
+      </WideButton>
+
+      {/* keeps parity with mobile even if unused in web for now */}
+      <div style={{ display: 'none' }}>{network}</div>
+    </div>
+  );
+};
+
+export default Nft;

--- a/ext/src/pages/Popup/NftGallery.tsx
+++ b/ext/src/pages/Popup/NftGallery.tsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useContext, useMemo } from 'react';
+import { useNavigate } from 'react-router';
+
+import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
+import { NetworkContext } from '@shared/hooks/NetworkContext';
+import { useNftDiscovery } from '@shared/hooks/useNftDiscovery';
+import { getTokenIconColor } from '@shared/models/token-list';
+import { NftInfo } from '@shared/types/token-info';
+
+import NftImage from '../../components/NftImage';
+import { BackgroundCaller } from '../../modules/background-caller';
+import { LayerzStorage } from '../../class/layerz-storage';
+import { ThemedText } from '../../components/ThemedText';
+import { WideButton } from './DesignSystem';
+
+const ITEM_GAP = 14;
+
+function keyForNft(nft: NftInfo) {
+  return `${nft.contractAddress}:${nft.tokenId}`;
+}
+
+function buildNftParam(nft: NftInfo) {
+  return encodeURIComponent(JSON.stringify(nft));
+}
+
+const NftTile: React.FC<{ nft: NftInfo; onPress: (nft: NftInfo) => void }> = ({ nft, onPress }) => {
+  const iconColor = getTokenIconColor(nft?.name);
+  const fallbackText = nft?.name?.charAt(0) || '?';
+
+  return (
+    <button
+      onClick={() => onPress(nft)}
+      style={{
+        border: 'none',
+        padding: 0,
+        background: 'transparent',
+        cursor: 'pointer',
+        width: '100%',
+      }}
+      aria-label="Open NFT"
+      title="Open NFT"
+    >
+      <div
+        style={{
+          width: '100%',
+          aspectRatio: '1 / 1',
+          borderRadius: 18,
+          overflow: 'hidden',
+          backgroundColor: iconColor,
+        }}
+      >
+        <NftImage src={nft.image} backgroundColor={iconColor} fallbackText={fallbackText} />
+      </div>
+    </button>
+  );
+};
+
+const NftGallery: React.FC = () => {
+  const navigate = useNavigate();
+  const { network } = useContext(NetworkContext);
+  const { accountNumber } = useContext(AccountNumberContext);
+  const { nftList, isLoading, error } = useNftDiscovery(network, accountNumber, BackgroundCaller, LayerzStorage);
+
+  const data = useMemo(() => nftList ?? [], [nftList]);
+
+  const handleOpenNft = useCallback(
+    (nft: NftInfo) => {
+      navigate(`/Nft?nft=${buildNftParam(nft)}`);
+    },
+    [navigate]
+  );
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <ThemedText type="headline">NFTs</ThemedText>
+
+      {error ? (
+        <div style={{ textAlign: 'center', padding: 20, color: 'red' }}>Error: {error.message}</div>
+      ) : isLoading && data.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: 20, color: '#666' }}>Loading…</div>
+      ) : data.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: 20, color: '#666' }}>No NFTs</div>
+      ) : (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: ITEM_GAP,
+            padding: '12px 18px 18px 18px',
+          }}
+        >
+          {data.map((nft) => (
+            <NftTile key={keyForNft(nft)} nft={nft} onPress={handleOpenNft} />
+          ))}
+        </div>
+      )}
+
+      <WideButton onClick={() => navigate('/')} style={{ marginTop: 6 }}>
+        Back to Wallet
+      </WideButton>
+    </div>
+  );
+};
+
+export default NftGallery;

--- a/ext/src/pages/Popup/Popup.tsx
+++ b/ext/src/pages/Popup/Popup.tsx
@@ -44,6 +44,8 @@ import TestPage from './TestPage';
 import TransactionSuccessEvm from './TransactionSuccessEvm';
 import UnlockPassword from './UnlockPassword';
 import SendTokenStacks from './SendTokenStacks';
+import NftGallery from './NftGallery';
+import Nft from './Nft';
 
 const AppContent: React.FC = () => {
   const navigate = useNavigate();
@@ -110,6 +112,8 @@ const AppContent: React.FC = () => {
             {/* we are using camel case because screen name matches one in the mobile app */}
             <Route path="/SwapXArkDeposit" element={<SwapXArkDeposit />} />
             <Route path="/swap-xark-claim" element={<SwapXArkClaim />} />
+            <Route path="/NftGallery" element={<NftGallery />} />
+            <Route path="/Nft" element={<Nft />} />
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/transaction-success" element={<TransactionSuccessEvm />} />
             <Route path="/action" element={<Action />} />

--- a/ext/src/pages/Popup/components/NftsView.tsx
+++ b/ext/src/pages/Popup/components/NftsView.tsx
@@ -1,0 +1,160 @@
+import React, { useCallback, useContext, useEffect, useImperativeHandle, useMemo, useState, forwardRef } from 'react';
+import { useNavigate } from 'react-router';
+
+import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
+import { NetworkContext } from '@shared/hooks/NetworkContext';
+import { useNftDiscovery } from '@shared/hooks/useNftDiscovery';
+import { getTokenIconColor } from '@shared/models/token-list';
+import { NftInfo } from '@shared/types/token-info';
+
+import NftImage from '../../../components/NftImage';
+import { BackgroundCaller } from '../../../modules/background-caller';
+import { LayerzStorage } from '../../../class/layerz-storage';
+import { ThemedText } from '../../../components/ThemedText';
+
+const MAX_PREVIEW_ITEMS = 4;
+
+function buildNftParam(nft: NftInfo) {
+  return encodeURIComponent(JSON.stringify(nft));
+}
+
+const NftPreviewItem: React.FC<{
+  nft: NftInfo;
+  onPress: (nft: NftInfo) => void;
+  selected: boolean;
+  style?: React.CSSProperties;
+}> = ({ nft, onPress, selected, style }) => {
+  const iconColor = getTokenIconColor(nft?.name);
+  const fallbackText = nft?.name?.charAt(0) || '?';
+
+  return (
+    <button
+      style={{
+        border: '1px solid #e0e0e0',
+        borderRadius: 8,
+        padding: 6,
+        background: 'white',
+        cursor: 'pointer',
+        opacity: selected ? 0.9 : 1,
+        ...style,
+      }}
+      onClick={() => onPress(nft)}
+      title={nft?.name ? `NFT ${nft.name}` : 'NFT'}
+      aria-label={nft?.name ? `NFT ${nft.name}` : 'NFT'}
+    >
+      <div
+        style={{
+          width: 64,
+          height: 64,
+          borderRadius: 8,
+          overflow: 'hidden',
+          backgroundColor: iconColor,
+        }}
+      >
+        <NftImage src={nft.image} backgroundColor={iconColor} fallbackText={fallbackText} />
+      </div>
+    </button>
+  );
+};
+
+const NftsView = forwardRef<{ refresh: () => void }, { selectedNft?: string; onViewGalleryPress?: () => void }>(({ selectedNft, onViewGalleryPress }, ref) => {
+  const navigate = useNavigate();
+  const { network } = useContext(NetworkContext);
+  const { accountNumber } = useContext(AccountNumberContext);
+  const { nftList, error, mutate } = useNftDiscovery(network, accountNumber, BackgroundCaller, LayerzStorage);
+  const [show, setShow] = useState(false);
+
+  const data = useMemo(() => nftList ?? [], [nftList]);
+
+  const handleViewGalleryPress = useCallback(() => {
+    if (onViewGalleryPress) return onViewGalleryPress();
+    navigate('/NftGallery');
+  }, [navigate, onViewGalleryPress]);
+
+  const handleNftPress = useCallback(
+    (nft: NftInfo) => {
+      navigate(`/Nft?nft=${buildNftParam(nft)}`);
+    },
+    [navigate]
+  );
+
+  useEffect(() => {
+    if (data.length > 0) setShow(true);
+  }, [data.length]);
+
+  useImperativeHandle(ref, () => ({
+    refresh: () => {
+      mutate();
+    },
+  }));
+
+  if (error) {
+    return (
+      <div style={{ padding: 10, marginTop: 10 }}>
+        <h2 style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10, textAlign: 'center' }}>NFTs</h2>
+        <div style={{ textAlign: 'center', padding: 20, color: 'red' }}>Error: {error.message}</div>
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  const previewNfts = data.slice(0, MAX_PREVIEW_ITEMS);
+  const hasMoreThanPreview = data.length > MAX_PREVIEW_ITEMS;
+
+  return (
+    <div
+      style={{
+        padding: 10,
+        marginTop: 10,
+        display: !show ? 'none' : 'block',
+      }}
+    >
+      <h2 style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10, textAlign: 'center' }}>NFTs</h2>
+
+      <div
+        style={{
+          padding: 12,
+          border: '1px solid #e0e0e0',
+          borderRadius: 8,
+          margin: '4px 8px',
+          background: 'white',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: 20,
+          flexWrap: 'wrap',
+        }}
+      >
+        {previewNfts.map((nft) => (
+          <NftPreviewItem key={`${nft.contractAddress}:${nft.tokenId}`} nft={nft} onPress={handleNftPress} selected={selectedNft === nft.tokenId} />
+        ))}
+      </div>
+
+      {hasMoreThanPreview ? (
+        <button
+          style={{
+            margin: '4px 8px',
+            width: 'calc(100% - 16px)',
+            backgroundColor: 'white',
+            border: '1px solid #e0e0e0',
+            borderRadius: 8,
+            padding: 12,
+            cursor: 'pointer',
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+          onClick={handleViewGalleryPress}
+        >
+          <ThemedText style={{ fontSize: 14, fontWeight: 700, color: '#666' }}>View Gallery</ThemedText>
+        </button>
+      ) : null}
+    </div>
+  );
+});
+
+NftsView.displayName = 'NftsView';
+
+export default NftsView;

--- a/shared/hooks/useNftDiscovery.ts
+++ b/shared/hooks/useNftDiscovery.ts
@@ -5,7 +5,7 @@ import { StacksWallet } from '../class/wallets/stacks-wallet';
 import { IBackgroundCaller } from '../types/IBackgroundCaller';
 import { IStorage } from '../types/IStorage';
 import { NETWORK_SPARK, NETWORK_STACKS, Networks } from '../types/networks';
-import { CachedTokenInfo, NftInfo } from '../types/token-info';
+import { NftInfo } from '../types/token-info';
 
 const STORAGE_KEY_CACHED_NFT = 'STORAGE_KEY_CACHED_NFT';
 


### PR DESCRIPTION
ported by cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces NFT discovery with cached Stacks support, adds gallery/detail screens and Home preview, and resolves IPFS NFT images.
> 
> - **UI (Extension)**
>   - Add NFT gallery `ext/src/pages/Popup/NftGallery.tsx` and NFT detail `ext/src/pages/Popup/Nft.tsx`; register routes in `ext/src/pages/Popup/Popup.tsx`.
>   - Integrate `NftsView` preview into `ext/src/pages/Popup/Home.tsx` with refresh support; add `ext/src/pages/Popup/components/NftsView.tsx`.
>   - New `ext/src/components/NftImage.tsx` to render NFT images with IPFS URL resolution and fallback.
> - **Data/Logic**
>   - Implement `shared/hooks/useNftDiscovery.ts` using SWR to fetch/cache Stacks NFTs via background caller; returns `nftList`, loading/error, and `mutate` for refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68ec79da282ed87e018a98e11075748c391a5225. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->