### PR TITLE
chore: bump ark

### DIFF
--- a/ext/package-lock.json
+++ b/ext/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.14",
-        "@arkade-os/sdk": "0.3.9",
+        "@arkade-os/boltz-swap": "0.2.16",
+        "@arkade-os/sdk": "0.3.10",
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@breeztech/breez-sdk-liquid": "0.11.11",
         "@buildonspark/spark-sdk": "0.4.5",
@@ -136,12 +136,12 @@
       }
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.14.tgz",
-      "integrity": "sha512-CiPPxVt7WBJzgrliBAbxmAx53nZ1LtZESViDdzLLp9W6t0PzySEerqlZjBQL8GTAiLvr9rb/EEbKDq2GlEWKVQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.16.tgz",
+      "integrity": "sha512-42vIGlDCvJry1UOifi8jKxfcD3jBjf5Ldfwjs+bz5jfjUZGflCBS2cqZxujtB3vlbANTNUIwP9qI0maE2cFV2A==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.9",
+        "@arkade-os/sdk": "0.3.10",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.9.tgz",
-      "integrity": "sha512-n9yQrhrgcZh4xxgJAyr11RiOjCGkil3WLqEBuSu6o1dNX9utyscvRduXgr6E+qmyi8If1wxKI91Ks0PRGnf+2A==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.10.tgz",
+      "integrity": "sha512-3O/ftt5h9equtbMuzBmWEbw2M8AeDrokoLSMQDvoQF4Lz9y8A0azZyVZjLZJlvNhQFL2ZVH+Y8urSI8YoHpJWg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/ext/package.json
+++ b/ext/package.json
@@ -21,8 +21,8 @@
     "prepare": "cd .. && husky ext/.husky"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.14",
-    "@arkade-os/sdk": "0.3.9",
+    "@arkade-os/boltz-swap": "0.2.16",
+    "@arkade-os/sdk": "0.3.10",
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@breeztech/breez-sdk-liquid": "0.11.11",
     "@buildonspark/spark-sdk": "0.4.5",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.14",
-        "@arkade-os/sdk": "0.3.9",
+        "@arkade-os/boltz-swap": "0.2.16",
+        "@arkade-os/sdk": "0.3.10",
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@breeztech/breez-sdk-liquid": "0.11.11",
         "@breeztech/react-native-breez-sdk-liquid": "0.11.11",
@@ -146,12 +146,12 @@
       "license": "MIT"
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.14.tgz",
-      "integrity": "sha512-CiPPxVt7WBJzgrliBAbxmAx53nZ1LtZESViDdzLLp9W6t0PzySEerqlZjBQL8GTAiLvr9rb/EEbKDq2GlEWKVQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.16.tgz",
+      "integrity": "sha512-42vIGlDCvJry1UOifi8jKxfcD3jBjf5Ldfwjs+bz5jfjUZGflCBS2cqZxujtB3vlbANTNUIwP9qI0maE2cFV2A==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.9",
+        "@arkade-os/sdk": "0.3.10",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.9.tgz",
-      "integrity": "sha512-n9yQrhrgcZh4xxgJAyr11RiOjCGkil3WLqEBuSu6o1dNX9utyscvRduXgr6E+qmyi8If1wxKI91Ks0PRGnf+2A==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.10.tgz",
+      "integrity": "sha512-3O/ftt5h9equtbMuzBmWEbw2M8AeDrokoLSMQDvoQF4Lz9y8A0azZyVZjLZJlvNhQFL2ZVH+Y8urSI8YoHpJWg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -34,8 +34,8 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.14",
-    "@arkade-os/sdk": "0.3.9",
+    "@arkade-os/boltz-swap": "0.2.16",
+    "@arkade-os/sdk": "0.3.10",
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@breeztech/breez-sdk-liquid": "0.11.11",
     "@breeztech/react-native-breez-sdk-liquid": "0.11.11",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates dependency versions across extension and mobile to align with newer Arkade packages.
> 
> - Bump `@arkade-os/boltz-swap` from `0.2.14` -> `0.2.16`
> - Bump `@arkade-os/sdk` from `0.3.9` -> `0.3.10` (including as a transitive dep of `boltz-swap`)
> - Update `ext/package.json`, `mobile/package.json`, and respective `package-lock.json` files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b09551b2b90960a36162c2f8bd5534fc3ecdb029. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->