### PR TITLE
feat: prettify ext ui

### DIFF
--- a/ext/src/pages/Popup/DesignSystem.tsx
+++ b/ext/src/pages/Popup/DesignSystem.tsx
@@ -79,11 +79,11 @@ export const ActionPopupButton: React.FC<{
         ref={buttonRef}
         onClick={handleClick}
         style={{
-          backgroundColor: '#282c34',
-          color: 'white',
-          border: '1px solid white',
+          backgroundColor: '#0c1f6c',
+          color: '#fbfff9',
+          border: '0px solid white',
           padding: '10px 20px',
-          borderRadius: '5px',
+          borderRadius: '9px',
           cursor: 'pointer',
           fontSize: '20px',
           transition: 'background-color 0.3s',
@@ -151,7 +151,7 @@ export const Switch = <T extends string>({ items, activeItem, onItemClick }: { i
       style={{
         display: 'flex',
         flexWrap: 'wrap',
-        backgroundColor: '#f0f0f0',
+        backgroundColor: '#1c3a88',
         borderRadius: '8px',
         padding: '4px',
         width: '100%',
@@ -165,8 +165,8 @@ export const Switch = <T extends string>({ items, activeItem, onItemClick }: { i
             padding: '8px 16px',
             border: 'none',
             borderRadius: '6px',
-            backgroundColor: item === activeItem ? '#282c34' : 'transparent',
-            color: item === activeItem ? 'white' : '#666',
+            backgroundColor: item === activeItem ? '#fbfff9' : 'transparent',
+            color: item === activeItem ? 'black' : '#666',
             fontWeight: item === activeItem ? 'bold' : 'normal',
             cursor: 'pointer',
             transition: 'all 0.3s ease',
@@ -186,11 +186,11 @@ export const Button: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & { 
     {...props}
     disabled={disabled}
     style={{
-      backgroundColor: '#282c34',
-      color: 'white',
-      border: '1px solid white',
+      backgroundColor: '#0b1f5b',
+      color: '#fbfff9',
+      border: '0px solid white',
       padding: '10px 20px',
-      borderRadius: '5px',
+      borderRadius: '9px',
       cursor: disabled ? 'not-allowed' : 'pointer',
       fontSize: '20px',
       transition: 'background-color 0.3s',
@@ -214,11 +214,11 @@ export const WideButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> 
     {...props}
     disabled={disabled}
     style={{
-      backgroundColor: '#282c34',
-      color: 'white',
-      border: '1px solid white',
+      backgroundColor: '#0c1f6c',
+      color: '#fbfff9',
+      border: '0px solid white',
       padding: '10px 20px',
-      borderRadius: '5px',
+      borderRadius: '9px',
       cursor: disabled ? 'not-allowed' : 'pointer',
       fontSize: '20px',
       transition: 'background-color 0.3s',
@@ -281,11 +281,11 @@ export const HodlButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> 
       onTouchStart={startProgress}
       onTouchEnd={stopProgress}
       style={{
-        backgroundColor: '#282c34',
-        color: 'white',
-        border: '1px solid white',
+        backgroundColor: '#0c1f6c',
+        color: '#fbfff9',
+        border: '0px solid white',
         padding: '10px 20px',
-        borderRadius: '5px',
+        borderRadius: '9px',
         cursor: disabled ? 'not-allowed' : 'pointer',
         fontSize: '20px',
         transition: 'background-color 0.3s',
@@ -360,7 +360,7 @@ export const TextArea: React.FC<React.TextareaHTMLAttributes<HTMLTextAreaElement
 export const Bubble: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div
     style={{
-      backgroundColor: '#ebebeb',
+      backgroundColor: '#0b1f5b',
       borderRadius: '20px',
       padding: '10px 20px',
       marginBottom: '5px',
@@ -475,11 +475,10 @@ export const Card: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     style={{
       width: '95%',
       height: '100%',
-      backgroundColor: 'white',
-      border: '1px solid #ebebeb',
-      borderRadius: '10px',
+      backgroundImage: 'linear-gradient(to bottom, #0c1f6c, #1c3a88)',
+      border: '0px solid #ebebeb',
+      borderRadius: '0px',
       padding: '20px',
-      boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
     }}
   >
     {children}

--- a/ext/src/pages/Popup/Popup.css
+++ b/ext/src/pages/Popup/Popup.css
@@ -1,14 +1,13 @@
 .App {
-  padding: 20px;
-  background-image: linear-gradient(to bottom, #fd5d2b, #9df9ec);
-  color: #011474;
+  padding: 0px;
+  background-image: linear-gradient(to bottom, #0c1f6c, #1c3a88);
+  color: #fbfff9;
   position: absolute;
   top: 0px;
   bottom: 0px;
   left: 0px;
   right: 0px;
   text-align: center;
-  background-color: #fff;
 }
 
 .App-logo {
@@ -29,7 +28,7 @@
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
-  color: #282c34;
+  color: #fbfff9;
 }
 
 .App-link {

--- a/ext/src/pages/Popup/Popup.tsx
+++ b/ext/src/pages/Popup/Popup.tsx
@@ -6,7 +6,6 @@ import { SWRConfig } from 'swr';
 import '../../modules/breeze-adapter'; // needed to be imported before we can use BreezWallet
 import '../../modules/spark-adapter'; // needed to be imported before we can use SparkWallet
 
-import { Hello } from '@shared/class/hello';
 import { AccountNumberContextProvider } from '@shared/hooks/AccountNumberContext';
 import { EStep, InitializationContext, InitializationContextProvider } from '@shared/hooks/InitializationContext';
 import { NetworkContextProvider } from '@shared/hooks/NetworkContext';
@@ -122,10 +121,7 @@ const AppContent: React.FC = () => {
   return (
     <div className="App">
       <header className="App-header">
-        <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <h1 onClick={() => navigate('/')} style={{ margin: 0, cursor: 'pointer' }}>
-            {Hello.world()}
-          </h1>
+        <div style={{ position: 'absolute', top: 0, right: 20 }}>
           <SettingsIcon onClick={() => navigate('/settings')} data-testid="settings-button" />
         </div>
         <Card>

--- a/ext/src/pages/Popup/SwapDetails.tsx
+++ b/ext/src/pages/Popup/SwapDetails.tsx
@@ -125,13 +125,14 @@ const SwapDetails: React.FC = () => {
             marginRight: '12px',
             display: 'flex',
             alignItems: 'center',
+            color: '#fbfff9',
           }}
         >
           <ArrowLeftIcon size={20} />
         </button>
         <div>
           <h2 style={{ margin: 0, fontSize: '18px' }}>{directionText}</h2>
-          <div style={{ fontSize: '14px', color: '#666', marginTop: '2px' }}>{formattedDateWithTime}</div>
+          <div style={{ fontSize: '14px', color: '#fbfff9', marginTop: '2px' }}>{formattedDateWithTime}</div>
         </div>
       </div>
 
@@ -141,7 +142,7 @@ const SwapDetails: React.FC = () => {
           textAlign: 'center',
           marginBottom: '32px',
           padding: '24px',
-          backgroundColor: '#f8f9fa',
+          backgroundColor: '#0c1f6c',
           borderRadius: '12px',
         }}
       >
@@ -150,12 +151,12 @@ const SwapDetails: React.FC = () => {
             fontSize: '32px',
             fontWeight: 'bold',
             marginBottom: '8px',
-            color: '#333',
+            color: '#fbfff9',
           }}
         >
-          {amountPrimary} <span style={{ fontSize: '18px', color: '#666' }}>{ticker}</span>
+          {amountPrimary} <span style={{ fontSize: '18px', color: '#fbfff9' }}>{ticker}</span>
         </div>
-        {amountUsd && <div style={{ fontSize: '16px', color: '#666' }}>{amountUsd}</div>}
+        {amountUsd && <div style={{ fontSize: '16px', color: '#fbfff9' }}>{amountUsd}</div>}
       </div>
 
       {/* Status Chip */}
@@ -185,7 +186,7 @@ const SwapDetails: React.FC = () => {
       {/* Details List */}
       <div
         style={{
-          backgroundColor: '#f8f9fa',
+          backgroundColor: '#0c1f6c',
           borderRadius: '12px',
           padding: '20px',
           marginBottom: '24px',
@@ -204,7 +205,7 @@ const SwapDetails: React.FC = () => {
               borderBottom: '1px solid #e0e0e0',
             }}
           >
-            <span style={{ color: '#666', fontSize: '14px' }}>Swap ID</span>
+            <span style={{ color: '#fbfff9', fontSize: '14px' }}>Swap ID</span>
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
               <button
                 onClick={() => handleCopy(swap.id)}
@@ -213,7 +214,7 @@ const SwapDetails: React.FC = () => {
                   border: 'none',
                   cursor: 'pointer',
                   padding: '2px',
-                  color: '#666',
+                  color: '#fbfff9',
                 }}
                 title="Copy ID"
               >
@@ -243,7 +244,7 @@ const SwapDetails: React.FC = () => {
               borderBottom: '1px solid #e0e0e0',
             }}
           >
-            <span style={{ color: '#666', fontSize: '14px' }}>Date</span>
+            <span style={{ color: '#fbfff9', fontSize: '14px' }}>Date</span>
             <span style={{ fontSize: '14px' }}>{formattedDate}</span>
           </div>
 
@@ -256,7 +257,7 @@ const SwapDetails: React.FC = () => {
               borderBottom: '1px solid #e0e0e0',
             }}
           >
-            <span style={{ color: '#666', fontSize: '14px' }}>Type</span>
+            <span style={{ color: '#fbfff9', fontSize: '14px' }}>Type</span>
             <span style={{ fontSize: '14px' }}>{directionText}</span>
           </div>
 
@@ -269,7 +270,7 @@ const SwapDetails: React.FC = () => {
               borderBottom: '1px solid #e0e0e0',
             }}
           >
-            <span style={{ color: '#666', fontSize: '14px' }}>Network</span>
+            <span style={{ color: '#fbfff9', fontSize: '14px' }}>Network</span>
             <span style={{ fontSize: '14px' }}>{capitalizeFirstLetter(swap.network)}</span>
           </div>
 
@@ -281,14 +282,14 @@ const SwapDetails: React.FC = () => {
               ...(showConfirmations ? { paddingBottom: '8px', borderBottom: '1px solid #e0e0e0' } : {}),
             }}
           >
-            <span style={{ color: '#666', fontSize: '14px' }}>Status</span>
+            <span style={{ color: '#fbfff9', fontSize: '14px' }}>Status</span>
             <span style={{ fontSize: '14px' }}>{capitalizeFirstLetter(swap.status)}</span>
           </div>
 
           {/* Confirmations */}
           {showConfirmations && (
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <span style={{ color: '#666', fontSize: '14px' }}>Confirmations</span>
+              <span style={{ color: '#fbfff9', fontSize: '14px' }}>Confirmations</span>
               <span style={{ fontSize: '14px' }}>
                 {swap.confirmations} / {swap.targetConfirmations}
               </span>
@@ -304,8 +305,8 @@ const SwapDetails: React.FC = () => {
           <Button
             onClick={handleClaim}
             style={{
-              backgroundColor: '#4CAF50',
-              color: 'white',
+              backgroundColor: '#0c1f6c',
+              color: '#fbfff9',
               padding: '12px 24px',
               fontSize: '16px',
               fontWeight: '600',
@@ -320,8 +321,8 @@ const SwapDetails: React.FC = () => {
           <Button
             onClick={handleOpenInExplorer}
             style={{
-              backgroundColor: '#f0f0f0',
-              color: '#333',
+              backgroundColor: '#0c1f6c',
+              color: '#fbfff9',
               border: '1px solid #ddd',
               padding: '12px 24px',
               display: 'flex',

--- a/ext/src/pages/Popup/components/Balance.tsx
+++ b/ext/src/pages/Popup/components/Balance.tsx
@@ -81,6 +81,7 @@ const BalanceDefault = forwardRef<{ refresh: () => void }, BalanceProps>(({ netw
 
       <h1>
         <span id="home-balance">{displayBalance}</span> {ticker}
+        &nbsp;<span style={{ fontSize: 14 }}>{displaySubBalance !== '—' ? `$${displaySubBalance}` : ''}</span>
         {canBuyWithFiat ? (
           <span style={{ paddingLeft: '15px' }}>
             <Button onClick={handleBuyClick}>
@@ -88,14 +89,11 @@ const BalanceDefault = forwardRef<{ refresh: () => void }, BalanceProps>(({ netw
             </Button>
           </span>
         ) : null}
-        <div style={{ width: '100%', marginBottom: '15px' }}>
-          <span style={{ fontSize: 14 }}>{displaySubBalance !== '—' ? `$${displaySubBalance}` : ''}</span>
-        </div>
       </h1>
 
-      <h3>
-        <span id="pocket-balance">Pocket balance: {accountBalance ? formatBalance(accountBalance, getDecimalsByNetwork(NETWORK_BITCOIN), 8) : ''}</span> {getTickerByNetwork(NETWORK_BITCOIN)}
-      </h3>
+      <span id="pocket-balance" style={{ position: 'absolute', top: 0, left: 20, fontSize: 14 }}>
+        Pocket balance: {accountBalance ? formatBalance(accountBalance, getDecimalsByNetwork(NETWORK_BITCOIN), 8) : ''} {getTickerByNetwork(NETWORK_BITCOIN)}
+      </span>
     </>
   );
 });
@@ -222,9 +220,9 @@ const BalanceLightning = forwardRef<{ refresh: () => void }, BalanceProps>(({ ne
         ) : null}
       </div>
 
-      <h3>
-        <span id="pocket-balance">Pocket balance: {accountBalance ? formatBalance(accountBalance, getDecimalsByNetwork(NETWORK_BITCOIN), 8) : ''}</span> {getTickerByNetwork(NETWORK_BITCOIN)}
-      </h3>
+      <span id="pocket-balance" style={{ position: 'absolute', top: 0, left: 20, fontSize: 14 }}>
+        Pocket balance: {accountBalance ? formatBalance(accountBalance, getDecimalsByNetwork(NETWORK_BITCOIN), 8) : ''} {getTickerByNetwork(NETWORK_BITCOIN)}
+      </span>
     </>
   );
 });
@@ -325,9 +323,9 @@ const BalanceUsdt = forwardRef<{ refresh: () => void }, BalanceProps>(({ network
         </table>
       </div>
 
-      <h3>
-        <span id="pocket-balance">Pocket balance: {accountBalance ? formatBalance(accountBalance, getDecimalsByNetwork(NETWORK_BITCOIN), 8) : ''}</span> {getTickerByNetwork(NETWORK_BITCOIN)}
-      </h3>
+      <span id="pocket-balance" style={{ position: 'absolute', top: 0, left: 20, fontSize: 14 }}>
+        Pocket balance: {accountBalance ? formatBalance(accountBalance, getDecimalsByNetwork(NETWORK_BITCOIN), 8) : ''} {getTickerByNetwork(NETWORK_BITCOIN)}
+      </span>
     </>
   );
 });

--- a/ext/src/pages/Popup/components/PartnersView.tsx
+++ b/ext/src/pages/Popup/components/PartnersView.tsx
@@ -63,9 +63,9 @@ const PartnersView: React.FC = () => {
             style={{
               display: 'block',
               padding: '1rem',
-              backgroundColor: 'white',
-              borderRadius: '0.5rem',
-              border: '1px solid #e5e7eb',
+              backgroundColor: '#13286c',
+              borderRadius: '9px',
+              border: '0px solid #e5e7eb',
               textDecoration: 'none',
               color: 'inherit',
               transition: 'background-color 0.2s',
@@ -74,7 +74,7 @@ const PartnersView: React.FC = () => {
               e.currentTarget.style.backgroundColor = '#f3f4f6';
             }}
             onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = 'white';
+              e.currentTarget.style.backgroundColor = '#13286c';
             }}
           >
             <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>

--- a/ext/src/pages/Popup/components/SwapListView.tsx
+++ b/ext/src/pages/Popup/components/SwapListView.tsx
@@ -123,7 +123,7 @@ const SwapListView = forwardRef<{ refresh: () => void }>((props, ref) => {
         marginBottom: '20px',
         border: '1px solid #ddd',
         borderRadius: '8px',
-        backgroundColor: '#f9f9f9',
+        backgroundColor: '#0c1f6c',
       }}
     >
       <div
@@ -132,7 +132,7 @@ const SwapListView = forwardRef<{ refresh: () => void }>((props, ref) => {
           alignItems: 'center',
           padding: '12px 16px',
           borderBottom: '1px solid #eee',
-          backgroundColor: '#f0f0f0',
+          backgroundColor: '#0c1f6c',
           borderRadius: '8px 8px 0 0',
         }}
       >

--- a/shared/class/hello.ts
+++ b/shared/class/hello.ts
@@ -1,5 +1,0 @@
-export class Hello {
-  static world(): string {
-    return 'LZ Bitcoin Wallet';
-  }
-}

--- a/shared/models/partners-list.ts
+++ b/shared/models/partners-list.ts
@@ -10,6 +10,13 @@ const partnersList: PartnerInfo[] = [
     description: 'Buy & sell bitcoin non-custodially, p2p',
   },
   {
+    name: 'BTC Map',
+    network: NETWORK_BITCOIN,
+    url: 'https://btcmap.org/map',
+    imgUrl: '',
+    description: 'Find places to spend sats wherever you are',
+  },
+  {
     name: 'Bitrefill',
     network: NETWORK_BITCOIN,
     url: 'https://bitrefill.com',


### PR DESCRIPTION
made it default blue color, like btc on mobile

<img width="914" height="661" alt="image" src="https://github.com/user-attachments/assets/77fdd991-41f0-4f36-a1b0-29bc125c01c7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches popup UI to a blue theme, streamlines header/layout, updates component styles, and adds BTC Map to partners.
> 
> - **UI/Theming**
>   - Switch popup background to blue gradient in `ext/src/pages/Popup/Popup.css` and unify component colors (`#0c1f6c`, `#1c3a88`, `#fbfff9`).
>   - Update `DesignSystem` components (`Button`, `WideButton`, `HodlButton`, `Switch`, `Bubble`, `Card`) to new blue styles and rounded radii.
>   - Restyle swap views: `SwapDetails.tsx` and `components/SwapListView.tsx` with blue panels, text colors, and buttons.
>   - Restyle partners cards in `components/PartnersView.tsx` to blue tiles.
> - **Layout/UX**
>   - Move settings icon to top-right; remove header title and `Hello` usage; delete `shared/class/hello.ts`.
>   - Adjust balances: show USD sub-balance inline in default view and reposition "Pocket balance" as top-left overlay across balance views.
> - **Content**
>   - Add `BTC Map` entry to `shared/models/partners-list.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04dafe04097c9c3aa85788e18b2461637b01136a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->