### PR TITLE
feat: send nft

### DIFF
--- a/mobile/app/Nft.tsx
+++ b/mobile/app/Nft.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from 'react';
 import { Linking, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
-import { Stack, useLocalSearchParams } from 'expo-router';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
 import { MaterialIcons } from '@expo/vector-icons';
 
@@ -37,6 +37,7 @@ function buildExplorerUrl(nft: NftInfo): string {
 export default function Nft() {
   const params = useLocalSearchParams<NftScreenParams>();
   const { network } = useContext(NetworkContext);
+  const router = useRouter();
 
   const nft = useMemo(() => parseNftParam(params.nft), [params.nft]);
 
@@ -60,6 +61,12 @@ export default function Nft() {
     if (!nft) return;
     const url = buildExplorerUrl(nft);
     Linking.openURL(url);
+  };
+
+  const handleSend = () => {
+    if (!nft) return;
+    const sendParams: NftScreenParams = { nft: JSON.stringify(nft) };
+    router.push({ pathname: '/SendNft', params: sendParams });
   };
 
   if (!nft) {
@@ -123,9 +130,20 @@ export default function Nft() {
         </ScrollView>
 
         <View style={styles.bottomButtonWrap}>
-          <TouchableOpacity style={styles.explorerButton} onPress={handleOpenInExplorer} activeOpacity={0.85}>
-            <ThemedText style={styles.explorerButtonText}>View on explorer</ThemedText>
-          </TouchableOpacity>
+          <View style={styles.bottomButtonsRow}>
+            <TouchableOpacity style={styles.actionButton} onPress={handleSend} activeOpacity={0.85} accessibilityRole="button" accessibilityLabel="Send NFT">
+              <MaterialIcons name="call-made" size={20} color="rgba(255, 255, 255, 0.95)" />
+              <ThemedText style={styles.actionButtonText} numberOfLines={1}>
+                Send
+              </ThemedText>
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.actionButton} onPress={handleOpenInExplorer} activeOpacity={0.85} accessibilityRole="button" accessibilityLabel="View NFT on explorer">
+              <ThemedText style={styles.actionButtonText} numberOfLines={1}>
+                View on explorer
+              </ThemedText>
+            </TouchableOpacity>
+          </View>
         </View>
       </View>
     </GradientScreen>
@@ -223,14 +241,22 @@ const styles = StyleSheet.create({
     right: 18,
     bottom: 22,
   },
-  explorerButton: {
+  bottomButtonsRow: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  actionButton: {
     backgroundColor: 'rgba(255, 255, 255, 0.35)',
     borderRadius: 14,
     paddingVertical: 16,
     alignItems: 'center',
     justifyContent: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 12,
   },
-  explorerButtonText: {
+  actionButtonText: {
     fontSize: 16,
     fontWeight: '600',
     color: 'rgba(255, 255, 255, 0.95)',

--- a/mobile/app/NftGallery.tsx
+++ b/mobile/app/NftGallery.tsx
@@ -52,29 +52,39 @@ export default function NftGallery() {
       <View style={styles.root}>
         <ScreenHeader title="NFTs" />
 
-        {error ? (
-          <View style={styles.center}>
-            <ThemedText style={styles.errorText}>Error: {error.message}</ThemedText>
-          </View>
-        ) : isLoading && data.length === 0 ? (
-          <View style={styles.center}>
-            <ActivityIndicator size="large" color="rgba(255, 255, 255, 0.8)" />
-          </View>
-        ) : data.length === 0 ? (
-          <View style={styles.center}>
-            <ThemedText style={styles.emptyText}>No NFTs</ThemedText>
-          </View>
-        ) : (
-          <FlatList
-            data={data}
-            numColumns={2}
-            keyExtractor={keyForNft}
-            renderItem={({ item }) => <NftTile nft={item} onPress={handleOpenNft} />}
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={styles.listContent}
-            columnWrapperStyle={styles.columnWrapper}
-          />
-        )}
+        {(() => {
+          if (isLoading && data.length === 0) {
+            return (
+              <View style={styles.center}>
+                <ActivityIndicator size="large" color="rgba(255, 255, 255, 0.8)" />
+              </View>
+            );
+          }
+
+          if (data.length === 0) {
+            return (
+              <View style={styles.center}>
+                <ThemedText style={styles.emptyText}>No NFTs</ThemedText>
+              </View>
+            );
+          }
+
+          return (
+            <View style={styles.listWrapper}>
+              {error ? <ThemedText style={styles.errorText}>Error: {error.message}</ThemedText> : null}
+              <FlatList
+                data={data}
+                numColumns={2}
+                keyExtractor={keyForNft}
+                renderItem={({ item }) => <NftTile nft={item} onPress={handleOpenNft} />}
+                showsVerticalScrollIndicator={false}
+                style={styles.list}
+                contentContainerStyle={styles.listContent}
+                columnWrapperStyle={styles.columnWrapper}
+              />
+            </View>
+          );
+        })()}
       </View>
     </GradientScreen>
   );
@@ -82,6 +92,12 @@ export default function NftGallery() {
 
 const styles = StyleSheet.create({
   root: {
+    flex: 1,
+  },
+  listWrapper: {
+    flex: 1,
+  },
+  list: {
     flex: 1,
   },
   center: {

--- a/mobile/app/SendNft.tsx
+++ b/mobile/app/SendNft.tsx
@@ -1,0 +1,288 @@
+import { Ionicons } from '@expo/vector-icons';
+import * as bip21 from 'bip21';
+import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, Alert, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { Stack, router, useLocalSearchParams } from 'expo-router';
+
+import GradientScreen from '@/components/GradientScreen';
+import ScreenHeader from '@/components/navigation/ScreenHeader';
+import { ThemedText } from '@/components/ThemedText';
+import { BackgroundExecutor } from '@/src/modules/background-executor';
+import { ScanQrContext } from '@/src/hooks/ScanQrContext';
+import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
+import { NetworkContext } from '@shared/hooks/NetworkContext';
+import { StacksWallet } from '@shared/class/wallets/stacks-wallet';
+import { NftInfo } from '@shared/types/token-info';
+import { NETWORK_STACKS } from '@shared/types/networks';
+import { TSupportedLazyInitWalletNetworks } from '@shared/modules/wallet-utils';
+
+export type SendNftParams = {
+  nft: string;
+};
+
+function parseNftParam(nftParam: string): NftInfo | null {
+  try {
+    return JSON.parse(nftParam) as NftInfo;
+  } catch (_) {
+    return null;
+  }
+}
+
+export default function SendNft() {
+  const params = useLocalSearchParams<SendNftParams>();
+  const { network } = useContext(NetworkContext);
+  const { accountNumber } = useContext(AccountNumberContext);
+  const { scanQr } = useContext(ScanQrContext);
+
+  const nft = useMemo(() => parseNftParam(params.nft), [params.nft]);
+  const title = useMemo(() => {
+    if (!nft) return 'Send NFT';
+    if (nft.name) return `Send ${nft.name}`;
+    const base = nft.collectionName || 'NFT';
+    return nft.tokenId ? `Send ${base}-#${nft.tokenId}` : `Send ${base}`;
+  }, [nft]);
+
+  const [localAddress, setLocalAddress] = useState('');
+  const [sending, setSending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [txid, setTxid] = useState<string | null>(null);
+  const inputRef = useRef<TextInput>(null);
+
+  const handleScanQR = useCallback(async () => {
+    try {
+      const scanned = await scanQr();
+      if (!scanned) return;
+      try {
+        const decoded = bip21.decode(scanned);
+        if (decoded?.address) {
+          setLocalAddress(decoded.address);
+          return;
+        }
+      } catch {
+        // ignore
+      }
+      setLocalAddress(scanned);
+    } catch (e) {
+      Alert.alert('Error', 'Failed to scan QR code');
+    }
+  }, [scanQr]);
+
+  const handleInputWrapperPress = () => {
+    inputRef.current?.focus();
+  };
+
+  const handleSend = useCallback(async () => {
+    if (!nft) return;
+    setErrorMessage('');
+
+    if (network !== NETWORK_STACKS) {
+      Alert.alert('Unsupported', 'NFT sending is currently supported only on Stacks.');
+      return;
+    }
+
+    if (!localAddress.trim()) {
+      setErrorMessage('Please enter a recipient address');
+      return;
+    }
+
+    if (!StacksWallet.isAddressValid(localAddress)) {
+      setErrorMessage('Invalid address');
+      return;
+    }
+
+    setSending(true);
+    try {
+      const wallet: any = await BackgroundExecutor.lazyInitWallet(network as TSupportedLazyInitWalletNetworks, accountNumber);
+      if (typeof wallet?.transferNFT !== 'function') {
+        throw new Error('NFT transfer is not supported by this wallet');
+      }
+
+      const id = await wallet.transferNFT(nft, localAddress);
+      setTxid(id);
+    } catch (e: any) {
+      setErrorMessage(e?.message || 'Failed to send NFT');
+    } finally {
+      setSending(false);
+    }
+  }, [accountNumber, localAddress, network, nft]);
+
+  if (!nft) {
+    return (
+      <GradientScreen variant={network}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.root}>
+          <ScreenHeader title="Send NFT" />
+          <View style={styles.center}>
+            <ThemedText style={styles.errorText}>NFT not found</ThemedText>
+          </View>
+        </View>
+      </GradientScreen>
+    );
+  }
+
+  return (
+    <GradientScreen variant={network}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={styles.root}>
+        <ScreenHeader title={title} />
+
+        <View style={styles.content}>
+          {/* Replicate input + scan button from /send/send-address.tsx */}
+          <View style={styles.inputSection}>
+            <View style={styles.inputContainer}>
+              <TouchableOpacity style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-nft-address-input">
+                <ThemedText style={styles.inputLabel}>To</ThemedText>
+                <TextInput
+                  ref={inputRef}
+                  style={styles.input}
+                  placeholder="Enter address"
+                  placeholderTextColor="rgba(255, 255, 255, 0.8)"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  onChangeText={setLocalAddress}
+                  value={localAddress}
+                  editable={!sending && !txid}
+                  testID="send-nft-recipient-input"
+                />
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.scanButton} onPress={handleScanQR} disabled={sending || Boolean(txid)} testID="send-nft-scan-button">
+                <Ionicons name="scan-outline" size={24} color="rgba(255, 255, 255, 0.8)" />
+              </TouchableOpacity>
+            </View>
+
+            {errorMessage && (
+              <View style={styles.errorContainer}>
+                <Ionicons name="close" size={16} color="white" />
+                <ThemedText style={styles.errorText}>{errorMessage}</ThemedText>
+              </View>
+            )}
+          </View>
+
+          {txid ? (
+            <View style={styles.successBox}>
+              <ThemedText style={styles.successTitle}>NFT sent</ThemedText>
+              <ThemedText style={styles.successSub} numberOfLines={1} ellipsizeMode="middle">
+                Tx: {txid}
+              </ThemedText>
+              <TouchableOpacity style={styles.secondaryButton} onPress={() => router.replace('/Home')} activeOpacity={0.85} testID="send-nft-back-button">
+                <ThemedText style={styles.secondaryButtonText}>Back to Wallet</ThemedText>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <TouchableOpacity style={styles.primaryButton} onPress={handleSend} activeOpacity={0.85} disabled={sending} testID="send-nft-send-button">
+              {sending ? <ActivityIndicator color="rgba(255,255,255,0.95)" /> : <ThemedText style={styles.primaryButtonText}>Send</ThemedText>}
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+    </GradientScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  content: {
+    paddingHorizontal: 18,
+    paddingTop: 14,
+  },
+  // Copied from /send/send-address.tsx
+  inputSection: {
+    marginBottom: 30,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    borderRadius: 20,
+    height: 64,
+    paddingLeft: 24,
+    paddingRight: 12,
+    gap: 12,
+  },
+  inputWrapper: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  inputLabel: {
+    color: 'rgba(255, 255, 255, 0.5)',
+    fontSize: 14,
+    fontWeight: '400',
+    marginBottom: 4,
+  },
+  input: {
+    color: 'rgba(255, 255, 255, 0.8)',
+    fontSize: 16,
+    padding: 0,
+    margin: 0,
+  },
+  scanButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  errorContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+    gap: 6,
+  },
+  errorText: {
+    color: 'white',
+    fontSize: 14,
+  },
+  primaryButton: {
+    marginTop: 14,
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+    borderRadius: 16,
+    paddingVertical: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.15)',
+  },
+  primaryButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: 'rgba(255, 255, 255, 0.95)',
+  },
+  successBox: {
+    marginTop: 18,
+    padding: 14,
+    borderRadius: 16,
+    backgroundColor: 'rgba(0, 0, 0, 0.18)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.12)',
+  },
+  successTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: 'rgba(255, 255, 255, 0.95)',
+    marginBottom: 6,
+  },
+  successSub: {
+    fontSize: 13,
+    color: 'rgba(255, 255, 255, 0.75)',
+  },
+  secondaryButton: {
+    marginTop: 14,
+    backgroundColor: 'rgba(255, 255, 255, 0.16)',
+    borderRadius: 14,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: 'rgba(255, 255, 255, 0.95)',
+  },
+});

--- a/mobile/components/NftsView.tsx
+++ b/mobile/components/NftsView.tsx
@@ -71,15 +71,6 @@ const NftsView = forwardRef<{ refresh: () => void }, { selectedNft?: string; onV
     },
   }));
 
-  if (error) {
-    return (
-      <View style={styles.container}>
-        <ThemedText style={styles.title}>NFT</ThemedText>
-        <ThemedText style={styles.errorText}>Error: {error.message}</ThemedText>
-      </View>
-    );
-  }
-
   if (nftList.length === 0) {
     return null;
   }
@@ -101,6 +92,8 @@ const NftsView = forwardRef<{ refresh: () => void }, { selectedNft?: string; onV
           />
         ))}
       </View>
+
+      {error ? <ThemedText style={styles.errorText}>Error: {error.message}</ThemedText> : null}
 
       {hasMoreThanPreview && (
         <TouchableOpacity
@@ -142,6 +135,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: 'rgba(255, 100, 100, 0.8)',
     textAlign: 'center',
+    paddingTop: 8,
   },
   previewRow: {
     flexDirection: 'row',

--- a/shared/class/wallets/stacks-wallet.ts
+++ b/shared/class/wallets/stacks-wallet.ts
@@ -143,8 +143,12 @@ export class StacksWallet implements InterfaceAccountBasedWallet, InterfaceCanHa
       },
     });
 
+    if (!Array.isArray(nftBalances?.results)) {
+      throw new Error('Failed to fetch NFTs for Stacks');
+    }
+
     const nfts: NftInfo[] = [];
-    for (const token of nftBalances?.results || []) {
+    for (const token of nftBalances.results || []) {
       const contractAddress = token.asset_identifier.split('::')[0];
       const tokenId = token.value.repr.replace('u', '');
 
@@ -406,6 +410,45 @@ export class StacksWallet implements InterfaceAccountBasedWallet, InterfaceCanHa
     }
 
     throw new Error(`Failed to broadcast sBTC transfer: ${JSON.stringify(broadcastResponse)}`);
+  }
+
+  async transferNFT(nft: NftInfo, address: string): Promise<string> {
+    assert(this._sdkWallet, 'Stacks wallet is not initialized');
+    assert(this._sdkWallet.accounts[this._accountNumber], 'Stacks account not found');
+    assert(address, 'Recipient address is required');
+    assert(validateStacksAddress(address), 'Recipient address is invalid');
+
+    const [contractAddress, contractName] = nft.contractAddress.split('.');
+    assert(contractAddress && contractName, `Incorrect Stacks contract identifier for NFT: ${nft.contractAddress}`);
+
+    const senderKey = this._sdkWallet.accounts[this._accountNumber].stxPrivateKey;
+    const senderAddress = await this.getOffchainReceiveAddress();
+
+    // token ids come as strings in our types; ensure we can build a uint CV
+    const tokenId = BigInt(nft.tokenId.replace(/^u/, ''));
+
+    // SIP-009 NFTs commonly expose: (transfer (token-id uint) (sender principal) (recipient principal))
+    const transaction = await makeContractCall({
+      contractAddress,
+      contractName,
+      functionName: 'transfer',
+      functionArgs: [uintCV(tokenId), standardPrincipalCV(senderAddress), standardPrincipalCV(address)],
+      senderKey,
+      network: 'mainnet',
+      postConditionMode: 'allow',
+    });
+
+    const broadcastResponse: any = await broadcastTransaction({ transaction });
+
+    if (broadcastResponse && typeof broadcastResponse.txid === 'string') {
+      return broadcastResponse.txid;
+    }
+
+    if (typeof broadcastResponse === 'string') {
+      return broadcastResponse;
+    }
+
+    throw new Error(`Failed to broadcast NFT transfer: ${JSON.stringify(broadcastResponse)}`);
   }
 
   /**

--- a/shared/hooks/useBalance.ts
+++ b/shared/hooks/useBalance.ts
@@ -121,7 +121,7 @@ export function useBalance(network: Networks, accountNumber: number, backgroundC
       break;
 
     case NETWORK_STACKS:
-      refreshInterval = 5_000; // stacks block time
+      refreshInterval = 10_000; // stacks block time
       break;
 
     case NETWORK_LIGHTNING:

--- a/shared/hooks/useNftDiscovery.ts
+++ b/shared/hooks/useNftDiscovery.ts
@@ -55,9 +55,13 @@ export const nftDiscoveryFetcher = async (arg: nftDiscoveryFetcherArg): Promise<
   return [];
 };
 
-export function useNftDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, storage: IStorage, refreshInterval = 5_000) {
-  // Only enable refresh interval for NETWORK_SPARK & NETWORK_STACKS
-  const shouldRefresh = network === NETWORK_SPARK || network === NETWORK_STACKS;
+export function useNftDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, storage: IStorage, refreshInterval = 10_000) {
+  let shouldRefresh = false;
+  switch (network) {
+    case NETWORK_STACKS:
+      shouldRefresh = true;
+      break;
+  }
 
   const arg: nftDiscoveryFetcherArg = {
     cacheKey: 'nftDiscoveryFetcher',

--- a/shared/tests/integration-vi/stacks-wallet.test.ts
+++ b/shared/tests/integration-vi/stacks-wallet.test.ts
@@ -67,7 +67,7 @@ test('stacks wallet can get tokens', async (context) => {
     {
       id: 'STX',
       logoURI: 'https://static.tildacdn.net/tild6638-6331-4134-b936-386137393566/favicon_6.ico',
-      balance: '97074379',
+      balance: '94616451',
       name: 'STX',
       chainId: 0,
       symbol: 'STX',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Send NFT flow on mobile (Stacks only), including a new screen, send button from NFT details, wallet `transferNFT`, and refresh/error handling tweaks.
> 
> - **Mobile (UI/Flows)**
>   - Add `app/SendNft.tsx` screen to send NFTs (QR scan, address validation, progress/success states; Stacks-only).
>   - Update `app/Nft.tsx` to include a bottom "Send" action and route to `SendNft`.
>   - Improve `app/NftGallery.tsx` conditional rendering; show list with inline error and loaders; add list wrapper styles.
>   - Tweak `components/NftsView.tsx` to surface errors below preview and remove early error-return.
> - **Stacks Wallet / Data**
>   - Add `StacksWallet.transferNFT(nft, address)` using contract call to SIP-009 `transfer`.
>   - Harden `fetchNfts()` (validate API results) and minor loop cleanup.
>   - Adjust refresh intervals: `useBalance` (Stacks: 10s) and `useNftDiscovery` default/Stacks-enabled refresh.
> - **Tests**
>   - Update Stacks token balance expectation and add integration tests for NFTs and common transactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28c0cc9c9272cced95e72f88f33a2a9b4308e4c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->