### PR TITLE
refactor: do not use cache in usetokendiscovery hook

### DIFF
--- a/ext/src/pages/Popup/components/Balance.tsx
+++ b/ext/src/pages/Popup/components/Balance.tsx
@@ -27,7 +27,6 @@ import {
   Networks,
 } from '@shared/types/networks';
 import { CachedTokenInfo } from '@shared/types/token-info';
-import { LayerzStorage } from '../../../class/layerz-storage';
 import { Button } from '../DesignSystem';
 
 interface BalanceProps {
@@ -261,8 +260,8 @@ const USDTTokenRow: React.FC<{
 const BalanceUsdt = forwardRef<{ refresh: () => void }, BalanceProps>(({ network, accountNumber, BackgroundCaller }, ref) => {
   const availableNetworks = useAvailableNetworks();
   const { accountBalance } = useAccountBalance(accountNumber, availableNetworks);
-  const { tokenList: rsTokenListOrig, mutate: mutateRsTokens } = useTokenDiscovery(NETWORK_ROOTSTOCK, accountNumber, BackgroundCaller, LayerzStorage);
-  const { tokenList: liquidTokenListOrig, mutate: mutateLiquidTokens } = useTokenDiscovery(NETWORK_LIQUID, accountNumber, BackgroundCaller, LayerzStorage);
+  const { tokenList: rsTokenListOrig, mutate: mutateRsTokens } = useTokenDiscovery(NETWORK_ROOTSTOCK, accountNumber, BackgroundCaller);
+  const { tokenList: liquidTokenListOrig, mutate: mutateLiquidTokens } = useTokenDiscovery(NETWORK_LIQUID, accountNumber, BackgroundCaller);
   const [tokenBalances, setTokenBalances] = useState<TTokenBalances>({});
   const ticker = getTickerByNetwork(network);
 

--- a/ext/src/pages/Popup/components/TokensView.tsx
+++ b/ext/src/pages/Popup/components/TokensView.tsx
@@ -12,7 +12,6 @@ import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-uti
 
 import { BackgroundCaller } from '../../../modules/background-caller';
 import { SendTokenEvmProps } from '../SendTokenEvm';
-import { LayerzStorage } from '../../../class/layerz-storage';
 import { SendTokenStacksProps } from '@/pages/Popup/SendTokenStacks';
 
 const TokenRow: React.FC<{ token: CachedTokenInfo; setShow: (show: boolean) => void }> = ({ token, setShow }) => {
@@ -113,7 +112,7 @@ const TokenRow: React.FC<{ token: CachedTokenInfo; setShow: (show: boolean) => v
 const TokensView = forwardRef<{ refresh: () => void }>((props, ref) => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
-  const { tokenList, error, mutate } = useTokenDiscovery(network, accountNumber, BackgroundCaller, LayerzStorage);
+  const { tokenList, error, mutate } = useTokenDiscovery(network, accountNumber, BackgroundCaller);
   const [show, setShow] = useState(false);
 
   useImperativeHandle(ref, () => ({

--- a/mobile/components/Balance.tsx
+++ b/mobile/components/Balance.tsx
@@ -7,7 +7,6 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { OnrampProps } from '@/app/Onramp';
 import { ThemedText } from '@/components/ThemedText';
-import { LayerzStorage } from '@/src/class/layerz-storage';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { getNetworkImageAsset } from '@/utils/networkAssets';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
@@ -260,8 +259,8 @@ const TokenRow = ({ network, token, setTokenBalances }: { network: Networks; tok
 const BalanceUsdt = forwardRef<{ refresh: () => void }>((props, ref) => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
-  const { tokenList: rsTokenListOrig, mutate: mutateRsTokens } = useTokenDiscovery(NETWORK_ROOTSTOCK, accountNumber, BackgroundExecutor, LayerzStorage);
-  const { tokenList: liquidTokenListOrig, mutate: mutateLiquidTokens } = useTokenDiscovery(NETWORK_LIQUID, accountNumber, BackgroundExecutor, LayerzStorage);
+  const { tokenList: rsTokenListOrig, mutate: mutateRsTokens } = useTokenDiscovery(NETWORK_ROOTSTOCK, accountNumber, BackgroundExecutor);
+  const { tokenList: liquidTokenListOrig, mutate: mutateLiquidTokens } = useTokenDiscovery(NETWORK_LIQUID, accountNumber, BackgroundExecutor);
   const [tokenBalances, setTokenBalances] = useState<TTokenBalances>({});
   const ticker = getTickerByNetwork(network);
 

--- a/mobile/components/TokensView.tsx
+++ b/mobile/components/TokensView.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect, useImperativeHandle, useState, forwardRef
 import { Image, StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
-import { LayerzStorage } from '@/src/class/layerz-storage';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
@@ -71,7 +70,7 @@ const TokenRow: React.FC<{ token: CachedTokenInfo; onPress: (token: CachedTokenI
 const TokensView = forwardRef<{ refresh: () => void }, { onTokenPress: (token: CachedTokenInfo) => void; selectedToken?: string }>(({ onTokenPress, selectedToken }, ref) => {
   const { network } = useContext(NetworkContext);
   const { accountNumber } = useContext(AccountNumberContext);
-  const { tokenList, error, mutate } = useTokenDiscovery(network, accountNumber, BackgroundExecutor, LayerzStorage);
+  const { tokenList, error, mutate } = useTokenDiscovery(network, accountNumber, BackgroundExecutor);
   const [show, setShow] = useState(false);
 
   useImperativeHandle(ref, () => ({

--- a/mobile/hooks/withAsset.tsx
+++ b/mobile/hooks/withAsset.tsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 
 import { useSendFlow } from '@/app/send/_layout';
-import { LayerzStorage } from '@/src/class/layerz-storage';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { useBalance } from '@shared/hooks/useBalance';
@@ -29,7 +28,7 @@ export const withAsset = <P extends object>(Component: React.ComponentType<P & S
     const { network, token } = useSendFlow();
     const { accountNumber } = useContext(AccountNumberContext);
     const { balance: tokenBalance } = useTokenBalance(network, accountNumber, token!, BackgroundExecutor);
-    const { tokenList } = useTokenDiscovery(network, accountNumber, BackgroundExecutor, LayerzStorage);
+    const { tokenList } = useTokenDiscovery(network, accountNumber, BackgroundExecutor);
     const { tokenExchangeRate } = useTokenExchangeRate(network, token ?? '', 'USD');
     const tokenInfo = tokenList.find((t) => t.id === token);
 

--- a/shared/hooks/useTokenDiscovery.ts
+++ b/shared/hooks/useTokenDiscovery.ts
@@ -5,83 +5,29 @@ import { SparkWallet } from '../class/wallets/spark-wallet';
 import { StacksWallet } from '../class/wallets/stacks-wallet';
 import { getTokenList } from '../models/token-list';
 import { IBackgroundCaller } from '../types/IBackgroundCaller';
-import { IStorage } from '../types/IStorage';
 import { NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_SPARK, NETWORK_STACKS, Networks } from '../types/networks';
 import { CachedTokenInfo } from '../types/token-info';
-
-const STORAGE_KEY_CACHED_TOKEN_LIST = 'STORAGE_KEY_CACHED_TOKEN_LIST_V2';
 
 interface tokenDiscoveryFetcherArg {
   cacheKey: string;
   network: Networks;
   accountNumber: number;
   backgroundCaller: IBackgroundCaller;
-  storage: IStorage;
-}
-
-/**
- * returns cached tokens from storage if present, null otherwise
- */
-async function restoreCachedTokens(cacheKey: string, storage: IStorage): Promise<CachedTokenInfo[] | null> {
-  try {
-    const cachedTokensString = await storage.getItem(cacheKey);
-    const cachedTokens = JSON.parse(cachedTokensString);
-    if (Array.isArray(cachedTokens) && cachedTokens.length > 0) {
-      return cachedTokens;
-    }
-  } catch (_) {}
-  return null;
 }
 
 export const tokenDiscoveryFetcher = async (arg: tokenDiscoveryFetcherArg): Promise<CachedTokenInfo[]> => {
-  const { network, accountNumber, backgroundCaller, storage } = arg;
-
-  const cacheKey = STORAGE_KEY_CACHED_TOKEN_LIST + network + accountNumber;
+  const { network, accountNumber, backgroundCaller } = arg;
 
   if (network === NETWORK_SPARK) {
-    if (!backgroundCaller.lazyInitWalletReady(network, accountNumber)) {
-      // wallet not ready, definitely can use cached tokens (if any)
-      const cachedTokens = await restoreCachedTokens(cacheKey, storage);
-      if (cachedTokens) return cachedTokens;
-    }
-
-    // Lazy initialize Spark wallet
     const wallet = await backgroundCaller.lazyInitWallet(network, accountNumber);
     assert(wallet instanceof SparkWallet, 'Not a Spark wallet');
-
-    // we do NOT fetch from network, we rely on cached value inside wallet internals
-    if (!wallet._lastBalanceFetch) {
-      // balance never fetched yet, so we can use cached tokens (if any)
-      const cachedTokens = await restoreCachedTokens(cacheKey, storage);
-      if (cachedTokens) return cachedTokens;
-    }
-
-    const tokenInfos: CachedTokenInfo[] = wallet.getTokenBalances();
-    if (tokenInfos.length > 0) {
-      await storage.setItem(cacheKey, JSON.stringify(tokenInfos)); // saving to cache
-    }
-    return tokenInfos;
+    await wallet.fetchTokenBalances();
+    return wallet.getTokenBalances();
   } else if (network === NETWORK_STACKS) {
-    if (!backgroundCaller.lazyInitWalletReady(network, accountNumber)) {
-      // wallet not ready, definitely can use cached tokens (if any)
-      const cachedTokens = await restoreCachedTokens(cacheKey, storage);
-      if (cachedTokens) return cachedTokens;
-    }
-
     const wallet = await backgroundCaller.lazyInitWallet(network, accountNumber);
     assert(wallet instanceof StacksWallet, 'Not a Stacks wallet');
-
     await wallet.fetchTokenBalances();
-    const tokenInfos: CachedTokenInfo[] = [];
-    for (const token of wallet.getTokenBalances()) {
-      tokenInfos.push(token);
-    }
-
-    if (tokenInfos.length > 0) {
-      await storage.setItem(cacheKey, JSON.stringify(tokenInfos)); // saving to cache
-    }
-
-    return tokenInfos;
+    return wallet.getTokenBalances();
   } else if (network === NETWORK_LIQUID || network === NETWORK_LIQUID_TESTNET) {
     const tokens = getTokenList(network).map((token) => ({
       ...token,
@@ -99,7 +45,7 @@ export const tokenDiscoveryFetcher = async (arg: tokenDiscoveryFetcherArg): Prom
   }
 };
 
-export function useTokenDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, storage: IStorage, refreshInterval = 5_000) {
+export function useTokenDiscovery(network: Networks, accountNumber: number, backgroundCaller: IBackgroundCaller, refreshInterval = 5_000) {
   // Only enable refresh interval for NETWORK_SPARK & NETWORK_STACKS
   const shouldRefresh = network === NETWORK_SPARK || network === NETWORK_STACKS;
 
@@ -108,7 +54,6 @@ export function useTokenDiscovery(network: Networks, accountNumber: number, back
     network,
     accountNumber,
     backgroundCaller,
-    storage,
   };
 
   const { data, error, isLoading, mutate } = useSWR(arg, tokenDiscoveryFetcher, {


### PR DESCRIPTION
Since we are using SWR, it already has a built-in caching mechanism, so we do not need to apply it manually.