### PR TITLE
fix: use pressable on expo

### DIFF
--- a/mobile/app/ActionPopupModal.tsx
+++ b/mobile/app/ActionPopupModal.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { GestureResponderEvent, StyleSheet, Text, View } from 'react-native';
+import Pressable from '../components/Pressable';
 import { useRouter } from 'expo-router';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { getGradientColors } from '@/utils/gradientUtils';
@@ -48,8 +49,8 @@ export default function ActionPopupModal() {
   // accessibility is disabled on some wrappers for maestro to be able to see the buttons
 
   return (
-    <TouchableOpacity accessible={false} style={styles.modalOverlay} activeOpacity={1} onPress={handleClose}>
-      <TouchableOpacity accessible={false} activeOpacity={1} onPress={(e) => e.stopPropagation()}>
+    <Pressable accessible={false} style={styles.modalOverlay} activeOpacity={1} onPress={handleClose}>
+      <Pressable accessible={false} activeOpacity={1} onPress={(e: GestureResponderEvent) => e.stopPropagation()}>
         <View accessible={false} style={[styles.popupContainer, { backgroundColor }]}>
           <View style={styles.actionsContainer}>
             {title && (
@@ -58,14 +59,14 @@ export default function ActionPopupModal() {
               </View>
             )}
             {actions.map((action, index) => (
-              <TouchableOpacity accessible={true} key={index} onPress={() => handleActionPress(action.onClick, index)} style={styles.actionItem} activeOpacity={0.8}>
+              <Pressable accessible={true} key={index} onPress={() => handleActionPress(action.onClick, index)} style={styles.actionItem} activeOpacity={0.8}>
                 <View style={styles.actionContent}>{action.children}</View>
-              </TouchableOpacity>
+              </Pressable>
             ))}
           </View>
         </View>
-      </TouchableOpacity>
-    </TouchableOpacity>
+      </Pressable>
+    </Pressable>
   );
 }
 

--- a/mobile/app/BackdoorNetworkSwitcher.tsx
+++ b/mobile/app/BackdoorNetworkSwitcher.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
+import Pressable from '../components/Pressable';
 import { useRouter } from 'expo-router';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { NetworkContext } from '@shared/hooks/NetworkContext';
@@ -19,7 +20,7 @@ const BackdoorNetworkSwitcher: React.FC = () => {
   return (
     <SafeAreaView style={styles.container}>
       {networks.map((network) => (
-        <TouchableOpacity
+        <Pressable
           key={network}
           testID={`backdoor-network-${network}`}
           style={[styles.networkItem, currentNetwork === network && styles.selectedNetworkItem]}
@@ -29,7 +30,7 @@ const BackdoorNetworkSwitcher: React.FC = () => {
           <View style={styles.networkItemContent}>
             <Text>{network}</Text>
           </View>
-        </TouchableOpacity>
+        </Pressable>
       ))}
     </SafeAreaView>
   );

--- a/mobile/app/Changelog.tsx
+++ b/mobile/app/Changelog.tsx
@@ -4,7 +4,8 @@ import { ThemedText } from '@/components/ThemedText';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import * as Linking from 'expo-linking';
 import React, { useContext, useEffect, useState } from 'react';
-import { ActivityIndicator, FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, FlatList, StyleSheet, View } from 'react-native';
+import Pressable from '../components/Pressable';
 
 const gitCommitHash = require('../git_commit_hash.json');
 
@@ -61,9 +62,9 @@ export default function ChangelogScreen() {
   };
 
   const renderCommitItem = ({ item, index }: { item: CommitData; index: number }) => (
-    <TouchableOpacity style={styles.commitItem} onPress={() => openCommitInBrowser(item.sha)}>
+    <Pressable style={styles.commitItem} onPress={() => openCommitInBrowser(item.sha)}>
       <ThemedText style={styles.commitMessage}>{item.commit.message}</ThemedText>
-    </TouchableOpacity>
+    </Pressable>
   );
 
   const renderContent = () => {

--- a/mobile/app/ClaimUsernameModal.tsx
+++ b/mobile/app/ClaimUsernameModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
-import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View, ActivityIndicator } from 'react-native';
+import { ActivityIndicator, GestureResponderEvent, Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
+import Pressable from '../components/Pressable';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { createClient } from '@shared/openapi/generated/layerzme/client';
 import { getApiUsersByUsername, postApiUsers } from '@shared/openapi/generated/layerzme';
@@ -101,7 +102,7 @@ export default function ClaimUsernameModalScreen() {
 
   return (
     <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={[styles.keyboardAvoidingView, { backgroundColor }]} keyboardVerticalOffset={0}>
-      <TouchableOpacity accessible={false} style={[styles.modalContent, { marginBottom: keyboardHeight, backgroundColor }]} activeOpacity={1} onPress={(e) => e.stopPropagation()}>
+      <Pressable accessible={false} style={[styles.modalContent, { marginBottom: keyboardHeight, backgroundColor }]} activeOpacity={1} onPress={(e: GestureResponderEvent) => e.stopPropagation()}>
         <View accessible={false} style={[styles.popupContainer, { backgroundColor }]}>
           <View style={styles.contentContainer}>
             <View style={styles.formBody}>
@@ -126,12 +127,12 @@ export default function ClaimUsernameModalScreen() {
               {Boolean(errorMessage) && <ThemedText style={styles.errorText}>{errorMessage}</ThemedText>}
             </View>
 
-            <TouchableOpacity style={styles.claimButton} onPress={handleClaim} activeOpacity={0.8} disabled={isSubmitting}>
+            <Pressable style={styles.claimButton} onPress={handleClaim} activeOpacity={0.8} disabled={isSubmitting}>
               {isSubmitting ? <ActivityIndicator color="#f7f5ff" /> : <ThemedText style={styles.claimButtonText}>Claim</ThemedText>}
-            </TouchableOpacity>
+            </Pressable>
           </View>
         </View>
-      </TouchableOpacity>
+      </Pressable>
     </KeyboardAvoidingView>
   );
 }

--- a/mobile/app/DAppBrowser.tsx
+++ b/mobile/app/DAppBrowser.tsx
@@ -1,8 +1,9 @@
 import { Asset } from 'expo-asset';
+import Pressable from '../components/Pressable';
 import * as FileSystem from 'expo-file-system';
 import { File as ExpoFsFile, Directory } from 'expo-file-system';
 import React, { useCallback, useContext, useEffect, useRef, useState, useMemo } from 'react';
-import { StyleSheet, TouchableOpacity, View, Alert, TextInput, PanResponder, Image, AppState, AppStateStatus, ViewStyle, StyleProp, Dimensions } from 'react-native';
+import { StyleSheet, View, Alert, TextInput, PanResponder, Image, AppState, AppStateStatus, ViewStyle, StyleProp, Dimensions } from 'react-native';
 import WebView, { WebViewMessageEvent, WebViewNavigation } from 'react-native-webview';
 import { Stack, useLocalSearchParams, useRouter, Link, useNavigation } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -1072,10 +1073,10 @@ const DAppBrowser: React.FC = () => {
           <GestureDetector gesture={panGesture}>
             <Animated.View style={addressBarAnimatedStyle} pointerEvents={showTabsOverview ? 'none' : 'auto'}>
               <View style={[styles.addressContainer, isNetworkSelectorVisible && styles.addressContainerWithSelector]}>
-                {isNetworkSelectorVisible && <TouchableOpacity style={styles.absoluteFill} activeOpacity={1} onPress={hideNetworkSwitcherModal} />}
-                <TouchableOpacity style={styles.networkButton} onPress={showNetworkSwitcherModal} disabled={isNetworkSelectorVisible}>
+                {isNetworkSelectorVisible && <Pressable style={styles.absoluteFill} activeOpacity={1} onPress={hideNetworkSwitcherModal} />}
+                <Pressable style={styles.networkButton} onPress={showNetworkSwitcherModal} disabled={isNetworkSelectorVisible}>
                   <ExpoImage source={getNetworkImageAsset(network)} style={styles.networkIcon} contentFit="contain" />
-                </TouchableOpacity>
+                </Pressable>
                 <View style={styles.addressBarWrapper} pointerEvents={isNetworkSelectorVisible ? 'none' : 'auto'}>
                   <View style={styles.addressBar}>
                     <TextInput
@@ -1123,30 +1124,30 @@ const DAppBrowser: React.FC = () => {
                       testID="DappBrowserAddressBar"
                     />
                     {isAddressInputFocused ? (
-                      <TouchableOpacity style={styles.stopButton} onPress={() => setAddressInput('')}>
+                      <Pressable style={styles.stopButton} onPress={() => setAddressInput('')}>
                         <Ionicons name="close-circle" size={20} color="rgba(255, 255, 255, 0.8)" />
-                      </TouchableOpacity>
+                      </Pressable>
                     ) : isLoading ? (
-                      <TouchableOpacity style={styles.stopButton} onPress={stopLoading} testID="BrowserStopButton">
+                      <Pressable style={styles.stopButton} onPress={stopLoading} testID="BrowserStopButton">
                         <Ionicons name="close-circle" size={20} color="rgba(255, 255, 255, 0.8)" />
-                      </TouchableOpacity>
+                      </Pressable>
                     ) : (
-                      <TouchableOpacity style={styles.stopButton} onPress={onRefresh} testID="BrowserRefreshButton">
+                      <Pressable style={styles.stopButton} onPress={onRefresh} testID="BrowserRefreshButton">
                         <Ionicons name="reload" size={18} color="rgba(255, 255, 255, 0.8)" />
-                      </TouchableOpacity>
+                      </Pressable>
                     )}
                   </View>
                   <Animated.View style={[styles.progressBar, progressBarAnimatedStyle]} />
                 </View>
-                <TouchableOpacity style={styles.closeButton} onPress={() => router.back()} disabled={isNetworkSelectorVisible} testID="BrowserCloseButton">
+                <Pressable style={styles.closeButton} onPress={() => router.back()} disabled={isNetworkSelectorVisible} testID="BrowserCloseButton">
                   <Ionicons name="close" size={20} color={isAddressInputFocused || isNetworkSelectorVisible ? 'rgba(255, 255, 255, 0.3)' : 'rgba(255, 255, 255, 0.9)'} />
-                </TouchableOpacity>
+                </Pressable>
               </View>
             </Animated.View>
           </GestureDetector>
 
           <View style={styles.contentContainer}>
-            {isNetworkSelectorVisible && <TouchableOpacity style={styles.networkSelectorDismissOverlay} activeOpacity={1} onPress={hideNetworkSwitcherModal} />}
+            {isNetworkSelectorVisible && <Pressable style={styles.networkSelectorDismissOverlay} activeOpacity={1} onPress={hideNetworkSwitcherModal} />}
 
             <Animated.View style={[styles.webviewContainer, webviewContainerAnimatedStyle, styles.flex1]} {...panResponder.panHandlers}>
               <Animated.View style={[styles.absoluteFill, swipeOverlayAnimatedStyle, styles.swipeOverlayStyle]} />
@@ -1235,7 +1236,7 @@ const DAppBrowser: React.FC = () => {
                   <View style={styles.navButtonContainer}>
                     {activeTab?.canGoBack && getBackHistory().length > 0 ? (
                       <Link href="/DAppBrowser" asChild>
-                        <TouchableOpacity style={styles.navButton} onPress={goBack}>
+                        <Pressable style={styles.navButton} onPress={goBack}>
                           <Link.Trigger>
                             <View>
                               <Ionicons name="arrow-back" size={24} color="white" />
@@ -1247,19 +1248,19 @@ const DAppBrowser: React.FC = () => {
                               return <Link.MenuAction key={`back-${historyIndex}`} title={item.title} icon="arrow.left" onPress={() => goToHistoryItem(historyIndex)} />;
                             })}
                           </Link.Menu>
-                        </TouchableOpacity>
+                        </Pressable>
                       </Link>
                     ) : (
-                      <TouchableOpacity style={styles.navButton} onPress={goBack} disabled={!activeTab?.canGoBack} testID="BrowserBackButton">
+                      <Pressable style={styles.navButton} onPress={goBack} disabled={!activeTab?.canGoBack} testID="BrowserBackButton">
                         <Ionicons name="arrow-back" size={24} color={activeTab?.canGoBack ? 'white' : 'rgba(255, 255, 255, 0.3)'} />
-                      </TouchableOpacity>
+                      </Pressable>
                     )}
                   </View>
 
                   <View style={styles.navButtonContainer}>
                     {activeTab?.canGoForward && getForwardHistory().length > 0 ? (
                       <Link href="/DAppBrowser" asChild>
-                        <TouchableOpacity style={styles.navButton} onPress={goForward}>
+                        <Pressable style={styles.navButton} onPress={goForward}>
                           <Link.Trigger>
                             <View>
                               <Ionicons name="arrow-forward" size={24} color="white" />
@@ -1271,12 +1272,12 @@ const DAppBrowser: React.FC = () => {
                               return <Link.MenuAction key={`forward-${historyIndex}`} title={item.title} icon="arrow.right" onPress={() => goToHistoryItem(historyIndex)} />;
                             })}
                           </Link.Menu>
-                        </TouchableOpacity>
+                        </Pressable>
                       </Link>
                     ) : (
-                      <TouchableOpacity style={styles.navButton} onPress={goForward} disabled={!activeTab?.canGoForward} testID="BrowserForwardButton">
+                      <Pressable style={styles.navButton} onPress={goForward} disabled={!activeTab?.canGoForward} testID="BrowserForwardButton">
                         <Ionicons name="arrow-forward" size={24} color={activeTab?.canGoForward ? 'white' : 'rgba(255, 255, 255, 0.3)'} />
-                      </TouchableOpacity>
+                      </Pressable>
                     )}
                   </View>
                 </>
@@ -1284,9 +1285,9 @@ const DAppBrowser: React.FC = () => {
             </View>
 
             <View style={styles.navigationCenter}>
-              <TouchableOpacity style={styles.addTabButton} onPress={createNewTab} testID="BrowserAddTabButton">
+              <Pressable style={styles.addTabButton} onPress={createNewTab} testID="BrowserAddTabButton">
                 <Ionicons name="add" size={24} color="white" />
-              </TouchableOpacity>
+              </Pressable>
             </View>
 
             <View style={styles.navigationRight}>
@@ -1294,11 +1295,11 @@ const DAppBrowser: React.FC = () => {
                 <View style={styles.navButton} />
               </View>
               <View style={styles.navButtonContainer}>
-                <TouchableOpacity style={styles.navButton} onPress={toggleTabsOverview} onLongPress={handleCloseAllTabs} testID="BrowserTabsOverviewButton">
+                <Pressable style={styles.navButton} onPress={toggleTabsOverview} onLongPress={handleCloseAllTabs} testID="BrowserTabsOverviewButton">
                   <View style={styles.tabsOverviewIcon}>
                     <ThemedText style={styles.tabsCount}>{tabs.length}</ThemedText>
                   </View>
-                </TouchableOpacity>
+                </Pressable>
               </View>
             </View>
           </View>

--- a/mobile/app/DAppBrowserTabItem.tsx
+++ b/mobile/app/DAppBrowserTabItem.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { TouchableOpacity, View, Image, Text, StyleSheet } from 'react-native';
+import { View, Image, Text, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { ThemedText } from '@/components/ThemedText';
 import { BROWSER_CONSTANTS } from './DAppBrowser';
+import Pressable from '../components/Pressable';
 
 interface BrowserTab {
   id: string;
@@ -53,7 +54,7 @@ export const DAppBrowserTabItem: React.FC<DAppBrowserTabItemProps> = ({ tab, ind
   }, [tab.screenshot, tab.id]);
 
   return (
-    <TouchableOpacity style={styles.tabCard} onPress={onPress}>
+    <Pressable style={styles.tabCard} onPress={onPress}>
       <View style={styles.tabCardHeader}>
         <View style={styles.tabCardTitleContainer}>
           <ThemedText style={styles.tabCardNumber}>#{index + 1}</ThemedText>
@@ -61,9 +62,9 @@ export const DAppBrowserTabItem: React.FC<DAppBrowserTabItemProps> = ({ tab, ind
             {tab.title}
           </ThemedText>
         </View>
-        <TouchableOpacity style={styles.tabCardCloseButton} onPress={onClose}>
+        <Pressable style={styles.tabCardCloseButton} onPress={onClose}>
           <Ionicons name="close" size={16} color="rgba(255, 255, 255, 0.8)" />
-        </TouchableOpacity>
+        </Pressable>
       </View>
 
       <View style={styles.tabCardPreview}>
@@ -90,7 +91,7 @@ export const DAppBrowserTabItem: React.FC<DAppBrowserTabItemProps> = ({ tab, ind
           </ThemedText>
         </View>
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/mobile/app/FeeSelector.tsx
+++ b/mobile/app/FeeSelector.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { View, TouchableOpacity, TextInput, ScrollView, StyleSheet, LayoutAnimation, Platform, UIManager, ActivityIndicator } from 'react-native';
+import Pressable from '../components/Pressable';
+import { View, TextInput, ScrollView, StyleSheet, LayoutAnimation, Platform, UIManager, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
 import GradientScreen from '@/components/GradientScreen';
@@ -96,26 +97,26 @@ const FeeSelector = () => {
 
       {!isCustomInputFocused && estimateFees && (
         <View style={styles.estimatesContainer}>
-          <TouchableOpacity style={[styles.feeOption, feeRate === estimateFees.slow && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.slow)}>
+          <Pressable style={[styles.feeOption, feeRate === estimateFees.slow && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.slow)}>
             <ThemedText style={styles.feeOptionText}>
               Economy ({estimateFees.slow} sat/vbyte)
               {feeRateOptions[estimateFees.slow] ? ` ≈ ${feeRateOptions[estimateFees.slow]} sats` : ''}
             </ThemedText>
-          </TouchableOpacity>
+          </Pressable>
 
-          <TouchableOpacity style={[styles.feeOption, feeRate === estimateFees.medium && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.medium)}>
+          <Pressable style={[styles.feeOption, feeRate === estimateFees.medium && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.medium)}>
             <ThemedText style={styles.feeOptionText}>
               Standard ({estimateFees.medium} sat/vbyte)
               {feeRateOptions[estimateFees.medium] ? ` ≈ ${feeRateOptions[estimateFees.medium]} sats` : ''}
             </ThemedText>
-          </TouchableOpacity>
+          </Pressable>
 
-          <TouchableOpacity style={[styles.feeOption, feeRate === estimateFees.fast && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.fast)}>
+          <Pressable style={[styles.feeOption, feeRate === estimateFees.fast && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.fast)}>
             <ThemedText style={styles.feeOptionText}>
               Priority ({estimateFees.fast} sat/vbyte)
               {feeRateOptions[estimateFees.fast] ? ` ≈ ${feeRateOptions[estimateFees.fast]} sats` : ''}
             </ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       )}
 
@@ -126,9 +127,9 @@ const FeeSelector = () => {
 
       <View style={styles.spacer} />
 
-      <TouchableOpacity style={[styles.doneButton, !customFeeRate && styles.disabledButton]} onPress={handleDone} disabled={!customFeeRate}>
+      <Pressable style={[styles.doneButton, !customFeeRate && styles.disabledButton]} onPress={handleDone} disabled={!customFeeRate}>
         <ThemedText style={styles.doneButtonText}>Done</ThemedText>
-      </TouchableOpacity>
+      </Pressable>
     </SafeAreaView>
   );
 };

--- a/mobile/app/Home.tsx
+++ b/mobile/app/Home.tsx
@@ -2,11 +2,12 @@ import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
 import { Stack, useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, Dimensions, RefreshControl, RefreshControlProps, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, Dimensions, RefreshControl, RefreshControlProps, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
 import Animated, { useAnimatedScrollHandler, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
 import Rive, { RiveRef } from 'rive-react-native';
+import Pressable from '../components/Pressable';
 
 import { ActionPopupButton } from '@/components/ActionPopupButton';
 import Balance from '@/components/Balance';
@@ -393,21 +394,21 @@ export default function Home() {
         </GestureDetector>
 
         {/* Invisible Settings Button for Maestro Testing */}
-        <TouchableOpacity style={styles.maestroSettingsButton} onPress={goToSettings} testID="SettingsButton" accessibilityLabel="Settings" />
+        <Pressable style={styles.maestroSettingsButton} onPress={goToSettings} testID="SettingsButton" accessibilityLabel="Settings" />
 
         <GradientScreen variant={network} scroll={true} onScroll={handleScroll} refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} {...refreshOptions} />}>
           <View style={[styles.root, styles.contentWithHeader]}>
             {/* Network Selector */}
             <View style={styles.networkSelectorContainer}>
-              <TouchableOpacity testID="NetworkSwitcherTrigger" style={styles.networkSelector} onPress={handleNetworkSelect} activeOpacity={0.8}>
+              <Pressable testID="NetworkSwitcherTrigger" style={styles.networkSelector} onPress={handleNetworkSelect} activeOpacity={0.8}>
                 <View testID={`selectedNetwork-${network}`} style={styles.networkIcon}>
                   {networkIconContent}
                 </View>
                 <ThemedText style={styles.networkName}>{capitalizeFirstLetter(network)}</ThemedText>
-                <TouchableOpacity onPress={handleNetworkSelect} onLongPress={() => router.push('/BackdoorNetworkSwitcher')} testID="BackdoorNetworkSwitcher">
+                <Pressable onPress={handleNetworkSelect} onLongPress={() => router.push('/BackdoorNetworkSwitcher')} testID="BackdoorNetworkSwitcher">
                   <Ionicons name="chevron-down" size={20} color="rgba(255, 255, 255, 0.8)" />
-                </TouchableOpacity>
-              </TouchableOpacity>
+                </Pressable>
+              </Pressable>
             </View>
 
             {/* Testnet Warning */}
@@ -434,7 +435,7 @@ export default function Home() {
 
             {/* Seed Backup Warning */}
             {hasBackedUpSeed === false && (
-              <TouchableOpacity style={styles.backupWarning} onPress={handleBackupSeed} activeOpacity={0.8}>
+              <Pressable style={styles.backupWarning} onPress={handleBackupSeed} activeOpacity={0.8}>
                 <View style={styles.backupWarningHeader}>
                   <View style={styles.backupWarningIcon}>
                     <Ionicons name="alert-circle-outline" size={24} color="rgba(255, 255, 255, 0.9)" />
@@ -444,7 +445,7 @@ export default function Home() {
                 <View style={styles.backupWarningTextRow}>
                   <ThemedText style={styles.backupWarningText}>Your Recovery phrase is necessary to recover your wallet. Please verify you have backed it up.</ThemedText>
                 </View>
-              </TouchableOpacity>
+              </Pressable>
             )}
 
             {/* Transactions Section */}
@@ -494,34 +495,34 @@ export default function Home() {
               <PlatformBlurView intensity={20} tint="dark" style={styles.navBlur} />
 
               {network === NETWORK_USDT ? (
-                <TouchableOpacity style={styles.navButtonLarge} testID="SendButton" onPress={() => router.push('/send/send-address-usdt')} activeOpacity={0.8}>
+                <Pressable style={styles.navButtonLarge} testID="SendButton" onPress={() => router.push({ pathname: '/send/send-address-usdt' } as any)} activeOpacity={0.8}>
                   <MaterialIcons name="call-made" size={24} color="rgba(255, 255, 255, 0.8)" />
                   <ThemedText style={styles.navButtonText}>Send</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               ) : (
-                <TouchableOpacity style={styles.navButtonLarge} testID="SendButton" onPress={handleSend} activeOpacity={0.8}>
+                <Pressable style={styles.navButtonLarge} testID="SendButton" onPress={handleSend} activeOpacity={0.8}>
                   <MaterialIcons name="call-made" size={24} color="rgba(255, 255, 255, 0.8)" />
                   <ThemedText style={styles.navButtonText}>Send</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               )}
 
               {network === NETWORK_LIGHTNING || network === NETWORK_LIGHTNING_TESTNET ? (
-                <TouchableOpacity style={styles.navButtonLarge} testID="ReceiveButton" onPress={() => router.push('/ReceiveOnLightningAddress')} activeOpacity={0.8}>
+                <Pressable style={styles.navButtonLarge} testID="ReceiveButton" onPress={() => router.push('/ReceiveOnLightningAddress')} activeOpacity={0.8}>
                   <MaterialIcons name="call-received" size={24} color="rgba(255, 255, 255, 0.8)" />
                   <ThemedText style={styles.navButtonText}>Receive</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               ) : network === NETWORK_USDT ? (
                 <ActionPopupButton actions={usdtReceiveActions} title="Layer to receive">
-                  <TouchableOpacity style={styles.navButtonLarge} testID="ReceiveButton" activeOpacity={0.8}>
+                  <Pressable style={styles.navButtonLarge} testID="ReceiveButton" activeOpacity={0.8}>
                     <MaterialIcons name="call-received" size={24} color="rgba(255, 255, 255, 0.8)" />
                     <ThemedText style={styles.navButtonText}>Receive</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 </ActionPopupButton>
               ) : (
-                <TouchableOpacity style={styles.navButtonLarge} testID="ReceiveButton" onPress={handleReceive} activeOpacity={0.8}>
+                <Pressable style={styles.navButtonLarge} testID="ReceiveButton" onPress={handleReceive} activeOpacity={0.8}>
                   <MaterialIcons name="call-received" size={24} color="rgba(255, 255, 255, 0.8)" />
                   <ThemedText style={styles.navButtonText}>Receive</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               )}
             </View>
 
@@ -530,16 +531,16 @@ export default function Home() {
                 <PlatformBlurView intensity={40} tint="light" style={styles.navBlur} />
                 {network === NETWORK_USDT ? (
                   <ActionPopupButton actions={usdtSwapActions} title="Choose network to swap">
-                    <TouchableOpacity style={styles.swapButtonInner} activeOpacity={0.8} testID="SwapButton">
+                    <Pressable style={styles.swapButtonInner} activeOpacity={0.8} testID="SwapButton">
                       <Ionicons name="swap-horizontal" size={22} color="rgba(255, 255, 255, 0.8)" />
                       <ThemedText style={styles.navButtonText}>Transfer</ThemedText>
-                    </TouchableOpacity>
+                    </Pressable>
                   </ActionPopupButton>
                 ) : (
-                  <TouchableOpacity style={styles.swapButtonInner} onPress={handleSwap} activeOpacity={0.8} testID="SwapButton">
+                  <Pressable style={styles.swapButtonInner} onPress={handleSwap} activeOpacity={0.8} testID="SwapButton">
                     <Ionicons name="swap-horizontal" size={22} color="rgba(255, 255, 255, 0.8)" />
                     <ThemedText style={styles.navButtonText}>Transfer</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 )}
               </View>
             )}

--- a/mobile/app/Nft.tsx
+++ b/mobile/app/Nft.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useMemo } from 'react';
-import { Linking, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import Pressable from '../components/Pressable';
+import { Linking, ScrollView, StyleSheet, View } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
 import { MaterialIcons } from '@expo/vector-icons';
@@ -105,9 +106,9 @@ export default function Nft() {
             <View style={styles.detailRow}>
               <ThemedText style={styles.detailLabel}>Contract</ThemedText>
               <View style={styles.detailValueWrap}>
-                <TouchableOpacity onPress={() => handleCopy(nft.contractAddress)} accessibilityLabel="Copy contract address">
+                <Pressable onPress={() => handleCopy(nft.contractAddress)} accessibilityLabel="Copy contract address">
                   <MaterialIcons name="content-copy" size={16} color="rgba(255, 255, 255, 0.8)" />
-                </TouchableOpacity>
+                </Pressable>
                 <ThemedText style={styles.detailValue} numberOfLines={1} ellipsizeMode="middle">
                   {truncateMiddle(nft.contractAddress.split('.')[0], 5, 4)}
                 </ThemedText>
@@ -117,9 +118,9 @@ export default function Nft() {
             <View style={styles.detailRow}>
               <ThemedText style={styles.detailLabel}>Token ID</ThemedText>
               <View style={styles.detailValueWrap}>
-                <TouchableOpacity onPress={() => handleCopy(nft.tokenId)} accessibilityLabel="Copy token id">
+                <Pressable onPress={() => handleCopy(nft.tokenId)} accessibilityLabel="Copy token id">
                   <MaterialIcons name="content-copy" size={16} color="rgba(255, 255, 255, 0.8)" />
-                </TouchableOpacity>
+                </Pressable>
                 <ThemedText style={styles.detailValue}>{nft.tokenId}</ThemedText>
               </View>
             </View>
@@ -131,18 +132,18 @@ export default function Nft() {
 
         <View style={styles.bottomButtonWrap}>
           <View style={styles.bottomButtonsRow}>
-            <TouchableOpacity style={styles.actionButton} onPress={handleSend} activeOpacity={0.85} accessibilityRole="button" accessibilityLabel="Send NFT">
+            <Pressable style={styles.actionButton} onPress={handleSend} activeOpacity={0.85} accessibilityRole="button" accessibilityLabel="Send NFT">
               <MaterialIcons name="call-made" size={20} color="rgba(255, 255, 255, 0.95)" />
               <ThemedText style={styles.actionButtonText} numberOfLines={1}>
                 Send
               </ThemedText>
-            </TouchableOpacity>
+            </Pressable>
 
-            <TouchableOpacity style={styles.actionButton} onPress={handleOpenInExplorer} activeOpacity={0.85} accessibilityRole="button" accessibilityLabel="View NFT on explorer">
+            <Pressable style={styles.actionButton} onPress={handleOpenInExplorer} activeOpacity={0.85} accessibilityRole="button" accessibilityLabel="View NFT on explorer">
               <ThemedText style={styles.actionButtonText} numberOfLines={1}>
                 View on explorer
               </ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           </View>
         </View>
       </View>

--- a/mobile/app/NftGallery.tsx
+++ b/mobile/app/NftGallery.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useMemo } from 'react';
-import { ActivityIndicator, FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
+import Pressable from '../components/Pressable';
+import { ActivityIndicator, FlatList, StyleSheet, View } from 'react-native';
 import { Stack, useRouter } from 'expo-router';
 
 import GradientScreen from '@/components/GradientScreen';
@@ -25,9 +26,9 @@ const NftTile = ({ nft, onPress }: { nft: NftInfo; onPress: (nft: NftInfo) => vo
   const iconColor = getTokenIconColor(nft?.name);
 
   return (
-    <TouchableOpacity style={styles.tileOuter} onPress={() => onPress(nft)} activeOpacity={0.85} accessibilityLabel="Open NFT">
+    <Pressable style={styles.tileOuter} onPress={() => onPress(nft)} activeOpacity={0.85} accessibilityLabel="Open NFT">
       <View style={[styles.tileInner, { backgroundColor: iconColor }]}>{nft.image ? <NftImage source={{ uri: nft.image }} style={styles.image} resizeMode="cover" /> : null}</View>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/mobile/app/PocketSwitch.tsx
+++ b/mobile/app/PocketSwitch.tsx
@@ -1,7 +1,8 @@
 import { Foundation, Ionicons } from '@expo/vector-icons';
+import Pressable from '../components/Pressable';
 import { useRouter } from 'expo-router';
 import React, { useContext } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import GradientFormSheet from '@/components/GradientFormSheet';
 import { ThemedText } from '@/components/ThemedText';
@@ -23,7 +24,7 @@ const ListItem = ({ item, onPress, accountNumber }: { item: AccountItem; onPress
   const last = accountNumber === accountItems.length - 1;
 
   return (
-    <TouchableOpacity style={[styles.item, active && styles.activeItem, first && styles.firstItem, last && styles.lastItem]} onPress={onPress} activeOpacity={0.7}>
+    <Pressable style={[styles.item, active && styles.activeItem, first && styles.firstItem, last && styles.lastItem]} onPress={onPress} activeOpacity={0.7}>
       <View style={styles.icon}>
         <IconComponent name={item.icon as any} size={24} color="white" />
       </View>
@@ -33,7 +34,7 @@ const ListItem = ({ item, onPress, accountNumber }: { item: AccountItem; onPress
           {accountBalance ? formatBalance(accountBalance, getDecimalsByNetwork(NETWORK_BITCOIN), 8) : '0'} {getTickerByNetwork(NETWORK_BITCOIN)}
         </ThemedText>
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
@@ -58,9 +59,9 @@ export default function PocketSwitch() {
         <View style={styles.header}>
           <ThemedText style={styles.title}>Your pockets</ThemedText>
         </View>
-        <TouchableOpacity style={styles.closeButton} onPress={handleClose}>
+        <Pressable style={styles.closeButton} onPress={handleClose}>
           <Ionicons name="close" size={20} color="rgba(255, 255, 255, 0.8)" />
-        </TouchableOpacity>
+        </Pressable>
 
         {/* Target Networks List */}
         <View style={styles.listContainer}>

--- a/mobile/app/PosMerchant.tsx
+++ b/mobile/app/PosMerchant.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import Pressable from '../components/Pressable';
+import { ActivityIndicator, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, TextInput, View } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import * as Crypto from 'expo-crypto';
 import bolt11lib from 'bolt11';
@@ -333,9 +334,9 @@ const PosMerchant: React.FC = () => {
         <View style={styles.centered}>
           <ThemedText style={styles.errorText}>{error}</ThemedText>
           <ThemedText style={styles.errorText}>{errorLogs}</ThemedText>
-          <TouchableOpacity style={styles.secondaryButton} onPress={() => router.back()}>
+          <Pressable style={styles.secondaryButton} onPress={() => router.back()}>
             <ThemedText style={[styles.secondaryButtonText, { paddingLeft: 10, paddingRight: 10 }]}>Back</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </GradientScreen>
     );
@@ -448,12 +449,12 @@ const PosMerchant: React.FC = () => {
             <View style={styles.section}>
               <ThemedText style={styles.sectionTitle}>Choose Amount</ThemedText>
               <View style={styles.toggleRow}>
-                <TouchableOpacity style={[styles.toggleButton, mode === 'range' && styles.toggleButtonActive]} onPress={() => setMode('range')}>
+                <Pressable style={[styles.toggleButton, mode === 'range' && styles.toggleButtonActive]} onPress={() => setMode('range')}>
                   <ThemedText style={styles.toggleText}>Enter total</ThemedText>
-                </TouchableOpacity>
-                <TouchableOpacity style={[styles.toggleButton, mode === 'tip' && styles.toggleButtonActive]} onPress={() => setMode('tip')}>
+                </Pressable>
+                <Pressable style={[styles.toggleButton, mode === 'tip' && styles.toggleButtonActive]} onPress={() => setMode('tip')}>
                   <ThemedText style={styles.toggleText}>Add tip</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               </View>
 
               {mode === 'range' ? (
@@ -502,9 +503,9 @@ const PosMerchant: React.FC = () => {
           </View>
 
           {!isSubmitted ? (
-            <TouchableOpacity style={[styles.primaryButton, (!isReadyToSubmit || isSubmitting) && styles.primaryButtonDisabled]} disabled={!isReadyToSubmit || isSubmitting} onPress={handleConfirm}>
+            <Pressable style={[styles.primaryButton, (!isReadyToSubmit || isSubmitting) && styles.primaryButtonDisabled]} disabled={!isReadyToSubmit || isSubmitting} onPress={handleConfirm}>
               {isSubmitting ? <ActivityIndicator color="#FFFFFF" /> : <ThemedText style={styles.primaryButtonText}>Confirm</ThemedText>}
-            </TouchableOpacity>
+            </Pressable>
           ) : null}
 
           {bolt11 && !isSending && !success ? (
@@ -524,9 +525,9 @@ const PosMerchant: React.FC = () => {
             <View style={styles.centered}>
               <Ionicons name="checkmark-circle" size={80} color="#4CAF50" />
               <ThemedText style={styles.centeredText}>Payment sent!</ThemedText>
-              <TouchableOpacity style={styles.secondaryButton} onPress={() => router.back()}>
+              <Pressable style={styles.secondaryButton} onPress={() => router.back()}>
                 <ThemedText style={[styles.secondaryButtonText, { paddingLeft: 10, paddingRight: 10 }]}>Done</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </View>
           ) : null}
         </ScrollView>

--- a/mobile/app/Receive.tsx
+++ b/mobile/app/Receive.tsx
@@ -4,7 +4,8 @@ import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Animated, Pressable, ScrollView, Share, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Animated, ScrollView, Share, StyleSheet, View } from 'react-native';
+import Pressable from '../components/Pressable';
 import QRCode from 'react-native-qrcode-svg';
 
 import GradientScreen from '@/components/GradientScreen';
@@ -354,9 +355,9 @@ export default function ReceiveScreen() {
           </View>
 
           <View style={styles.actionButtons}>
-            <TouchableOpacity testID="ShareButton" onPress={handleShare} style={styles.shareButton} disabled={!address}>
+            <Pressable testID="ShareButton" onPress={handleShare} style={styles.shareButton} disabled={!address}>
               <ThemedText style={styles.shareButtonText}>Share...</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           </View>
         </View>
       </ScrollView>

--- a/mobile/app/ReceiveLightning.tsx
+++ b/mobile/app/ReceiveLightning.tsx
@@ -1,8 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../components/Pressable';
 import * as Clipboard from 'expo-clipboard';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { Alert, ScrollView, Share, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { Alert, ScrollView, Share, StyleSheet, TextInput, View } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 
 import GradientScreen from '@/components/GradientScreen';
@@ -260,14 +261,14 @@ export default function ReceiveLightningScreen() {
 
                 {error ? <ThemedText style={styles.errorText}>{error}</ThemedText> : <ThemedText style={styles.hintText}>Enter the amount you want to receive</ThemedText>}
 
-                <TouchableOpacity
+                <Pressable
                   style={[styles.generateButton, (isGenerating || !isWalletInitialized) && styles.disabledButton]}
                   onPress={generateInvoice}
                   disabled={isGenerating || !isWalletInitialized}
                   testID="GenerateButton"
                 >
                   <ThemedText style={styles.generateButtonText}>{isGenerating ? 'Generating...' : !isWalletInitialized ? 'Initializing...' : 'Generate Invoice'}</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               </>
             ) : (
               <>
@@ -283,24 +284,24 @@ export default function ReceiveLightningScreen() {
                 </View>
 
                 <View style={styles.addressContainer}>
-                  <TouchableOpacity testID="CopyInvoiceButton" onPress={handleCopyInvoice} style={styles.addressTextContainer}>
+                  <Pressable testID="CopyInvoiceButton" onPress={handleCopyInvoice} style={styles.addressTextContainer}>
                     <ThemedText testID="InvoiceText" style={styles.addressText} numberOfLines={2} ellipsizeMode="middle">
                       {invoice}
                     </ThemedText>
                     <Ionicons testID="CopyIcon" name="copy-outline" size={20} color="rgba(255, 255, 255, 0.8)" style={styles.copyIcon} />
-                  </TouchableOpacity>
+                  </Pressable>
                 </View>
 
                 <View style={styles.actionButtons}>
-                  <TouchableOpacity style={styles.shareButton} onPress={handleShare} testID="LNShareButton">
+                  <Pressable style={styles.shareButton} onPress={handleShare} testID="LNShareButton">
                     <Ionicons name="share-outline" size={28} color="rgba(255, 255, 255, 0.8)" />
                     <ThemedText style={styles.shareButtonText}>Share invoice</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
 
-                  <TouchableOpacity style={styles.copyButton} onPress={handleNewInvoice} testID="NewInvoiceButton">
+                  <Pressable style={styles.copyButton} onPress={handleNewInvoice} testID="NewInvoiceButton">
                     <Ionicons name="refresh" size={22} color="rgba(255, 255, 255, 0.8)" />
                     <ThemedText style={styles.copyButtonText}>New invoice</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 </View>
               </>
             )}

--- a/mobile/app/ReceiveOnLightningAddress.tsx
+++ b/mobile/app/ReceiveOnLightningAddress.tsx
@@ -1,9 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../components/Pressable';
 import BigNumber from 'bignumber.js';
 import { Image } from 'expo-image';
 import { Stack, useRouter } from 'expo-router';
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, Animated, Pressable, ScrollView, Share, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Alert, Animated, ScrollView, Share, StyleSheet, View } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 import { useFocusEffect } from '@react-navigation/native';
 
@@ -265,13 +266,13 @@ export default function ReceiveOnLightningAddressScreen() {
           </View>
 
           <View style={styles.actionButtons}>
-            <TouchableOpacity testID="ShareButton" onPress={handleShare} style={styles.shareButton} disabled={!lightningAddress}>
+            <Pressable testID="ShareButton" onPress={handleShare} style={styles.shareButton} disabled={!lightningAddress}>
               <ThemedText style={styles.shareButtonText}>Share...</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
             <ActionPopupButton actions={lightningReceiveActions} title="Layer to receive on">
-              <TouchableOpacity style={styles.receiveWithAmountButton} testID="ReceiveOnLightningAddressWithAmountButton" activeOpacity={0.8}>
+              <Pressable style={styles.receiveWithAmountButton} testID="ReceiveOnLightningAddressWithAmountButton" activeOpacity={0.8}>
                 <ThemedText style={styles.receiveWithAmountButtonText}>Receive with amount</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </ActionPopupButton>
           </View>
         </View>

--- a/mobile/app/SeedBackup.tsx
+++ b/mobile/app/SeedBackup.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useRef, useCallback, useMemo, useEffect } from 'react';
-import { Alert, StyleSheet, TouchableOpacity, View, Animated, ActivityIndicator, Image, FlatList, LayoutAnimation, Platform, Pressable } from 'react-native';
+import { Alert, StyleSheet, View, Animated, ActivityIndicator, Image, FlatList, LayoutAnimation, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import * as Haptics from 'expo-haptics';
@@ -15,6 +15,7 @@ import { useAuthState } from '@/src/hooks/AuthStateContext';
 import { useAskPassword } from '@/src/hooks/AskPasswordContext';
 import { useSettings } from '@shared/hooks/useSettings';
 import * as LocalAuthentication from 'expo-local-authentication';
+import Pressable from '../components/Pressable';
 
 const TOTAL_WORDS = 12;
 const ERROR_TIMEOUT_MS = 2000;
@@ -66,7 +67,7 @@ const SelectableWordDisplay: React.FC<{
   const handlePress = useCallback(() => onPress(wordItem), [onPress, wordItem]);
 
   return (
-    <TouchableOpacity style={wordStyle} onPress={handlePress} disabled={wordItem.isSelected || showError}>
+    <Pressable style={wordStyle} onPress={handlePress} disabled={wordItem.isSelected || showError}>
       <Animated.View style={animatedViewStyle}>
         <View style={numberStyle}>
           <ThemedText style={styles.verifyWordNumberText}>{wordItem.isSelected && wordItem.selectedOrder !== undefined ? wordItem.selectedOrder + 1 : ''}</ThemedText>
@@ -75,7 +76,7 @@ const SelectableWordDisplay: React.FC<{
           <ThemedText style={styles.verifyWordText}>{wordItem.word}</ThemedText>
         </View>
       </Animated.View>
-    </TouchableOpacity>
+    </Pressable>
   );
 });
 
@@ -344,10 +345,10 @@ export default function SeedBackupScreen() {
               <ActivityIndicator size="large" color="rgba(255, 255, 255, 0.9)" />
             </View>
           ) : !isRevealed ? (
-            <TouchableOpacity style={styles.revealContent} onPress={handleRevealSeedPhrase} activeOpacity={0.8}>
+            <Pressable style={styles.revealContent} onPress={handleRevealSeedPhrase} activeOpacity={0.8}>
               <Ionicons name="eye-outline" size={80} color="rgba(255, 255, 255, 0.9)" />
               <ThemedText style={styles.revealText}>tap to reveal</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           ) : (
             <View style={styles.mnemonicDisplay}>
               {mnemonicWordsData.map((item) => (

--- a/mobile/app/SeedBackupQR.tsx
+++ b/mobile/app/SeedBackupQR.tsx
@@ -1,9 +1,10 @@
 import React, { useContext } from 'react';
-import { StyleSheet, View, TouchableOpacity } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { usePreventScreenCapture } from 'expo-screen-capture';
+import Pressable from '../components/Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
@@ -19,9 +20,9 @@ export default function SeedBackupQRScreen() {
     <GradientScreen variant={network}>
       <View style={styles.header}>
         <ThemedText style={styles.title}>Recovery Phrase</ThemedText>
-        <TouchableOpacity onPress={() => router.back()} style={styles.closeButton}>
+        <Pressable onPress={() => router.back()} style={styles.closeButton}>
           <Ionicons name="close" size={28} color="white" />
-        </TouchableOpacity>
+        </Pressable>
       </View>
 
       <View style={styles.qrCodeSection}>

--- a/mobile/app/SendAccountBased.tsx
+++ b/mobile/app/SendAccountBased.tsx
@@ -1,9 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../components/Pressable';
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useContext, useRef, useState } from 'react';
-import { View, ScrollView, ActivityIndicator, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
+import { View, ScrollView, ActivityIndicator, StyleSheet, TextInput } from 'react-native';
 
 import GradientScreen from '@/components/GradientScreen';
 import ScreenHeader from '@/components/navigation/ScreenHeader';
@@ -106,9 +107,9 @@ const SendAccountBased = () => {
         <View style={styles.successContainer}>
           <Ionicons name="checkmark-circle" size={80} color="#4CAF50" />
           <ThemedText style={styles.successTitle}>Transaction Sent!</ThemedText>
-          <TouchableOpacity style={styles.backButton} onPress={() => router.replace('/Home')}>
+          <Pressable style={styles.backButton} onPress={() => router.replace('/Home')}>
             <ThemedText style={styles.backButtonText}>Back to Wallet</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </GradientScreen>
     );
@@ -143,7 +144,7 @@ const SendAccountBased = () => {
                 onChangeText={(text) => router.setParams({ toAddress: text })}
                 value={toAddress}
               />
-              <TouchableOpacity
+              <Pressable
                 style={styles.scanButton}
                 onPress={async () => {
                   const scanned = await scanQr();
@@ -153,7 +154,7 @@ const SendAccountBased = () => {
                 }}
               >
                 <Ionicons name="scan-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
-              </TouchableOpacity>
+              </Pressable>
             </View>
           </View>
 
@@ -184,10 +185,10 @@ const SendAccountBased = () => {
           ) : null}
 
           {!isPreparing && !isPrepared ? (
-            <TouchableOpacity style={styles.sendButton} testID="send-screen-send-button" onPress={prepareTransaction}>
+            <Pressable style={styles.sendButton} testID="send-screen-send-button" onPress={prepareTransaction}>
               <Ionicons name="send" size={20} color="rgba(255, 255, 255, 0.8)" style={styles.sendIcon} />
               <ThemedText style={styles.sendButtonText}>Send</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           ) : null}
 
           {isPrepared ? (
@@ -207,7 +208,7 @@ const SendAccountBased = () => {
                   backgroundColor="#007AFF"
                 />
 
-                <TouchableOpacity
+                <Pressable
                   onPress={() => {
                     setIsPreparing(false);
                     setIsPrepared(false);
@@ -215,7 +216,7 @@ const SendAccountBased = () => {
                   style={styles.cancelButton}
                 >
                   <ThemedText style={styles.cancelButtonText}>Cancel</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               </View>
             )
           ) : null}

--- a/mobile/app/SendBtc.tsx
+++ b/mobile/app/SendBtc.tsx
@@ -1,9 +1,10 @@
 import { Stack, useRouter, useLocalSearchParams } from 'expo-router';
+import Pressable from '../components/Pressable';
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import * as bip21 from 'bip21';
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, AppState, AppStateStatus, ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, AppState, AppStateStatus, ScrollView, StyleSheet, TextInput, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 import GradientScreen from '@/components/GradientScreen';
@@ -226,9 +227,9 @@ const SendBtc: React.FC = () => {
               ) : (
                 <ThemedText style={styles.successSubMessage}>Your {getTickerByNetwork(network)} are on their way</ThemedText>
               )}
-              <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+              <Pressable style={styles.backButton} onPress={handleBack}>
                 <ThemedText style={styles.backButtonText}>Back to Wallet</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </View>
           </View>
         </ScrollView>
@@ -255,9 +256,9 @@ const SendBtc: React.FC = () => {
                 value={toAddress}
                 editable={!xArkSwap}
               />
-              <TouchableOpacity style={[styles.scanButton, xArkSwap && styles.inputDisabled]} disabled={xArkSwap} onPress={handleScanQR}>
+              <Pressable style={[styles.scanButton, xArkSwap && styles.inputDisabled]} disabled={xArkSwap} onPress={handleScanQR}>
                 <Ionicons name="scan-outline" size={24} color="rgba(255, 255, 255, 0.8)" />
-              </TouchableOpacity>
+              </Pressable>
             </View>
           </View>
 
@@ -283,7 +284,7 @@ const SendBtc: React.FC = () => {
           ) : null}
 
           {!isPreparing && !isPrepared && (
-            <TouchableOpacity
+            <Pressable
               style={styles.feeContainer}
               onPress={() => {
                 router.push({
@@ -307,14 +308,14 @@ const SendBtc: React.FC = () => {
                   <Ionicons name="chevron-forward" size={16} color="rgba(255, 255, 255, 0.6)" />
                 </View>
               </View>
-            </TouchableOpacity>
+            </Pressable>
           )}
 
           {!isPreparing && !isPrepared && (
-            <TouchableOpacity style={[styles.sendButton, !sendData && styles.disabledButton]} onPress={prepareTransaction} disabled={!sendData}>
+            <Pressable style={[styles.sendButton, !sendData && styles.disabledButton]} onPress={prepareTransaction} disabled={!sendData}>
               <Ionicons name="send" size={20} color="rgba(255, 255, 255, 0.8)" />
               <ThemedText style={styles.sendButtonText}>Send</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           )}
 
           {isPrepared && (
@@ -344,7 +345,7 @@ const SendBtc: React.FC = () => {
                 backgroundColor="#000000"
               />
 
-              <TouchableOpacity
+              <Pressable
                 onPress={() => {
                   setIsPreparing(false);
                   setIsPrepared(false);
@@ -352,7 +353,7 @@ const SendBtc: React.FC = () => {
                 style={styles.cancelButton}
               >
                 <ThemedText style={styles.cancelButtonText}>Cancel</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </View>
           )}
         </View>

--- a/mobile/app/SendEvm.tsx
+++ b/mobile/app/SendEvm.tsx
@@ -1,10 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../components/Pressable';
 import Slider from '@react-native-community/slider';
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import { Stack, useRouter, useLocalSearchParams } from 'expo-router';
 import React, { useContext, useEffect, useState } from 'react';
-import { Keyboard, StyleSheet, TextInput, TouchableOpacity, View, ScrollView } from 'react-native';
+import { Keyboard, StyleSheet, TextInput, View, ScrollView } from 'react-native';
 
 import GradientScreen from '@/components/GradientScreen';
 import ScreenHeader from '@/components/navigation/ScreenHeader';
@@ -259,9 +260,9 @@ export default function SendScreen() {
                 autoCapitalize="none"
                 autoCorrect={false}
               />
-              <TouchableOpacity style={styles.qrButton} onPress={handleScanQr}>
+              <Pressable style={styles.qrButton} onPress={handleScanQr}>
                 <Ionicons name="scan-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
-              </TouchableOpacity>
+              </Pressable>
             </View>
           </View>
 
@@ -304,10 +305,10 @@ export default function SendScreen() {
           ) : null}
 
           {screenState === 'init' ? (
-            <TouchableOpacity style={[styles.sendButton, (!recipientAddress || !amount) && styles.disabledButton]} onPress={handleSend} disabled={!recipientAddress || !amount}>
+            <Pressable style={[styles.sendButton, (!recipientAddress || !amount) && styles.disabledButton]} onPress={handleSend} disabled={!recipientAddress || !amount}>
               <Ionicons name="send" size={20} color="rgba(255, 255, 255, 0.8)" />
               <ThemedText style={styles.sendButtonText}>Send</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           ) : null}
 
           {screenState === 'prepared' && fees && maxFees ? (

--- a/mobile/app/SendLightning.tsx
+++ b/mobile/app/SendLightning.tsx
@@ -1,8 +1,9 @@
 import BigNumber from 'bignumber.js';
+import Pressable from '../components/Pressable';
 import * as bip21 from 'bip21';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, ScrollView, StyleSheet, TextInput, View } from 'react-native';
 import * as bolt11 from 'bolt11';
 
 import GradientScreen from '@/components/GradientScreen';
@@ -254,9 +255,9 @@ const SendLightning: React.FC = () => {
           <Ionicons name="checkmark-circle" size={80} color="#4CAF50" />
           <ThemedText style={styles.successMessage}>Payment Sent!</ThemedText>
           <ThemedText style={styles.successSubMessage}>{amountToSend ? formatBalance(amountToSend, 8, 8) : ''} sats</ThemedText>
-          <TouchableOpacity style={styles.backButton} onPress={() => router.replace('/Home')}>
+          <Pressable style={styles.backButton} onPress={() => router.replace('/Home')}>
             <ThemedText style={styles.backButtonText}>Back to Wallet</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </GradientScreen>
     );
@@ -296,9 +297,9 @@ const SendLightning: React.FC = () => {
                   multiline
                   textAlignVertical="top"
                 />
-                <TouchableOpacity style={styles.scanButton} onPress={handleQRScan}>
+                <Pressable style={styles.scanButton} onPress={handleQRScan}>
                   <Ionicons name="scan-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
-                </TouchableOpacity>
+                </Pressable>
               </View>
             </View>
           )}
@@ -353,10 +354,10 @@ const SendLightning: React.FC = () => {
 
               {/* Verify Button */}
               {sendState === 'idle' && (
-                <TouchableOpacity style={[styles.verifyButton]} onPress={prepareLightningAddressPayment}>
+                <Pressable style={[styles.verifyButton]} onPress={prepareLightningAddressPayment}>
                   <Ionicons name="flash" size={20} color="rgba(255, 255, 255, 0.8)" />
                   <ThemedText style={styles.verifyButtonText}>Send Payment</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               )}
 
               {/* Confirm Payment */}
@@ -370,9 +371,9 @@ const SendLightning: React.FC = () => {
                     progressColor="rgba(255, 255, 255, 0.3)"
                     backgroundColor="#000000"
                   />
-                  <TouchableOpacity onPress={handleCancel} style={styles.cancelButton}>
+                  <Pressable onPress={handleCancel} style={styles.cancelButton}>
                     <ThemedText style={styles.cancelButtonText}>Cancel</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 </View>
               )}
             </>
@@ -416,10 +417,10 @@ const SendLightning: React.FC = () => {
 
           {/* Verify Button */}
           {!isPayingToLightningAddress && sendState === 'idle' && invoice && amountToSend && (
-            <TouchableOpacity style={[styles.verifyButton]} onPress={prepareTransaction}>
+            <Pressable style={[styles.verifyButton]} onPress={prepareTransaction}>
               <Ionicons name="flash" size={20} color="rgba(255, 255, 255, 0.8)" />
               <ThemedText style={styles.verifyButtonText}>Send Payment</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           )}
 
           {/* Confirm Payment */}
@@ -434,9 +435,9 @@ const SendLightning: React.FC = () => {
                 backgroundColor="#000000"
               />
 
-              <TouchableOpacity onPress={handleCancel} style={styles.cancelButton}>
+              <Pressable onPress={handleCancel} style={styles.cancelButton}>
                 <ThemedText style={styles.cancelButtonText}>Cancel</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </View>
           )}
         </View>

--- a/mobile/app/SendLiquid.tsx
+++ b/mobile/app/SendLiquid.tsx
@@ -1,8 +1,9 @@
 import type { AssetBalance, PrepareSendRequest, PrepareSendResponse } from '@breeztech/breez-sdk-liquid';
+import Pressable from '../components/Pressable';
 import { Ionicons } from '@expo/vector-icons';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, ScrollView, StyleSheet, TextInput, View } from 'react-native';
 
 import GradientScreen from '@/components/GradientScreen';
 import ScreenHeader from '@/components/navigation/ScreenHeader';
@@ -194,9 +195,9 @@ const SendLiquid = () => {
         <View style={styles.successContainer}>
           <Ionicons name="checkmark-circle" size={80} color="#4CAF50" />
           <ThemedText style={styles.successText}>Transaction Sent!</ThemedText>
-          <TouchableOpacity style={styles.button} onPress={() => router.replace('/Home')}>
+          <Pressable style={styles.button} onPress={() => router.replace('/Home')}>
             <ThemedText style={styles.buttonText}>Back to Wallet</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </GradientScreen>
     );
@@ -258,9 +259,9 @@ const SendLiquid = () => {
               disabled={isSending}
             />
 
-            <TouchableOpacity style={[styles.button, styles.cancelButton, isSending && styles.disabledButton]} onPress={() => setShowConfirm(false)} disabled={isSending}>
+            <Pressable style={[styles.button, styles.cancelButton, isSending && styles.disabledButton]} onPress={() => setShowConfirm(false)} disabled={isSending}>
               <ThemedText style={styles.buttonText}>Cancel</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           </View>
         </ScrollView>
       </GradientScreen>
@@ -288,9 +289,9 @@ const SendLiquid = () => {
               autoCapitalize="none"
               autoCorrect={false}
             />
-            <TouchableOpacity style={styles.scanButton} onPress={handleScanQR}>
+            <Pressable style={styles.scanButton} onPress={handleScanQR}>
               <Ionicons name="qr-code-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
-            </TouchableOpacity>
+            </Pressable>
           </View>
 
           <ThemedText style={styles.inputLabel}>Amount</ThemedText>
@@ -310,9 +311,9 @@ const SendLiquid = () => {
 
           {error ? <ThemedText style={styles.errorText}>{error}</ThemedText> : null}
 
-          <TouchableOpacity style={[styles.button, isSending && styles.disabledButton]} onPress={handleSend} disabled={isSending}>
+          <Pressable style={[styles.button, isSending && styles.disabledButton]} onPress={handleSend} disabled={isSending}>
             <ThemedText style={styles.buttonText}>{isSending ? 'Preparing...' : 'Prepare'}</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </ScrollView>
     </GradientScreen>

--- a/mobile/app/SendNft.tsx
+++ b/mobile/app/SendNft.tsx
@@ -1,8 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as bip21 from 'bip21';
 import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Alert, StyleSheet, TextInput, View } from 'react-native';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
+import Pressable from '../components/Pressable';
 
 import GradientScreen from '@/components/GradientScreen';
 import ScreenHeader from '@/components/navigation/ScreenHeader';
@@ -132,7 +133,7 @@ export default function SendNft() {
           {/* Replicate input + scan button from /send/send-address.tsx */}
           <View style={styles.inputSection}>
             <View style={styles.inputContainer}>
-              <TouchableOpacity style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-nft-address-input">
+              <Pressable style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-nft-address-input">
                 <ThemedText style={styles.inputLabel}>To</ThemedText>
                 <TextInput
                   ref={inputRef}
@@ -146,10 +147,10 @@ export default function SendNft() {
                   editable={!sending && !txid}
                   testID="send-nft-recipient-input"
                 />
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.scanButton} onPress={handleScanQR} disabled={sending || Boolean(txid)} testID="send-nft-scan-button">
+              </Pressable>
+              <Pressable style={styles.scanButton} onPress={handleScanQR} disabled={sending || Boolean(txid)} testID="send-nft-scan-button">
                 <Ionicons name="scan-outline" size={24} color="rgba(255, 255, 255, 0.8)" />
-              </TouchableOpacity>
+              </Pressable>
             </View>
 
             {errorMessage && (
@@ -166,14 +167,14 @@ export default function SendNft() {
               <ThemedText style={styles.successSub} numberOfLines={1} ellipsizeMode="middle">
                 Tx: {txid}
               </ThemedText>
-              <TouchableOpacity style={styles.secondaryButton} onPress={() => router.replace('/Home')} activeOpacity={0.85} testID="send-nft-back-button">
+              <Pressable style={styles.secondaryButton} onPress={() => router.replace('/Home')} activeOpacity={0.85} testID="send-nft-back-button">
                 <ThemedText style={styles.secondaryButtonText}>Back to Wallet</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </View>
           ) : (
-            <TouchableOpacity style={styles.primaryButton} onPress={handleSend} activeOpacity={0.85} disabled={sending} testID="send-nft-send-button">
+            <Pressable style={styles.primaryButton} onPress={handleSend} activeOpacity={0.85} disabled={sending} testID="send-nft-send-button">
               {sending ? <ActivityIndicator color="rgba(255,255,255,0.95)" /> : <ThemedText style={styles.primaryButtonText}>Send</ThemedText>}
-            </TouchableOpacity>
+            </Pressable>
           )}
         </View>
       </View>

--- a/mobile/app/SendTokenEvm.tsx
+++ b/mobile/app/SendTokenEvm.tsx
@@ -1,7 +1,8 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../components/Pressable';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useContext, useEffect, useState } from 'react';
-import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, TouchableOpacity, View, TextInput, Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View, TextInput, Keyboard, TouchableWithoutFeedback } from 'react-native';
 
 import GradientScreen from '@/components/GradientScreen';
 import ScreenHeader from '@/components/navigation/ScreenHeader';
@@ -188,9 +189,9 @@ const SendTokenEvm: React.FC = () => {
                   onChangeText={(text) => router.setParams({ toAddress: text })}
                   placeholderTextColor="rgba(255, 255, 255, 0.6)"
                 />
-                <TouchableOpacity style={styles.scanButton} onPress={handleScanQr}>
+                <Pressable style={styles.scanButton} onPress={handleScanQr}>
                   <Ionicons name="scan-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
-                </TouchableOpacity>
+                </Pressable>
               </View>
             </View>
 
@@ -237,17 +238,17 @@ const SendTokenEvm: React.FC = () => {
             )}
 
             {screenState === 'init' && (
-              <TouchableOpacity style={styles.sendButton} onPress={prepareTransaction}>
+              <Pressable style={styles.sendButton} onPress={prepareTransaction}>
                 <Ionicons name="send" size={20} color="white" style={styles.sendIcon} />
                 <ThemedText style={styles.sendButtonText}>Send</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             )}
 
             {screenState === 'prepared' && (
               <View style={styles.confirmContainer}>
                 <LongPressButton onLongPressComplete={broadcastTransaction} style={styles.confirmButton} title="Hold to confirm send" />
 
-                <TouchableOpacity
+                <Pressable
                   style={styles.cancelButton}
                   onPress={() => {
                     setBytes('');
@@ -257,7 +258,7 @@ const SendTokenEvm: React.FC = () => {
                   }}
                 >
                   <ThemedText style={styles.cancelText}>Cancel</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               </View>
             )}
           </ScrollView>

--- a/mobile/app/SendTokenStacks.tsx
+++ b/mobile/app/SendTokenStacks.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useEffect, useCallback } from 'react';
-import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert, ActivityIndicator, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
+import Pressable from '../components/Pressable';
+import { View, Text, TextInput, StyleSheet, Alert, ActivityIndicator, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import assert from 'assert';
@@ -209,9 +210,9 @@ export default function SendTokenStacksScreen() {
                       autoCorrect={false}
                       editable={step === SendTokenStacksStep.Init}
                     />
-                    <TouchableOpacity style={styles.scanButton} onPress={handleScanQR} activeOpacity={0.7}>
+                    <Pressable style={styles.scanButton} onPress={handleScanQR} activeOpacity={0.7}>
                       <Ionicons name="scan-outline" size={20} color="rgba(255, 255, 255, 0.8)" />
-                    </TouchableOpacity>
+                    </Pressable>
                   </View>
                 </View>
 
@@ -219,9 +220,9 @@ export default function SendTokenStacksScreen() {
                 <View style={styles.section}>
                   <View style={styles.amountHeader}>
                     <Text style={[styles.label, { color: textColor }]}>Amount</Text>
-                    <TouchableOpacity onPress={handleMaxAmount} activeOpacity={0.7}>
+                    <Pressable onPress={handleMaxAmount} activeOpacity={0.7}>
                       <Text style={[styles.maxButton, { color: primaryColor }]}>MAX</Text>
-                    </TouchableOpacity>
+                    </Pressable>
                   </View>
                   <TextInput
                     style={[
@@ -297,10 +298,10 @@ export default function SendTokenStacksScreen() {
             {/* Action Buttons */}
             <View style={styles.buttonContainer}>
               {step === SendTokenStacksStep.Init && (
-                <TouchableOpacity style={styles.sendButton} onPress={prepareTransaction} activeOpacity={0.7} testID="send-screen-send-button">
+                <Pressable style={styles.sendButton} onPress={prepareTransaction} activeOpacity={0.7} testID="send-screen-send-button">
                   <Ionicons name="send" size={20} color="#FFFFFF" style={styles.sendIcon} />
                   <Text style={styles.sendButtonText}>Send</Text>
-                </TouchableOpacity>
+                </Pressable>
               )}
 
               {step === SendTokenStacksStep.Prepared && (
@@ -312,9 +313,9 @@ export default function SendTokenStacksScreen() {
                     title="Hold to confirm send"
                     progressColor="rgba(255, 255, 255, 0.3)"
                   />
-                  <TouchableOpacity style={styles.cancelButton} onPress={resetToInit} activeOpacity={0.7}>
+                  <Pressable style={styles.cancelButton} onPress={resetToInit} activeOpacity={0.7}>
                     <Text style={[styles.cancelButtonText, { color: textColor }]}>Cancel</Text>
-                  </TouchableOpacity>
+                  </Pressable>
                 </View>
               )}
             </View>
@@ -327,9 +328,9 @@ export default function SendTokenStacksScreen() {
                 </View>
                 <Text style={[styles.successTitle, { color: textColor }]}>Transaction Sent!</Text>
                 <Text style={[styles.successMessage, { color: textColor, opacity: 0.8 }]}>Your token transfer was successful.</Text>
-                <TouchableOpacity style={[styles.sendAnotherButton, { backgroundColor: successColor }]} onPress={resetToInit} activeOpacity={0.7}>
+                <Pressable style={[styles.sendAnotherButton, { backgroundColor: successColor }]} onPress={resetToInit} activeOpacity={0.7}>
                   <Text style={styles.sendAnotherButtonText}>Back to Wallet</Text>
-                </TouchableOpacity>
+                </Pressable>
               </View>
             )}
           </>

--- a/mobile/app/Settings.tsx
+++ b/mobile/app/Settings.tsx
@@ -1,8 +1,9 @@
 import * as Application from 'expo-application';
+import Pressable from '../components/Pressable';
 import { useRouter } from 'expo-router';
 import * as Linking from 'expo-linking';
 import React, { useContext, useEffect, useState } from 'react';
-import { Alert, Pressable, SectionList, SectionListData, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, SectionList, SectionListData, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import ScreenHeader from '@/components/navigation/ScreenHeader';

--- a/mobile/app/Swap.tsx
+++ b/mobile/app/Swap.tsx
@@ -1,10 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../components/Pressable';
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import * as Linking from 'expo-linking';
 import { useLocalSearchParams, useRouter, type Href } from 'expo-router';
 import React, { useContext, useState } from 'react';
-import { ActivityIndicator, Alert, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Alert, StyleSheet, View } from 'react-native';
 
 import AmountInput from '@/components/AmountInput';
 import Button from '@/components/Button';
@@ -164,9 +165,9 @@ export default function Swap() {
         {/* Header */}
         <View style={styles.header}>
           <ThemedText style={styles.title}>Transfer</ThemedText>
-          <TouchableOpacity style={styles.closeButton} onPress={handleClose}>
+          <Pressable style={styles.closeButton} onPress={handleClose}>
             <Ionicons name="close" size={20} color="rgba(255, 255, 255, 0.8)" />
-          </TouchableOpacity>
+          </Pressable>
         </View>
 
         {/* From Token Input */}
@@ -191,10 +192,10 @@ export default function Swap() {
           <ThemedText style={styles.toLabel} testID="ToLabel">
             To
           </ThemedText>
-          <TouchableOpacity style={styles.targetButton} onPress={handleToTokenSelect} testID="ToNetworkButton">
+          <Pressable style={styles.targetButton} onPress={handleToTokenSelect} testID="ToNetworkButton">
             <ThemedText style={styles.targetButtonText}>{option ? targetName : 'Select target network'}</ThemedText>
             <Ionicons name="chevron-down" size={20} color="rgba(255, 255, 255, 0.6)" />
-          </TouchableOpacity>
+          </Pressable>
         </View>
 
         {/* Error Display */}

--- a/mobile/app/SwapDetails.tsx
+++ b/mobile/app/SwapDetails.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useMemo } from 'react';
-import { Linking, StyleSheet, TouchableOpacity, View } from 'react-native';
+import Pressable from '../components/Pressable';
+import { Linking, StyleSheet, View } from 'react-native';
 import { Image } from 'expo-image';
 import * as Clipboard from 'expo-clipboard';
 import { MaterialIcons } from '@expo/vector-icons';
@@ -130,9 +131,9 @@ export default function SwapDetails() {
           <View style={styles.detailRow}>
             <ThemedText style={styles.detailLabel}>Swap ID</ThemedText>
             <View style={styles.detailValueWrap}>
-              <TouchableOpacity onPress={() => handleCopy(swap.id)}>
+              <Pressable onPress={() => handleCopy(swap.id)}>
                 <MaterialIcons name="content-copy" size={16} color="rgba(255, 255, 255, 0.8)" />
-              </TouchableOpacity>
+              </Pressable>
               <View style={styles.detailValueContainer}>
                 <ThemedText style={[styles.detailValue]} numberOfLines={1} ellipsizeMode="middle">
                   {swap.id}
@@ -175,15 +176,15 @@ export default function SwapDetails() {
         <View style={styles.actionButtonsContainer}>
           {/* Claim button for claimable Spark swaps */}
           {showClaimButton && (
-            <TouchableOpacity style={styles.primaryButton} onPress={handleClaim}>
+            <Pressable style={styles.primaryButton} onPress={handleClaim}>
               <ThemedText style={styles.primaryButtonText}>Claim Swap</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           )}
 
           {/* Open in explorer */}
-          <TouchableOpacity disabled={!swap.explorerUrl} style={[styles.explorerButton, !swap.explorerUrl && { opacity: 0.6 }]} onPress={handleOpenInExplorer}>
+          <Pressable disabled={!swap.explorerUrl} style={[styles.explorerButton, !swap.explorerUrl && { opacity: 0.6 }]} onPress={handleOpenInExplorer}>
             <ThemedText style={styles.explorerText}>Open in explorer</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </View>
     </GradientFormSheet>

--- a/mobile/app/SwapTarget.tsx
+++ b/mobile/app/SwapTarget.tsx
@@ -1,8 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../components/Pressable';
 import { Image } from 'expo-image';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import React, { useContext, useEffect, useState } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import GradientFormSheet from '@/components/GradientFormSheet';
 import { ThemedText } from '@/components/ThemedText';
@@ -25,10 +26,10 @@ const ListItem = ({ item, onPress, active, first, last }: { item: TargetNetworkI
   const networkImage = getNetworkImageAsset(item.target);
 
   return (
-    <TouchableOpacity style={[styles.item, active && styles.activeItem, first && styles.firstItem, last && styles.lastItem]} onPress={onPress} activeOpacity={0.7} testID={`SwapTarget-${item.target}`}>
+    <Pressable style={[styles.item, active && styles.activeItem, first && styles.firstItem, last && styles.lastItem]} onPress={onPress} activeOpacity={0.7} testID={`SwapTarget-${item.target}`}>
       <View style={styles.networkIcon}>{networkImage ? <Image source={networkImage} style={styles.networkImage} contentFit="contain" /> : null}</View>
       <ThemedText style={styles.networkName}>{item.name}</ThemedText>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
@@ -68,9 +69,9 @@ export default function SwapTarget() {
         <View style={styles.header}>
           <ThemedText style={styles.title}>Swap to</ThemedText>
         </View>
-        <TouchableOpacity style={styles.closeButton} onPress={handleClose}>
+        <Pressable style={styles.closeButton} onPress={handleClose}>
           <Ionicons name="close" size={20} color="rgba(255, 255, 255, 0.8)" />
-        </TouchableOpacity>
+        </Pressable>
 
         {/* Target Networks List */}
         <View style={styles.listContainer}>

--- a/mobile/app/SwapXArkClaim.tsx
+++ b/mobile/app/SwapXArkClaim.tsx
@@ -1,7 +1,8 @@
 import assert from 'assert';
+import Pressable from '../components/Pressable';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Alert, ScrollView, StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 import GradientScreen from '@/components/GradientScreen';
@@ -118,9 +119,9 @@ const SwapXArkClaim = () => {
               <Ionicons name="checkmark-circle" size={80} color="white" />
               <ThemedText style={styles.successMessage}>Swap Claimed Successfully!</ThemedText>
               {quote && <ThemedText style={styles.successSubMessage}>{formatBalance(quote.creditAmountSats.toString(), decimals)} BTC has been added to your Spark balance</ThemedText>}
-              <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+              <Pressable style={styles.backButton} onPress={handleBack}>
                 <ThemedText style={styles.backButtonText}>Back to Wallet</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </View>
           </View>
         </ScrollView>
@@ -138,9 +139,9 @@ const SwapXArkClaim = () => {
               <Ionicons name="checkmark-circle" size={80} color="white" />
               <ThemedText style={styles.successMessage}>Swap Refunded Successfully!</ThemedText>
               <ThemedText style={styles.successSubMessage}>Your Bitcoin has been sent back to your wallet</ThemedText>
-              <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+              <Pressable style={styles.backButton} onPress={handleBack}>
                 <ThemedText style={styles.backButtonText}>Back to Wallet</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </View>
           </View>
         </ScrollView>
@@ -201,15 +202,15 @@ const SwapXArkClaim = () => {
               </View>
 
               <View style={styles.buttonContainer}>
-                <TouchableOpacity style={[styles.primaryButton, disabled && styles.disabledButton]} onPress={swap.network === NETWORK_SPARK ? handleClaimSpark : handleClaimArk} disabled={disabled}>
+                <Pressable style={[styles.primaryButton, disabled && styles.disabledButton]} onPress={swap.network === NETWORK_SPARK ? handleClaimSpark : handleClaimArk} disabled={disabled}>
                   {isClaiming && <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.9)" />}
                   <ThemedText style={styles.primaryButtonText}>{isClaiming ? 'Claiming...' : 'Claim Swap'}</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
 
-                <TouchableOpacity style={[styles.secondaryButton, disabled && styles.disabledButton]} onPress={handleRefund} disabled={disabled}>
+                <Pressable style={[styles.secondaryButton, disabled && styles.disabledButton]} onPress={handleRefund} disabled={disabled}>
                   {isRefunding && <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.7)" />}
                   <ThemedText style={styles.secondaryButtonText}>{isRefunding ? 'Refunding...' : 'Refund Swap'}</ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               </View>
             </>
           )}

--- a/mobile/app/Tools.tsx
+++ b/mobile/app/Tools.tsx
@@ -1,8 +1,9 @@
-import { Alert, StyleSheet, TouchableOpacity, View, SectionList, Pressable } from 'react-native';
+import { Alert, PressableStateCallbackType, SectionList, StyleSheet, View } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Bugsnag from '@bugsnag/expo';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Pressable from '../components/Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import ScreenHeader from '@/components/navigation/ScreenHeader';
@@ -275,9 +276,9 @@ export default function TabThreeScreen() {
       case 'selfTest':
         return (
           <View style={styles.settingsGroup}>
-            <TouchableOpacity style={[styles.testButton, testState === 'running' && styles.testButtonDisabled]} onPress={handleSelfTest} disabled={testState === 'running'} testID="RunSelfTestButton">
+            <Pressable style={[styles.testButton, testState === 'running' && styles.testButtonDisabled]} onPress={handleSelfTest} disabled={testState === 'running'} testID="RunSelfTestButton">
               <ThemedText style={styles.testButtonText}>{testState === 'running' ? 'Running...' : 'Run Self Test'}</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
             {testState === 'ok' && (
               <View style={styles.testResult}>
                 <ThemedText style={styles.testResultSuccess} testID="SelfTestSuccess">
@@ -301,9 +302,9 @@ export default function TabThreeScreen() {
               <ThemedText style={styles.accountText}>Current Pocket: {accountNumber}</ThemedText>
               <View style={styles.accountButtonContainer}>
                 {[0, 1, 2, 3, 4].map((num) => (
-                  <TouchableOpacity key={num} style={[styles.accountButton, accountNumber === num && styles.accountButtonActive]} onPress={() => handleAccountChange(num)}>
+                  <Pressable key={num} style={[styles.accountButton, accountNumber === num && styles.accountButtonActive]} onPress={() => handleAccountChange(num)}>
                     <ThemedText style={[styles.accountButtonText, accountNumber === num && styles.accountButtonTextActive]}>{num}</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 ))}
               </View>
             </View>
@@ -313,11 +314,11 @@ export default function TabThreeScreen() {
       case 'bitcoinXpub':
         return (
           <View style={styles.settingsGroup}>
-            <TouchableOpacity style={styles.xpubContainer} onPress={handleCopyXpub} disabled={!btcXpub} testID="XpubCopyButton">
+            <Pressable style={styles.xpubContainer} onPress={handleCopyXpub} disabled={!btcXpub} testID="XpubCopyButton">
               <ThemedText style={styles.xpubText} selectable testID="XpubText" numberOfLines={2}>
                 {btcXpub || 'Not available'}
               </ThemedText>
-            </TouchableOpacity>
+            </Pressable>
             {!!btcXpub && <ThemedText style={styles.xpubHint}>Tap to copy</ThemedText>}
           </View>
         );
@@ -339,7 +340,7 @@ export default function TabThreeScreen() {
                       </ThemedText>
                       <View style={styles.settingOptionsContainer} testID={`SettingOptionsContainer-${key}`}>
                         {config.options.map((option) => (
-                          <TouchableOpacity
+                          <Pressable
                             key={option}
                             style={[styles.settingOption, currentValue === option && styles.settingOptionActive]}
                             onPress={() => handleSettingChange(key, option)}
@@ -348,7 +349,7 @@ export default function TabThreeScreen() {
                             <ThemedText style={[styles.settingOptionText, currentValue === option && styles.settingOptionTextActive]} testID={`SettingOptionText-${key}-${option}`}>
                               {formatOptionName(option)}
                             </ThemedText>
-                          </TouchableOpacity>
+                          </Pressable>
                         ))}
                       </View>
                     </View>
@@ -366,7 +367,7 @@ export default function TabThreeScreen() {
             {deviceId && (
               <>
                 <View style={styles.divider} />
-                <Pressable style={({ pressed }) => [styles.deviceIdRow, pressed && styles.deviceIdRowPressed]} onPress={handleDeviceIdPress} testID="DeviceIdButton">
+                <Pressable style={({ pressed }: PressableStateCallbackType) => [styles.deviceIdRow, pressed && styles.deviceIdRowPressed]} onPress={handleDeviceIdPress} testID="DeviceIdButton">
                   <ThemedText style={styles.deviceIdText} numberOfLines={2}>
                     Device ID: {deviceId}
                   </ThemedText>

--- a/mobile/app/TransactionDetails.tsx
+++ b/mobile/app/TransactionDetails.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Linking, StyleSheet, TouchableOpacity, View } from 'react-native';
+import Pressable from '../components/Pressable';
+import { Linking, StyleSheet, View } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming, withRepeat, withSequence } from 'react-native-reanimated';
 import { Image } from 'expo-image';
 import * as Clipboard from 'expo-clipboard';
@@ -568,7 +569,7 @@ export default function TransactionDetails() {
 
           {/* Transaction Timeline */}
           {timelineData && timelineData.length > 0 && (
-            <TouchableOpacity style={styles.timelineContainer} onPress={toggleTimeline} activeOpacity={0.9}>
+            <Pressable style={styles.timelineContainer} onPress={toggleTimeline} activeOpacity={0.9}>
               <View style={styles.timelineInnerContainer}>
                 <Timeline
                   key={`timeline-${confirmationEta}`}
@@ -681,7 +682,7 @@ export default function TransactionDetails() {
                   }}
                 />
               </View>
-            </TouchableOpacity>
+            </Pressable>
           )}
 
           {/* Details list */}
@@ -689,9 +690,9 @@ export default function TransactionDetails() {
             <View style={styles.detailRow}>
               <ThemedText style={styles.detailLabel}>{transaction.direction === 'send' ? 'To' : 'From'}</ThemedText>
               <View style={styles.detailValueWrap}>
-                <TouchableOpacity onPress={() => handleCopy(transaction.counterparty ?? '')}>
+                <Pressable onPress={() => handleCopy(transaction.counterparty ?? '')}>
                   <MaterialIcons name="content-copy" size={16} color="rgba(255, 255, 255, 0.8)" />
-                </TouchableOpacity>
+                </Pressable>
                 <View style={styles.detailValueContainer}>
                   <ThemedText style={[styles.detailValue]} numberOfLines={1} ellipsizeMode="middle">
                     {transaction.counterparty ?? '—'}
@@ -712,9 +713,9 @@ export default function TransactionDetails() {
           </View>
 
           {/* Open in explorer */}
-          <TouchableOpacity disabled={!transaction.explorerUrl} style={[styles.explorerButton, !transaction.explorerUrl && { opacity: 0.6 }]} onPress={handleOpenInExplorer}>
+          <Pressable disabled={!transaction.explorerUrl} style={[styles.explorerButton, !transaction.explorerUrl && { opacity: 0.6 }]} onPress={handleOpenInExplorer}>
             <ThemedText style={styles.explorerText}>Open in explorer</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </SafeAreaView>
     </DetachedSheet>

--- a/mobile/app/TransactionSuccessEvm.tsx
+++ b/mobile/app/TransactionSuccessEvm.tsx
@@ -12,7 +12,8 @@ import * as Clipboard from 'expo-clipboard';
 import * as Linking from 'expo-linking';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import React, { useEffect, useState } from 'react';
-import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import Pressable from '../components/Pressable';
 
 export type TransactionSuccessProps = {
   amount: string; // in sats
@@ -153,16 +154,16 @@ const TransactionSuccessEvm: React.FC = () => {
           <ThemedText style={styles.summaryLabel}>Transaction ID</ThemedText>
           <View style={styles.txIdContainer}>
             <ThemedText style={styles.txIdText}>{transactionId.replace('0x', '').substring(0, 16)}...</ThemedText>
-            <TouchableOpacity onPress={() => copyToClipboard(transactionId)}>
+            <Pressable onPress={() => copyToClipboard(transactionId)}>
               <Ionicons name="copy-outline" size={16} color="#007AFF" />
-            </TouchableOpacity>
+            </Pressable>
           </View>
         </View>
       </ThemedView>
 
-      <TouchableOpacity style={styles.explorerButton} onPress={openInExplorer}>
+      <Pressable style={styles.explorerButton} onPress={openInExplorer}>
         <ThemedText style={styles.explorerButtonText}>View in Explorer</ThemedText>
-      </TouchableOpacity>
+      </Pressable>
     </ScrollView>
   );
 };

--- a/mobile/app/UnlockPassword.tsx
+++ b/mobile/app/UnlockPassword.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useContext } from 'react';
-import { StyleSheet, TextInput, TouchableOpacity, Alert, KeyboardAvoidingView, Platform, ScrollView, View, Animated } from 'react-native';
+import Pressable from '../components/Pressable';
+import { StyleSheet, TextInput, Alert, KeyboardAvoidingView, Platform, ScrollView, View, Animated } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
@@ -130,7 +131,7 @@ export default function UnlockPassword() {
               </View>
 
               <Animated.View style={[styles.buttonSection, buttonTransition]}>
-                <TouchableOpacity
+                <Pressable
                   style={[styles.button, isLoading || !password ? styles.buttonDisabled : null]}
                   onPress={handleUnlockPassword}
                   disabled={isLoading || !password}
@@ -139,7 +140,7 @@ export default function UnlockPassword() {
                   <ThemedText type="button" darkColor={Colors.dark.buttonText}>
                     {isLoading ? 'Unlocking...' : 'Unlock'}
                   </ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               </Animated.View>
             </ScrollView>
           </KeyboardAvoidingView>

--- a/mobile/app/manual-backup/intro.tsx
+++ b/mobile/app/manual-backup/intro.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { View, StyleSheet, TouchableOpacity, Image, Animated } from 'react-native';
+import { View, StyleSheet, Image, Animated } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
 import { Colors, gradients } from '@shared/constants/Colors';
 import { LinearGradient } from 'expo-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useHorizontalSpringTransition, useSequentialSpringAnimation } from '@/hooks/useCustomTransitions';
+import Pressable from '../../components/Pressable';
 
 export default function ManualBackupIntroScreen() {
   const router = useRouter();
@@ -48,13 +49,13 @@ export default function ManualBackupIntroScreen() {
 
           <View style={styles.buttonSection}>
             <Animated.View style={[styles.buttonContainer, buttonTransition]}>
-              <TouchableOpacity style={styles.button} onPress={handleContinue} testID="ManualBackupContinueButton">
+              <Pressable style={styles.button} onPress={handleContinue} testID="ManualBackupContinueButton">
                 <View style={styles.view}>
                   <ThemedText type="button" darkColor={Colors.dark.buttonText}>
                     Continue
                   </ThemedText>
                 </View>
-              </TouchableOpacity>
+              </Pressable>
             </Animated.View>
           </View>
         </SafeAreaView>

--- a/mobile/app/onboarding/create-password.tsx
+++ b/mobile/app/onboarding/create-password.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { StyleSheet, TextInput, TouchableOpacity, Alert, KeyboardAvoidingView, Platform, ScrollView, View, Animated, Keyboard } from 'react-native';
+import { StyleSheet, TextInput, Alert, KeyboardAvoidingView, Platform, ScrollView, View, Animated, Keyboard } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -9,6 +9,7 @@ import ScreenHeader from '@/components/navigation/ScreenHeader';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { Colors } from '@shared/constants/Colors';
 import { useSequentialSpringAnimation } from '@/hooks/useCustomTransitions';
+import Pressable from '../../components/Pressable';
 
 export default function CreatePasswordScreen() {
   const [password, setPassword] = useState('');
@@ -293,7 +294,7 @@ export default function CreatePasswordScreen() {
               </View>
 
               <Animated.View style={[styles.buttonSection, buttonTransition]}>
-                <TouchableOpacity
+                <Pressable
                   style={[styles.button, isLoading || !password || !repeatPassword ? styles.buttonDisabled : null]}
                   onPress={handleCreatePassword}
                   disabled={isLoading || !password || !repeatPassword}
@@ -304,7 +305,7 @@ export default function CreatePasswordScreen() {
                   <ThemedText type="button" darkColor={Colors.dark.buttonText}>
                     {isLoading ? 'Creating...' : 'Create Password'}
                   </ThemedText>
-                </TouchableOpacity>
+                </Pressable>
               </Animated.View>
             </ScrollView>
           </KeyboardAvoidingView>

--- a/mobile/app/onboarding/create-wallet-intro.tsx
+++ b/mobile/app/onboarding/create-wallet-intro.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, StyleSheet, TouchableOpacity, Image, Animated, ActivityIndicator } from 'react-native';
+import { View, StyleSheet, Image, Animated, ActivityIndicator } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
 import { ThemedText } from '@/components/ThemedText';
@@ -9,6 +9,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useHorizontalSpringTransition, useSequentialSpringAnimation } from '@/hooks/useCustomTransitions';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { sleep } from '@shared/modules/sleep';
+import Pressable from '../../components/Pressable';
 
 export default function CreateWalletIntroScreen() {
   const router = useRouter();
@@ -77,7 +78,7 @@ export default function CreateWalletIntroScreen() {
 
           <View style={styles.buttonSection}>
             <Animated.View style={[styles.buttonContainer, buttonTransition]}>
-              <TouchableOpacity style={[styles.button, isLoading && styles.buttonDisabled]} onPress={handleCreateWallet} disabled={isLoading}>
+              <Pressable style={[styles.button, isLoading && styles.buttonDisabled]} onPress={handleCreateWallet} disabled={isLoading}>
                 <View style={styles.view}>
                   {isLoading ? (
                     <>
@@ -92,7 +93,7 @@ export default function CreateWalletIntroScreen() {
                     </ThemedText>
                   )}
                 </View>
-              </TouchableOpacity>
+              </Pressable>
             </Animated.View>
           </View>
         </SafeAreaView>

--- a/mobile/app/onboarding/create-wallet.tsx
+++ b/mobile/app/onboarding/create-wallet.tsx
@@ -1,6 +1,6 @@
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import React, { useState, useEffect, useMemo } from 'react';
-import { View, StyleSheet, Animated, FlatList, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Animated, FlatList } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { usePreventScreenCapture } from 'expo-screen-capture';
@@ -9,6 +9,7 @@ import { Typography } from '@/constants/Typography';
 import { useSequentialSpringAnimation } from '@/hooks/useCustomTransitions';
 import { Colors } from '@shared/constants/Colors';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
+import Pressable from '../../components/Pressable';
 
 type CreateWalletScreenParams = {
   mnemonic: string;
@@ -110,17 +111,17 @@ export default function CreateWalletScreen() {
             <View style={styles.bottomButtonContainer}>
               {!error && recoveryPhrase && (
                 <Animated.View style={verifyButtonAnimation}>
-                  <TouchableOpacity style={styles.skipButton} onPress={handleContinue} testID="SkipButton">
+                  <Pressable style={styles.skipButton} onPress={handleContinue} testID="SkipButton">
                     <ThemedText style={styles.buttonText}>Skip</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 </Animated.View>
               )}
 
               {!error && recoveryPhrase && (
                 <Animated.View style={verifyButtonAnimation}>
-                  <TouchableOpacity style={styles.verifyButton} onPress={handleVerify} testID="VerifyButton">
+                  <Pressable style={styles.verifyButton} onPress={handleVerify} testID="VerifyButton">
                     <ThemedText style={styles.buttonText}>Verify</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 </Animated.View>
               )}
             </View>

--- a/mobile/app/onboarding/import-wallet.tsx
+++ b/mobile/app/onboarding/import-wallet.tsx
@@ -4,7 +4,6 @@ import {
   ActivityIndicator,
   StyleSheet,
   TextInput,
-  TouchableOpacity,
   View,
   Animated,
   Image,
@@ -16,6 +15,7 @@ import {
   useWindowDimensions,
   Alert,
 } from 'react-native';
+import Pressable from '../../components/Pressable';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -291,7 +291,7 @@ export default function ImportWalletScreen() {
               </KeyboardAvoidingView>
               <Animated.View style={[styles.buttonSection, buttonTransition]}>
                 <Animated.View style={scanButtonTransition}>
-                  <TouchableOpacity
+                  <Pressable
                     style={[styles.scanButton, isLoading && styles.disabledButton]}
                     onPress={async () => {
                       const scanned = await scanQr();
@@ -302,10 +302,10 @@ export default function ImportWalletScreen() {
                     disabled={isLoading}
                   >
                     <Ionicons name="qr-code-outline" size={24} color="rgba(255, 255, 255, 0.9)" />
-                  </TouchableOpacity>
+                  </Pressable>
                 </Animated.View>
 
-                <TouchableOpacity
+                <Pressable
                   style={[styles.button, isLoading || !mnemonic.trim() ? styles.buttonDisabled : null]}
                   onPress={handleImportWallet}
                   disabled={isLoading || !mnemonic.trim()}
@@ -318,7 +318,7 @@ export default function ImportWalletScreen() {
                       Import
                     </ThemedText>
                   )}
-                </TouchableOpacity>
+                </Pressable>
               </Animated.View>
             </Animated.View>
           )}

--- a/mobile/app/onboarding/intro.tsx
+++ b/mobile/app/onboarding/intro.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, StyleSheet, TouchableOpacity, Animated } from 'react-native';
+import { View, StyleSheet, Animated } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
 import { Colors } from '@shared/constants/Colors';
 import { LinearGradient } from 'expo-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Rive, { RiveRef } from 'rive-react-native';
+import Pressable from '../../components/Pressable';
 
 const SLIDES = [
   {
@@ -155,17 +156,17 @@ export default function IntroScreen() {
 
           {/* Buttons */}
           <View style={styles.buttonSection}>
-            <TouchableOpacity style={styles.buttonPrimary} onPress={handleCreateWallet}>
+            <Pressable style={styles.buttonPrimary} onPress={handleCreateWallet}>
               <ThemedText type="defaultSemiBold" darkColor={Colors.dark.buttonText}>
                 Create Wallet
               </ThemedText>
-            </TouchableOpacity>
+            </Pressable>
 
-            <TouchableOpacity style={styles.buttonSecondary} onPress={handleImportWallet}>
+            <Pressable style={styles.buttonSecondary} onPress={handleImportWallet}>
               <ThemedText type="defaultSemiBold" darkColor={Colors.dark.buttonText}>
                 Import Wallet
               </ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           </View>
         </View>
       </SafeAreaView>

--- a/mobile/app/onboarding/tos.tsx
+++ b/mobile/app/onboarding/tos.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from 'react';
-import { StyleSheet, TouchableOpacity, Alert, View, Animated, Linking } from 'react-native';
+import { StyleSheet, Alert, View, Animated, Linking } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -11,6 +11,7 @@ import { Colors } from '@shared/constants/Colors';
 import { useSequentialSpringAnimation } from '@/hooks/useCustomTransitions';
 import { Image } from 'expo-image';
 import { EStep, InitializationContext } from '@shared/hooks/InitializationContext';
+import Pressable from '../../components/Pressable';
 
 export default function TermsOfServiceScreen() {
   const router = useRouter();
@@ -94,16 +95,16 @@ export default function TermsOfServiceScreen() {
           </View>
           <View style={styles.checkboxSection}>
             <Animated.View style={[checkboxTransition]}>
-              <TouchableOpacity style={styles.checkboxContainer} onPress={() => handleCheckboxPress('backup')} activeOpacity={0.7} testID="BackupRecoveryPhraseCheckbox">
+              <Pressable style={styles.checkboxContainer} onPress={() => handleCheckboxPress('backup')} activeOpacity={0.7} testID="BackupRecoveryPhraseCheckbox">
                 <View style={[styles.checkbox, backupChecked && styles.checkboxChecked]}>{backupChecked && <Ionicons name="checkmark" size={16} />}</View>
                 <ThemedText style={styles.checkboxText} darkColor="rgba(255, 255, 255, 0.9)">
                   I have backed up my recovery phrase and I understand I cannot recover my wallet without it.
                 </ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </Animated.View>
 
             <Animated.View style={[checkboxTransition]}>
-              <TouchableOpacity style={styles.checkboxContainer} onPress={() => handleCheckboxPress('terms')} activeOpacity={0.7} testID="TermsOfServiceCheckbox">
+              <Pressable style={styles.checkboxContainer} onPress={() => handleCheckboxPress('terms')} activeOpacity={0.7} testID="TermsOfServiceCheckbox">
                 <View style={[styles.checkbox, termsChecked && styles.checkboxChecked]}>{termsChecked && <Ionicons name="checkmark" size={16} />}</View>
                 <ThemedText style={styles.checkboxText} darkColor="rgba(255, 255, 255, 0.9)">
                   I have read and accept the{' '}
@@ -112,15 +113,15 @@ export default function TermsOfServiceScreen() {
                   </ThemedText>{' '}
                   of Layerz Tec Ltd.
                 </ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </Animated.View>
           </View>
           <Animated.View style={[styles.buttonSection, buttonTransition]}>
-            <TouchableOpacity style={[styles.button, !isButtonEnabled && styles.buttonDisabled]} onPress={handleAgree} disabled={!isButtonEnabled} testID="LetsGoButton">
+            <Pressable style={[styles.button, !isButtonEnabled && styles.buttonDisabled]} onPress={handleAgree} disabled={!isButtonEnabled} testID="LetsGoButton">
               <ThemedText type="button" darkColor={Colors.dark.buttonText}>
                 {isLoading ? 'Processing...' : "Let's go"}
               </ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           </Animated.View>
         </SafeAreaView>
       </View>

--- a/mobile/app/onboarding/verify-recovery-phrase.tsx
+++ b/mobile/app/onboarding/verify-recovery-phrase.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'expo-router';
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { View, StyleSheet, Animated, FlatList, TouchableOpacity, LayoutAnimation, Platform } from 'react-native';
+import { View, StyleSheet, Animated, FlatList, LayoutAnimation, Platform } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
@@ -11,6 +11,7 @@ import { Typography } from '@/constants/Typography';
 import { useSequentialSpringAnimation } from '@/hooks/useCustomTransitions';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { usePreventScreenCapture } from 'expo-screen-capture';
+import Pressable from '../../components/Pressable';
 
 // Constants
 const TOTAL_WORDS = 12;
@@ -64,7 +65,7 @@ const SelectableWordDisplay: React.FC<{
   const handlePress = useCallback(() => onPress(wordItem), [onPress, wordItem]);
 
   return (
-    <TouchableOpacity style={wordStyle} onPress={handlePress} disabled={wordItem.isSelected || showError}>
+    <Pressable style={wordStyle} onPress={handlePress} disabled={wordItem.isSelected || showError}>
       <Animated.View style={animatedViewStyle}>
         <View style={numberStyle}>
           <ThemedText style={styles.wordNumberText}>{wordItem.isSelected && wordItem.selectedOrder !== undefined ? wordItem.selectedOrder + 1 : ''}</ThemedText>
@@ -73,7 +74,7 @@ const SelectableWordDisplay: React.FC<{
           <ThemedText style={styles.wordText}>{wordItem.word}</ThemedText>
         </View>
       </Animated.View>
-    </TouchableOpacity>
+    </Pressable>
   );
 });
 
@@ -234,11 +235,11 @@ export default function VerifyRecoveryPhrase() {
             </View>
 
             <Animated.View style={[styles.buttonSection, verifyButtonAnimation]}>
-              <TouchableOpacity style={styles.successButton} onPress={handleContinue} testID="ContinueButton">
+              <Pressable style={styles.successButton} onPress={handleContinue} testID="ContinueButton">
                 <ThemedText type="button" darkColor={Colors.dark.buttonText}>
                   Continue
                 </ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </Animated.View>
           </SafeAreaView>
         </View>
@@ -285,9 +286,9 @@ export default function VerifyRecoveryPhrase() {
 
           <Animated.View style={[styles.buttonSection, verifyButtonAnimation]}>
             <Animated.View style={{ opacity: buttonOpacity }}>
-              <TouchableOpacity style={styles.skipButton} onPress={handleSkip} disabled={showError} testID="SkipButton">
+              <Pressable style={styles.skipButton} onPress={handleSkip} disabled={showError} testID="SkipButton">
                 <ThemedText style={[styles.buttonText, showError && styles.disabledButtonText]}>Skip Verify</ThemedText>
-              </TouchableOpacity>
+              </Pressable>
             </Animated.View>
           </Animated.View>
         </SafeAreaView>

--- a/mobile/app/send/send-address-lightning.tsx
+++ b/mobile/app/send/send-address-lightning.tsx
@@ -1,10 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../../components/Pressable';
 import assert from 'assert';
 import * as bip21 from 'bip21';
 import * as bolt11 from 'bolt11';
 import { Stack, useRouter } from 'expo-router';
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
 
 import { BalanceLightning } from '@/components/Balance';
 import GradientScreen from '@/components/GradientScreen';
@@ -200,7 +201,7 @@ const SendAddressLightning: React.FC = () => {
         <View style={styles.container}>
           <View style={styles.inputSection}>
             <View style={styles.inputContainer}>
-              <TouchableOpacity style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-lightning-invoice-input">
+              <Pressable style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-lightning-invoice-input">
                 <ThemedText style={styles.inputLabel}>To</ThemedText>
                 <TextInput
                   ref={inputRef}
@@ -212,10 +213,10 @@ const SendAddressLightning: React.FC = () => {
                   onChangeText={setLocalInvoice}
                   value={localInvoice}
                 />
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.scanButton} onPress={handleScanQR}>
+              </Pressable>
+              <Pressable style={styles.scanButton} onPress={handleScanQR}>
                 <Ionicons name="scan-outline" size={24} color="rgba(255, 255, 255, 0.8)" />
-              </TouchableOpacity>
+              </Pressable>
             </View>
 
             {showError && errorMessages[invoice] && (
@@ -242,9 +243,9 @@ const SendAddressLightning: React.FC = () => {
             </View>
           )}
 
-          <TouchableOpacity style={[styles.continueButton, !canContinue && styles.disabledButton]} onPress={handleContinue} disabled={!canContinue} testID="send-lightning-address-next-button">
+          <Pressable style={[styles.continueButton, !canContinue && styles.disabledButton]} onPress={handleContinue} disabled={!canContinue} testID="send-lightning-address-next-button">
             <ThemedText style={styles.continueButtonText}>Next</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </KeyboardAvoidingView>
     </GradientScreen>

--- a/mobile/app/send/send-address-usdt.tsx
+++ b/mobile/app/send/send-address-usdt.tsx
@@ -1,8 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../../components/Pressable';
 import * as bip21 from 'bip21';
 import { Stack, useRouter } from 'expo-router';
 import React, { useContext, useRef, useState } from 'react';
-import { KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
 
 import { BalanceUsdt } from '@/components/Balance';
 import GradientScreen from '@/components/GradientScreen';
@@ -83,7 +84,7 @@ const SendAddressUsdt: React.FC = () => {
       }
 
       setContextAddress(address);
-      router.push('/send/send-amount-usdt');
+      router.push({ pathname: '/send/send-amount-usdt' } as any);
     } catch (error: any) {
       setErrorMessage(error.message || 'Failed to validate address');
       setShowError(true);
@@ -105,7 +106,7 @@ const SendAddressUsdt: React.FC = () => {
         <View style={styles.container}>
           <View style={styles.inputSection}>
             <View style={styles.inputContainer}>
-              <TouchableOpacity style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-address-usdt-input">
+              <Pressable style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-address-usdt-input">
                 <ThemedText style={styles.inputLabel}>To</ThemedText>
                 <TextInput
                   ref={inputRef}
@@ -120,10 +121,10 @@ const SendAddressUsdt: React.FC = () => {
                   }}
                   value={localAddress}
                 />
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.scanButton} onPress={handleScanQR} testID="send-address-usdt-scan-qr">
+              </Pressable>
+              <Pressable style={styles.scanButton} onPress={handleScanQR} testID="send-address-usdt-scan-qr">
                 <Ionicons name="scan-outline" size={24} color="rgba(255, 255, 255, 0.8)" />
-              </TouchableOpacity>
+              </Pressable>
             </View>
 
             {showError && errorMessage && (
@@ -136,9 +137,9 @@ const SendAddressUsdt: React.FC = () => {
 
           <BalanceUsdt onSelectToken={handleTokenSelect} selectedToken={token} showTotalBalance={false} />
 
-          <TouchableOpacity style={[styles.continueButton, !canContinue && styles.disabledButton]} onPress={handleContinue} disabled={!canContinue} testID="send-address-usdt-continue">
+          <Pressable style={[styles.continueButton, !canContinue && styles.disabledButton]} onPress={handleContinue} disabled={!canContinue} testID="send-address-usdt-continue">
             <ThemedText style={styles.continueButtonText}>Next</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </KeyboardAvoidingView>
     </GradientScreen>

--- a/mobile/app/send/send-address.tsx
+++ b/mobile/app/send/send-address.tsx
@@ -2,7 +2,8 @@ import { Ionicons } from '@expo/vector-icons';
 import * as bip21 from 'bip21';
 import { Stack, useRouter } from 'expo-router';
 import React, { useContext, useRef, useState } from 'react';
-import { KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
+import Pressable from '../../components/Pressable';
 
 import GradientScreen from '@/components/GradientScreen';
 import ScreenSendHeader from '@/components/navigation/ScreenSendHeader';
@@ -90,7 +91,7 @@ const SendAddress: React.FC = () => {
         <View style={styles.container}>
           <View style={styles.inputSection}>
             <View style={styles.inputContainer}>
-              <TouchableOpacity style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-address-input">
+              <Pressable style={styles.inputWrapper} onPress={handleInputWrapperPress} activeOpacity={1} testID="send-address-input">
                 <ThemedText style={styles.inputLabel}>To</ThemedText>
                 <TextInput
                   ref={inputRef}
@@ -102,10 +103,10 @@ const SendAddress: React.FC = () => {
                   onChangeText={setLocalAddress}
                   value={localAddress}
                 />
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.scanButton} onPress={handleScanQR}>
+              </Pressable>
+              <Pressable style={styles.scanButton} onPress={handleScanQR}>
                 <Ionicons name="scan-outline" size={24} color="rgba(255, 255, 255, 0.8)" />
-              </TouchableOpacity>
+              </Pressable>
             </View>
 
             {errorMessage && (
@@ -118,9 +119,9 @@ const SendAddress: React.FC = () => {
 
           <TokensView onTokenPress={handleTokenPress} selectedToken={token} />
 
-          <TouchableOpacity style={[styles.continueButton, !localAddress.trim() && styles.disabledButton]} onPress={handleContinue} disabled={!localAddress.trim()} testID="send-address-next-button">
+          <Pressable style={[styles.continueButton, !localAddress.trim() && styles.disabledButton]} onPress={handleContinue} disabled={!localAddress.trim()} testID="send-address-next-button">
             <ThemedText style={styles.continueButtonText}>Next</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </KeyboardAvoidingView>
     </GradientScreen>

--- a/mobile/app/send/send-amount-acc.tsx
+++ b/mobile/app/send/send-amount-acc.tsx
@@ -2,7 +2,8 @@ import { Ionicons } from '@expo/vector-icons';
 import BigNumber from 'bignumber.js';
 import { Stack, useRouter } from 'expo-router';
 import React, { useState } from 'react';
-import { KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
+import Pressable from '../../components/Pressable';
 
 import AmountInput from '@/components/AmountInput';
 import GradientScreen from '@/components/GradientScreen';
@@ -130,9 +131,9 @@ const SendAmountAcc: React.FC<SendAssetProps> = ({ balance, exchangeRate, ticker
             )}
           </View>
 
-          <TouchableOpacity style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleNext} disabled={buttonDisabled} testID="send-amount-acc-next-button">
+          <Pressable style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleNext} disabled={buttonDisabled} testID="send-amount-acc-next-button">
             <ThemedText style={styles.continueButtonText}>Next</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </KeyboardAvoidingView>
     </GradientScreen>

--- a/mobile/app/send/send-amount-btc.tsx
+++ b/mobile/app/send/send-amount-btc.tsx
@@ -2,8 +2,9 @@ import { Ionicons } from '@expo/vector-icons';
 import BigNumber from 'bignumber.js';
 import { Stack, useRouter } from 'expo-router';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Alert, KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Alert, KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
 import Animated, { Extrapolation, interpolate, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import Pressable from '../../components/Pressable';
 
 import AmountInput from '@/components/AmountInput';
 import GradientScreen from '@/components/GradientScreen';
@@ -357,7 +358,7 @@ const SendAmountBtc: React.FC = () => {
 
           {!isLoading && !feeLoadingError && (
             <View style={styles.feeSelectorContainer}>
-              <TouchableOpacity style={isFeeSelectorExpanded ? styles.feeSelectorExpandedHeader : styles.feeSelectorHeader} onPress={toggleFeeSelector}>
+              <Pressable style={isFeeSelectorExpanded ? styles.feeSelectorExpandedHeader : styles.feeSelectorHeader} onPress={toggleFeeSelector}>
                 {isFeeSelectorExpanded ? (
                   <>
                     <ThemedText style={styles.feeSelectorTitle}>Network Fee</ThemedText>
@@ -379,39 +380,39 @@ const SendAmountBtc: React.FC = () => {
                     </Animated.View>
                   </>
                 )}
-              </TouchableOpacity>
+              </Pressable>
 
               {estimateFees && (
                 <Animated.View style={[styles.feeOptionsContainer, animatedFeeOptionsStyle]}>
-                  <TouchableOpacity style={[styles.feeOption, feeRate === estimateFees.fast && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.fast)}>
+                  <Pressable style={[styles.feeOption, feeRate === estimateFees.fast && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.fast)}>
                     <View style={styles.feeOptionContent}>
                       <ThemedText style={styles.feeOptionName}>Fast</ThemedText>
                       <ThemedText style={styles.feeOptionRate}>{estimateFees.fast} sats v/b</ThemedText>
                     </View>
                     <ThemedText style={styles.feeOptionAmount}>{feeRateOptions[estimateFees.fast] ? formatFee(feeRateOptions[estimateFees.fast]) : ''}</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
 
-                  <TouchableOpacity style={[styles.feeOption, feeRate === estimateFees.medium && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.medium)}>
+                  <Pressable style={[styles.feeOption, feeRate === estimateFees.medium && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.medium)}>
                     <View style={styles.feeOptionContent}>
                       <ThemedText style={styles.feeOptionName}>Medium</ThemedText>
                       <ThemedText style={styles.feeOptionRate}>{estimateFees.medium} sats v/b</ThemedText>
                     </View>
                     <ThemedText style={styles.feeOptionAmount}>{feeRateOptions[estimateFees.medium] ? formatFee(feeRateOptions[estimateFees.medium]) : ''}</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
 
-                  <TouchableOpacity style={[styles.feeOption, feeRate === estimateFees.slow && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.slow)}>
+                  <Pressable style={[styles.feeOption, feeRate === estimateFees.slow && styles.selectedFeeOption]} onPress={() => handleFeeSelection(estimateFees.slow)}>
                     <View style={styles.feeOptionContent}>
                       <ThemedText style={styles.feeOptionName}>Slow</ThemedText>
                       <ThemedText style={styles.feeOptionRate}>{estimateFees.slow} sats v/b</ThemedText>
                     </View>
                     <ThemedText style={styles.feeOptionAmount}>{feeRateOptions[estimateFees.slow] ? formatFee(feeRateOptions[estimateFees.slow]) : ''}</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 </Animated.View>
               )}
             </View>
           )}
 
-          <TouchableOpacity style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleContinue} disabled={buttonDisabled}>
+          <Pressable style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleContinue} disabled={buttonDisabled}>
             {isCreatingTransaction ? (
               <>
                 <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" />
@@ -420,7 +421,7 @@ const SendAmountBtc: React.FC = () => {
             ) : (
               <ThemedText style={styles.continueButtonText}>Next</ThemedText>
             )}
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </KeyboardAvoidingView>
     </GradientScreen>

--- a/mobile/app/send/send-amount-evm.tsx
+++ b/mobile/app/send/send-amount-evm.tsx
@@ -1,9 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../../components/Pressable';
 import Slider from '@react-native-community/slider';
 import BigNumber from 'bignumber.js';
 import { Stack, useRouter } from 'expo-router';
 import React, { useContext, useState } from 'react';
-import { ActivityIndicator, KeyboardAvoidingView, Platform, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, Platform, StyleSheet, View } from 'react-native';
 
 import AmountInput from '@/components/AmountInput';
 import GradientScreen from '@/components/GradientScreen';
@@ -173,7 +174,7 @@ const SendAmountEvm: React.FC<SendAssetProps> = ({ balance, exchangeRate, ticker
             </View>
           </View>
 
-          <TouchableOpacity style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={prepareTransaction} disabled={buttonDisabled || isPreparing}>
+          <Pressable style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={prepareTransaction} disabled={buttonDisabled || isPreparing}>
             {isPreparing ? (
               <>
                 <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" />
@@ -182,7 +183,7 @@ const SendAmountEvm: React.FC<SendAssetProps> = ({ balance, exchangeRate, ticker
             ) : (
               <ThemedText style={styles.continueButtonText}>Next</ThemedText>
             )}
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </KeyboardAvoidingView>
     </GradientScreen>

--- a/mobile/app/send/send-amount-lightning.tsx
+++ b/mobile/app/send/send-amount-lightning.tsx
@@ -1,10 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
+import Pressable from '../../components/Pressable';
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import * as bolt11 from 'bolt11';
 import { Stack, useRouter } from 'expo-router';
 import React, { useContext, useEffect, useState } from 'react';
-import { ActivityIndicator, KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
 
 import AmountInput from '@/components/AmountInput';
 import GradientScreen from '@/components/GradientScreen';
@@ -199,7 +200,7 @@ const SendAmountLightning: React.FC = () => {
             )}
           </View>
 
-          <TouchableOpacity style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleContinue} disabled={buttonDisabled}>
+          <Pressable style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleContinue} disabled={buttonDisabled}>
             {isPreparing ? (
               <>
                 <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" />
@@ -208,7 +209,7 @@ const SendAmountLightning: React.FC = () => {
             ) : (
               <ThemedText style={styles.continueButtonText}>Next</ThemedText>
             )}
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </KeyboardAvoidingView>
     </GradientScreen>

--- a/mobile/app/send/send-amount-liquid.tsx
+++ b/mobile/app/send/send-amount-liquid.tsx
@@ -4,7 +4,8 @@ import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import { Stack, useRouter } from 'expo-router';
 import React, { useContext, useMemo, useState } from 'react';
-import { ActivityIndicator, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View } from 'react-native';
+import Pressable from '../../components/Pressable';
 
 import AmountInput from '@/components/AmountInput';
 import GradientScreen from '@/components/GradientScreen';
@@ -169,7 +170,7 @@ const SendAmountLiquid: React.FC<SendAssetProps> = ({ balance, exchangeRate, tic
               )}
             </View>
 
-            <TouchableOpacity style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleContinue} disabled={buttonDisabled}>
+            <Pressable style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleContinue} disabled={buttonDisabled}>
               {isPreparing ? (
                 <>
                   <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" />
@@ -178,7 +179,7 @@ const SendAmountLiquid: React.FC<SendAssetProps> = ({ balance, exchangeRate, tic
               ) : (
                 <ThemedText style={styles.continueButtonText}>Next</ThemedText>
               )}
-            </TouchableOpacity>
+            </Pressable>
           </View>
         </ScrollView>
       </KeyboardAvoidingView>

--- a/mobile/app/send/send-amount-usdt.tsx
+++ b/mobile/app/send/send-amount-usdt.tsx
@@ -5,7 +5,8 @@ import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import { Stack, useRouter } from 'expo-router';
 import React, { useContext, useState } from 'react';
-import { ActivityIndicator, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View } from 'react-native';
+import Pressable from '../../components/Pressable';
 
 import AmountInput from '@/components/AmountInput';
 import GradientScreen from '@/components/GradientScreen';
@@ -229,7 +230,7 @@ const SendAmountUsdt: React.FC<SendAssetProps> = ({ balance, exchangeRate, ticke
               </View>
             )}
 
-            <TouchableOpacity style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleContinue} disabled={buttonDisabled || isPreparing}>
+            <Pressable style={[styles.continueButton, buttonDisabled && styles.disabledButton]} onPress={handleContinue} disabled={buttonDisabled || isPreparing}>
               {isPreparing ? (
                 <>
                   <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" />
@@ -238,7 +239,7 @@ const SendAmountUsdt: React.FC<SendAssetProps> = ({ balance, exchangeRate, ticke
               ) : (
                 <ThemedText style={styles.continueButtonText}>Next</ThemedText>
               )}
-            </TouchableOpacity>
+            </Pressable>
           </View>
         </ScrollView>
       </KeyboardAvoidingView>

--- a/mobile/app/send/send-confirm-lightning.tsx
+++ b/mobile/app/send/send-confirm-lightning.tsx
@@ -3,9 +3,10 @@ import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import { Stack, useRouter } from 'expo-router';
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View } from 'react-native';
 import Animated, { Easing, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import Rive, { RiveRef } from 'rive-react-native';
+import Pressable from '../../components/Pressable';
 
 import GradientScreen from '@/components/GradientScreen';
 import ScreenSendHeader from '@/components/navigation/ScreenSendHeader';
@@ -195,9 +196,9 @@ const SendConfirmLightning: React.FC = () => {
                   <Ionicons name="alert-circle" size={40} color="#FF3B30" />
                   <ThemedText style={styles.errorTitle}>Error</ThemedText>
                   <ThemedText style={styles.errorText}>{error}</ThemedText>
-                  <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+                  <Pressable style={styles.backButton} onPress={() => router.back()}>
                     <ThemedText style={styles.backButtonText}>Go Back</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 </View>
               ) : (
                 <>
@@ -269,11 +270,11 @@ const SendConfirmLightning: React.FC = () => {
           </ScrollView>
         </KeyboardAvoidingView>
         {!error && (
-          <TouchableOpacity style={[styles.sendButton, isSending && styles.disabledButton]} onPress={isSuccess ? handleHome : sendPayment} disabled={isSending} testID="send-lightning-confirm-button">
+          <Pressable style={[styles.sendButton, isSending && styles.disabledButton]} onPress={isSuccess ? handleHome : sendPayment} disabled={isSending} testID="send-lightning-confirm-button">
             <ThemedText style={styles.sendButtonText} testID={isSuccess ? 'send-lightning-success-text' : undefined}>
               {isSuccess ? 'Back to Wallet' : isSending ? 'Sending...' : 'Confirm Send'}
             </ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         )}
       </View>
     </GradientScreen>

--- a/mobile/app/send/send-confirm.tsx
+++ b/mobile/app/send/send-confirm.tsx
@@ -3,9 +3,10 @@ import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import { Redirect, Stack, useRouter } from 'expo-router';
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { Alert, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View } from 'react-native';
 import Animated, { Easing, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import Rive, { RiveRef } from 'rive-react-native';
+import Pressable from '../../components/Pressable';
 
 import GradientScreen from '@/components/GradientScreen';
 import ScreenSendHeader from '@/components/navigation/ScreenSendHeader';
@@ -269,9 +270,9 @@ const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
                   <Ionicons name="alert-circle" size={40} color="#FF3B30" />
                   <ThemedText style={styles.errorTitle}>Error</ThemedText>
                   <ThemedText style={styles.errorText}>{error}</ThemedText>
-                  <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+                  <Pressable style={styles.backButton} onPress={() => router.back()}>
                     <ThemedText style={styles.backButtonText}>Go Back</ThemedText>
-                  </TouchableOpacity>
+                  </Pressable>
                 </View>
               ) : (
                 <>
@@ -331,11 +332,11 @@ const SendConfirm: React.FC<SendAssetProps> = ({ ticker, token }) => {
           </ScrollView>
         </KeyboardAvoidingView>
         {!error && (
-          <TouchableOpacity style={[styles.sendButton, isBroadcasting && styles.disabledButton]} onPress={isSuccess ? handleHome : broadcast} disabled={isBroadcasting} testID="send-confirm-button">
+          <Pressable style={[styles.sendButton, isBroadcasting && styles.disabledButton]} onPress={isSuccess ? handleHome : broadcast} disabled={isBroadcasting} testID="send-confirm-button">
             <ThemedText style={styles.sendButtonText} testID={isSuccess ? 'send-success-text' : undefined}>
               {isSuccess ? 'Back to Wallet' : isBroadcasting ? 'Sending...' : 'Confirm Send'}
             </ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         )}
       </View>
     </GradientScreen>

--- a/mobile/components/ActionPopupButton.tsx
+++ b/mobile/components/ActionPopupButton.tsx
@@ -1,5 +1,5 @@
 import React, { cloneElement, ReactElement } from 'react';
-import { TouchableOpacityProps } from 'react-native';
+import type { PressableProps } from './Pressable';
 import { useRouter } from 'expo-router';
 import { useActionPopup } from '@/contexts/ActionPopupContext';
 
@@ -9,7 +9,7 @@ interface Action {
 }
 
 interface ActionPopupButtonProps {
-  children: ReactElement<TouchableOpacityProps>;
+  children: ReactElement<PressableProps>;
   actions: Action[];
   title?: string;
 }

--- a/mobile/components/AmountInput.tsx
+++ b/mobile/components/AmountInput.tsx
@@ -2,7 +2,8 @@ import { Denomination } from '@/app/send/_layout';
 import { Ionicons } from '@expo/vector-icons';
 import BigNumber from 'bignumber.js';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TextInput, View } from 'react-native';
+import Pressable from './Pressable';
 
 import { ThemedText } from './ThemedText';
 
@@ -151,13 +152,13 @@ export default function AmountInput({
   }, [balance, denomination, exchangeRateNumber, ticker]);
 
   return (
-    <TouchableOpacity style={styles.container} onPress={handleContainerPress} activeOpacity={1} testID={testID}>
+    <Pressable style={styles.container} onPress={handleContainerPress} activeOpacity={1} testID={testID}>
       {/* Max Button */}
       {onMaxPress && (
         <View style={styles.maxButtonContainer}>
-          <TouchableOpacity style={styles.maxButton} onPress={onMaxPress}>
+          <Pressable style={styles.maxButton} onPress={onMaxPress}>
             <ThemedText style={styles.maxButtonText}>max</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       )}
 
@@ -180,25 +181,20 @@ export default function AmountInput({
 
       {/* Bottom Row: Secondary Value and Balance */}
       <View style={styles.bottomRow}>
-        <TouchableOpacity
-          style={styles.usdContainer}
-          onPress={canSwitchDenomination ? handleDenominationSwitch : undefined}
-          disabled={!canSwitchDenomination}
-          activeOpacity={canSwitchDenomination ? 0.7 : 1}
-        >
+        <Pressable style={styles.usdContainer} onPress={canSwitchDenomination ? handleDenominationSwitch : undefined} disabled={!canSwitchDenomination} activeOpacity={canSwitchDenomination ? 0.7 : 1}>
           <ThemedText style={[styles.usdText, !canSwitchDenomination && styles.disabledText]}>{secondaryValue}</ThemedText>
           {canSwitchDenomination && <Ionicons name="swap-vertical" size={16} color="rgba(255, 255, 255, 0.5)" style={styles.swapIcon} />}
-        </TouchableOpacity>
+        </Pressable>
 
         {onBalancePress ? (
-          <TouchableOpacity onPress={onBalancePress} activeOpacity={0.7}>
+          <Pressable onPress={onBalancePress} activeOpacity={0.7}>
             <ThemedText style={styles.balanceText}>Balance {formattedBalance}</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         ) : (
           <ThemedText style={styles.balanceText}>Balance {formattedBalance}</ThemedText>
         )}
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 

--- a/mobile/components/Balance.tsx
+++ b/mobile/components/Balance.tsx
@@ -3,7 +3,8 @@ import PlatformBlurView from '@/components/PlatformBlurView';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import React, { useContext, useEffect, useImperativeHandle, useMemo, useState, forwardRef } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import Pressable from './Pressable';
 
 import { OnrampProps } from '@/app/Onramp';
 import { ThemedText } from '@/components/ThemedText';
@@ -64,9 +65,9 @@ const Balance = forwardRef<{ refresh: () => void }>((props, ref) => {
       </View>
 
       {canBuyWithFiat && (
-        <TouchableOpacity style={styles.buyButton} onPress={handleBuyClick} activeOpacity={0.8}>
+        <Pressable style={styles.buyButton} onPress={handleBuyClick} activeOpacity={0.8}>
           <ThemedText style={styles.buyButtonText}>Fund</ThemedText>
-        </TouchableOpacity>
+        </Pressable>
       )}
     </View>
   );
@@ -183,7 +184,7 @@ export const BalanceLightning = forwardRef<{ refresh: () => void }, BalanceLight
       const ticker = getTickerByNetwork(network);
 
       return (
-        <TouchableOpacity style={[styles.listBalanceRow, selectedNetwork === network && styles.selectedListBalanceRow]} key={network} onPress={() => onSelectNetwork(network)}>
+        <Pressable style={[styles.listBalanceRow, selectedNetwork === network && styles.selectedListBalanceRow]} key={network} onPress={() => onSelectNetwork(network)}>
           <View style={styles.listBalanceRowLabel}>
             <View style={styles.networkIcon}>{networkIconContent}</View>
             <ThemedText style={styles.listBalanceLabel}>{capitalizeFirstLetter(network)}</ThemedText>
@@ -195,7 +196,7 @@ export const BalanceLightning = forwardRef<{ refresh: () => void }, BalanceLight
             </ThemedText>
             <ThemedText style={styles.listBalanceFiat}>{formattedFiatBalance}</ThemedText>
           </View>
-        </TouchableOpacity>
+        </Pressable>
       );
     });
   }, [network, sparkBalance, liquidBalance, sparkExchangeRate, liquidExchangeRate, arkBalance, arkExchangeRate, selectedNetwork, onSelectNetwork]);
@@ -252,7 +253,7 @@ const TokenRow = ({
     setTokenBalances((prev) => ({ ...prev, [token.id]: balance }));
   }, [balance, token.id, setTokenBalances]);
 
-  const Container = onSelect ? TouchableOpacity : View;
+  const Container = onSelect ? Pressable : View;
   const containerProps = onSelect ? { onPress: () => onSelect(token.id, network), activeOpacity: 0.7 } : {};
 
   return (

--- a/mobile/components/Button.tsx
+++ b/mobile/components/Button.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { TouchableOpacity, TouchableOpacityProps, StyleSheet, ActivityIndicator, ViewStyle, TextStyle } from 'react-native';
+import { StyleSheet, ActivityIndicator, ViewStyle, TextStyle } from 'react-native';
+import Pressable, { PressableProps } from './Pressable';
 import PlatformBlurView from './PlatformBlurView';
 import { ThemedText } from './ThemedText';
 
-export interface ButtonProps extends TouchableOpacityProps {
+export interface ButtonProps extends PressableProps {
   title: string;
   variant?: 'high' | 'normal' | 'light' | 'lighter' | 'secondary' | 'dark' | 'darker';
   loading?: boolean;
@@ -70,9 +71,9 @@ export default function Button({ title, onPress, variant = 'normal', disabled = 
 
   if (variant === 'secondary') {
     return (
-      <TouchableOpacity style={[styles.button, styles.secondaryButton, style]} onPress={onPress} disabled={disabled || loading} activeOpacity={activeOpacity} {...restProps}>
+      <Pressable style={[styles.button, styles.secondaryButton, style]} onPress={onPress} disabled={disabled || loading} activeOpacity={activeOpacity} {...restProps}>
         {renderContent()}
-      </TouchableOpacity>
+      </Pressable>
     );
   }
 
@@ -82,11 +83,11 @@ export default function Button({ title, onPress, variant = 'normal', disabled = 
   };
 
   return (
-    <TouchableOpacity style={getButtonStyle()} onPress={onPress} disabled={disabled || loading} activeOpacity={activeOpacity} {...restProps}>
+    <Pressable style={getButtonStyle()} onPress={onPress} disabled={disabled || loading} activeOpacity={activeOpacity} {...restProps}>
       <PlatformBlurView intensity={25} tint="dark" style={blurStyle}>
         {renderContent()}
       </PlatformBlurView>
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 

--- a/mobile/components/ChooseLayer.tsx
+++ b/mobile/components/ChooseLayer.tsx
@@ -1,6 +1,7 @@
 import { Image } from 'expo-image';
 import React from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import Pressable from './Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { getNetworkGradient } from '@shared/constants/Colors';
@@ -31,7 +32,7 @@ const ChooseLayer: React.FC<ChooseLayerProps> = ({ selectedLayer, onSelectLayer,
           const ticker = getTickerByNetwork(layer);
 
           return (
-            <TouchableOpacity key={layer} style={[styles.layerCard, isSelected && styles.selectedLayerCard]} onPress={() => onSelectLayer(layer)} activeOpacity={0.8}>
+            <Pressable key={layer} style={[styles.layerCard, isSelected && styles.selectedLayerCard]} onPress={() => onSelectLayer(layer)} activeOpacity={0.8}>
               <View style={[styles.layerIconContainer, { backgroundColor: gradientColors[0] }]}>
                 {networkImage ? <Image source={networkImage} style={styles.layerIcon} contentFit="contain" /> : null}
               </View>
@@ -42,7 +43,7 @@ const ChooseLayer: React.FC<ChooseLayerProps> = ({ selectedLayer, onSelectLayer,
                   <ThemedText style={styles.checkmark}>✓</ThemedText>
                 </View>
               )}
-            </TouchableOpacity>
+            </Pressable>
           );
         })}
       </View>

--- a/mobile/components/DashboardTiles.tsx
+++ b/mobile/components/DashboardTiles.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo, useState, useCallback, useRef, useEffect, useContext } from 'react';
-import { View, StyleSheet, Dimensions, Text, Image, TouchableOpacity, FlatList, Animated } from 'react-native';
+import { View, StyleSheet, Dimensions, Text, Image, FlatList, Animated } from 'react-native';
 import { Image as ExpoImage } from 'expo-image';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
+import Pressable from './Pressable';
 import { getAvailableNetworks, NETWORK_BITCOIN, NETWORK_USDT, Networks } from '@shared/types/networks';
 import { getNetworkGradient, gradients as sharedGradients } from '@shared/constants/Colors';
 import { getIsTestnet, getTickerByNetwork, getDecimalsByNetwork } from '@shared/models/network-getters';
@@ -142,14 +143,12 @@ const LayerCardTile = ({ card, index, onCardPress, transitionId: _transitionId, 
     <View style={styles.itemContainer}>
       <Animated.View style={[styles.card, { transform: [{ scale: scaleAnim }] }]}>
         <LinearGradient colors={gradientColors as [string, string]} start={{ x: 0.5, y: 0 }} end={{ x: 0.5, y: 1 }} style={styles.gradientBackground} />
-        <TouchableOpacity
+        <Pressable
           onPress={handlePress}
           onPressIn={handlePressIn}
           onPressOut={handlePressOut}
           style={styles.touchableCard}
           activeOpacity={1}
-          delayPressIn={50}
-          delayPressOut={50}
           testID={displayCard.networkId ? `network-${displayCard.networkId}` : `card-${displayCard.name.toLowerCase()}`}
         >
           <View style={styles.topRow}>
@@ -191,7 +190,7 @@ const LayerCardTile = ({ card, index, onCardPress, transitionId: _transitionId, 
               <Text style={styles.cardUsdValue}>{displayCard.usdValue || ''}</Text>
             </View>
           </View>
-        </TouchableOpacity>
+        </Pressable>
       </Animated.View>
     </View>
   );

--- a/mobile/components/LongPressButton.tsx
+++ b/mobile/components/LongPressButton.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { StyleSheet, TouchableOpacity, View, Animated, Text, Easing, ActivityIndicator, ViewStyle, TextStyle } from 'react-native';
+import { StyleSheet, View, Animated, Text, Easing, ActivityIndicator, ViewStyle, TextStyle } from 'react-native';
+import Pressable from './Pressable';
 
 interface LongPressButtonProps {
   onLongPressComplete: () => void;
@@ -76,7 +77,7 @@ const LongPressButton: React.FC<LongPressButtonProps> = ({
   });
 
   return (
-    <TouchableOpacity
+    <Pressable
       activeOpacity={0.8}
       style={[styles.button, { backgroundColor }, disabled ? styles.disabled : null, style]}
       onPressIn={disabled || isLoading ? undefined : startProgress}
@@ -86,7 +87,7 @@ const LongPressButton: React.FC<LongPressButtonProps> = ({
       <View style={styles.contentContainer}>{isLoading ? <ActivityIndicator color="white" /> : <Text style={[styles.buttonText, textStyle]}>{title}</Text>}</View>
 
       {pressing && <Animated.View style={[styles.progressBar, { width: progressWidth, backgroundColor: progressColor }]} />}
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/mobile/components/NftsView.tsx
+++ b/mobile/components/NftsView.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useEffect, useImperativeHandle, useMemo, useState, forwardRef } from 'react';
-import { StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { useRouter } from 'expo-router';
+import Pressable from './Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import NftImage from '@/components/NftImage';
@@ -24,7 +25,7 @@ const NftPreviewItem: React.FC<{
   const iconColor = getTokenIconColor(nft?.name);
 
   return (
-    <TouchableOpacity
+    <Pressable
       style={[styles.nftPreviewItem, style, selected && styles.selectedNftPreviewItem]}
       onPress={() => onPress(nft)}
       activeOpacity={0.8}
@@ -38,7 +39,7 @@ const NftPreviewItem: React.FC<{
           <ThemedText style={styles.nftPreviewFallbackText}>{nft?.name?.charAt(0) || '?'}</ThemedText>
         )}
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
@@ -97,16 +98,9 @@ const NftsView = forwardRef<{ refresh: () => void }, { selectedNft?: string; onV
       {error ? <ThemedText style={styles.errorText}>Error: {error.message}</ThemedText> : null}
 
       {hasMoreThanPreview && (
-        <TouchableOpacity
-          style={styles.viewGalleryButton}
-          onPress={handleViewGalleryPress}
-          activeOpacity={0.85}
-          testID="view-gallery-button"
-          accessibilityRole="button"
-          accessibilityLabel="View NFT Gallery"
-        >
+        <Pressable style={styles.viewGalleryButton} onPress={handleViewGalleryPress} activeOpacity={0.85} testID="view-gallery-button" accessibilityRole="button" accessibilityLabel="View NFT Gallery">
           <ThemedText style={styles.viewGalleryButtonText}>View Gallery</ThemedText>
-        </TouchableOpacity>
+        </Pressable>
       )}
     </View>
   );

--- a/mobile/components/Pressable.tsx
+++ b/mobile/components/Pressable.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Platform, Pressable as RNPressable, PressableProps as RNPressableProps, StyleProp, View, ViewStyle } from 'react-native';
+
+export type PressableProps = RNPressableProps & {
+  style?: StyleProp<ViewStyle>;
+  activeOpacity?: number;
+  androidRippleColor?: string;
+  noFeedback?: boolean; // disables ripple/opacity feedback when true
+};
+
+const Pressable = React.forwardRef<View, PressableProps>(({ style, children, disabled, activeOpacity = 0.6, androidRippleColor, android_ripple, noFeedback = false, ...rest }, ref) => {
+  const ripple = noFeedback ? undefined : (android_ripple ?? (Platform.OS === 'android' ? { color: androidRippleColor ?? 'rgba(255, 255, 255, 0.08)', foreground: true } : undefined));
+
+  return (
+    <RNPressable
+      ref={ref}
+      android_ripple={ripple}
+      disabled={disabled}
+      style={(state) => {
+        const resolvedStyle = typeof style === 'function' ? style(state) : style;
+        const pressedStyle = !noFeedback && state.pressed && !disabled ? { opacity: activeOpacity } : null;
+        return [resolvedStyle, pressedStyle];
+      }}
+      {...rest}
+    >
+      {children}
+    </RNPressable>
+  );
+});
+
+Pressable.displayName = 'Pressable';
+
+export default Pressable;

--- a/mobile/components/ScanQrComponent.tsx
+++ b/mobile/components/ScanQrComponent.tsx
@@ -1,10 +1,11 @@
 import { BarcodeScanningResult, CameraType, CameraView } from 'expo-camera';
 import React, { useContext, useEffect, useRef, useCallback, useState, memo } from 'react';
-import { ActivityIndicator, AppState, AppStateStatus, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, AppState, AppStateStatus, StyleSheet, View } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
+import Pressable from './Pressable';
 
 import GradientFormSheet from '@/components/GradientFormSheet';
 import PlatformBlurView from '@/components/PlatformBlurView';
@@ -66,11 +67,11 @@ const StableCameraView = memo<{
       <View style={styles.container}>
         <CameraView style={styles.camera} facing={facing} onBarcodeScanned={onBarcodeScanned} barcodeScannerSettings={{ barcodeTypes: ['qr'] }} autofocus={'on'} />
         {/* Close button in top right corner - positioned absolutely outside CameraView */}
-        <TouchableOpacity style={[styles.closeButton, { top: topInset }]} onPress={onCancel} testID="CloseCameraButton">
+        <Pressable style={[styles.closeButton, { top: topInset }]} onPress={onCancel} testID="CloseCameraButton">
           <PlatformBlurView intensity={80} tint="dark" style={styles.closeButtonBlur}>
             <Ionicons name="close" size={24} color="white" />
           </PlatformBlurView>
-        </TouchableOpacity>
+        </Pressable>
       </View>
     </GestureDetector>
   );

--- a/mobile/components/StickyHeader.tsx
+++ b/mobile/components/StickyHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { StyleSheet, View, TouchableOpacity } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedText } from './ThemedText';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -9,6 +9,7 @@ import { handleQrIntent } from '@/src/modules/scan-routing';
 import { Ionicons, Foundation } from '@expo/vector-icons';
 import PlatformBlurView from './PlatformBlurView';
 import Animated, { useAnimatedStyle, interpolate, SharedValue } from 'react-native-reanimated';
+import Pressable from './Pressable';
 
 interface StickyHeaderProps {
   scrollY: SharedValue<number>;
@@ -66,7 +67,7 @@ const StickyHeader: React.FC<StickyHeaderProps> = ({ scrollY, onSettingsPress })
       {/* Header Content */}
       <View style={styles.header}>
         {/* Left Side: Pocket */}
-        <TouchableOpacity style={styles.pocket} onPress={handlePocketPress}>
+        <Pressable style={styles.pocket} onPress={handlePocketPress}>
           <View style={styles.pocketIconContainer}>
             <IconComponent name={accountItem.icon as any} size={22} color="white" />
           </View>
@@ -74,16 +75,16 @@ const StickyHeader: React.FC<StickyHeaderProps> = ({ scrollY, onSettingsPress })
             {accountItem.name.length > 10 ? accountItem.name.substring(0, 10) + '...' : accountItem.name}
           </ThemedText>
           <Ionicons name="chevron-down" size={16} color="rgba(255, 255, 255, 0.8)" />
-        </TouchableOpacity>
+        </Pressable>
 
         {/* Right Side: Camera and Settings Icons */}
         <View style={styles.headerRight}>
-          <TouchableOpacity style={styles.iconButton} onPress={handleCameraPress} testID="CameraButton">
+          <Pressable style={styles.iconButton} onPress={handleCameraPress} testID="CameraButton">
             <Ionicons name="scan-outline" size={24} color="rgba(255, 255, 255, 0.8)" />
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.iconButton} onPress={onSettingsPress} testID="SettingsButton">
+          </Pressable>
+          <Pressable style={styles.iconButton} onPress={onSettingsPress} testID="SettingsButton">
             <Ionicons name="settings-outline" size={24} color="rgba(255, 255, 255, 0.8)" />
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </View>
     </View>

--- a/mobile/components/SwapList.tsx
+++ b/mobile/components/SwapList.tsx
@@ -1,7 +1,8 @@
 import { MaterialIcons } from '@expo/vector-icons';
 import React, { useContext, useImperativeHandle, forwardRef } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
+import Pressable from './Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-utils';
@@ -46,7 +47,7 @@ const SwapItem = ({ swap }: { swap: CommonSwap }) => {
   };
 
   return (
-    <TouchableOpacity style={styles.swapItem} onPress={handleSwapPress}>
+    <Pressable style={styles.swapItem} onPress={handleSwapPress}>
       <View style={styles.swapIcon}>
         <MaterialIcons name={getSwapIcon()} size={24} color="rgba(255, 255, 255, 0.8)" />
       </View>
@@ -64,15 +65,15 @@ const SwapItem = ({ swap }: { swap: CommonSwap }) => {
       <View style={styles.swapAmounts}>
         {swap.network === NETWORK_SPARK && swap.status === 'claimable' ? (
           <View style={styles.actionButtons}>
-            <TouchableOpacity style={styles.actionButton} onPress={handleClaim}>
+            <Pressable style={styles.actionButton} onPress={handleClaim}>
               <ThemedText style={styles.actionButtonText}>Claim</ThemedText>
-            </TouchableOpacity>
+            </Pressable>
           </View>
         ) : (
           <ThemedText style={styles.statusText}>{capitalizeFirstLetter(swap.status)}</ThemedText>
         )}
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/mobile/components/TokensView.tsx
+++ b/mobile/components/TokensView.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useImperativeHandle, useState, forwardRef } from 'react';
-import { Image, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
+import Pressable from './Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { LayerzStorage } from '@/src/class/layerz-storage';
@@ -44,7 +45,7 @@ const TokenRow: React.FC<{ token: CachedTokenInfo; onPress: (token: CachedTokenI
   };
 
   return (
-    <TouchableOpacity style={[styles.tokenRow, selected && styles.selectedTokenRow]} onPress={handleTokenPress} activeOpacity={0.7} testID={`token-row-${token.id}`}>
+    <Pressable style={[styles.tokenRow, selected && styles.selectedTokenRow]} onPress={handleTokenPress} activeOpacity={0.7} testID={`token-row-${token.id}`}>
       {/* Token Icon */}
       <View style={[styles.tokenIcon, { backgroundColor: iconColor }]}>
         {token.logoURI ? (
@@ -64,7 +65,7 @@ const TokenRow: React.FC<{ token: CachedTokenInfo; onPress: (token: CachedTokenI
         </ThemedText>
         <ThemedText style={styles.tokenPrice}>{balance && tokenExchangeRate && tokenExchangeRate > 0 ? '$' + formatFiatBalance(balance, token.decimals, tokenExchangeRate) : null}</ThemedText>
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/mobile/components/Transaction.tsx
+++ b/mobile/components/Transaction.tsx
@@ -1,7 +1,8 @@
 import { MaterialIcons } from '@expo/vector-icons';
 import React, { useMemo, useState, useEffect } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Image } from 'expo-image';
+import Pressable from './Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
@@ -171,7 +172,7 @@ export default function Transaction({ transaction, onPress }: TransactionProps) 
   }, [transaction.tokenTransfers, transaction.direction]);
 
   return (
-    <TouchableOpacity style={styles.transactionItem} onPress={onPress}>
+    <Pressable style={styles.transactionItem} onPress={onPress}>
       <View style={styles.transactionIcon}>{transactionIcon}</View>
 
       <View style={styles.transactionDetails}>
@@ -184,7 +185,7 @@ export default function Transaction({ transaction, onPress }: TransactionProps) 
         <ThemedText style={styles.transactionAmount}>{formattedTransactionAmount}</ThemedText>
         {formattedTransactionUsdAmount && <ThemedText style={styles.transactionUsd}>{formattedTransactionUsdAmount}</ThemedText>}
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 

--- a/mobile/components/action/EthRequestAccounts.tsx
+++ b/mobile/components/action/EthRequestAccounts.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
 import React, { useContext, useEffect, useState } from 'react';
-import { Alert, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, StyleSheet, View } from 'react-native';
+import Pressable from '../Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { BrowserBridge } from '@/src/class/browser-bridge';
@@ -78,12 +79,12 @@ export function EthRequestAccounts(args: EthRequestAccountsArgs) {
       </View>
 
       <View style={styles.buttonContainer}>
-        <TouchableOpacity style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
+        <Pressable style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.secondaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Deny'}</ThemedText>
-        </TouchableOpacity>
-        <TouchableOpacity style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
+        </Pressable>
+        <Pressable style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.primaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Allow'}</ThemedText>
-        </TouchableOpacity>
+        </Pressable>
       </View>
     </View>
   );

--- a/mobile/components/action/EthSignTypedData.tsx
+++ b/mobile/components/action/EthSignTypedData.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
 import React, { useContext, useState } from 'react';
-import { Alert, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, ScrollView, StyleSheet, View } from 'react-native';
+import Pressable from '../Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { BrowserBridge } from '@/src/class/browser-bridge';
@@ -89,12 +90,12 @@ export function EthSignTypedData(args: EthSignTypedDataArgs) {
         </View>
 
         <View style={styles.buttonContainer}>
-          <TouchableOpacity style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
+          <Pressable style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
             <ThemedText style={[styles.buttonText, styles.secondaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Deny'}</ThemedText>
-          </TouchableOpacity>
-          <TouchableOpacity style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
+          </Pressable>
+          <Pressable style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
             <ThemedText style={[styles.buttonText, styles.primaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Allow'}</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </ScrollView>
     </View>

--- a/mobile/components/action/PersonalSign.tsx
+++ b/mobile/components/action/PersonalSign.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from 'react';
-import { Alert, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
+import Pressable from '../Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
@@ -93,12 +94,12 @@ export function PersonalSign(args: PersonalSignArgs) {
       </View>
 
       <View style={styles.buttonContainer}>
-        <TouchableOpacity style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
+        <Pressable style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.secondaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Deny'}</ThemedText>
-        </TouchableOpacity>
-        <TouchableOpacity style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
+        </Pressable>
+        <Pressable style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.primaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Allow'}</ThemedText>
-        </TouchableOpacity>
+        </Pressable>
       </View>
     </View>
   );

--- a/mobile/components/action/SendTransaction.tsx
+++ b/mobile/components/action/SendTransaction.tsx
@@ -1,7 +1,8 @@
 import { useRouter } from 'expo-router';
 import React, { useContext, useState } from 'react';
-import { Alert, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, ScrollView, StyleSheet, View } from 'react-native';
 import Slider from '@react-native-community/slider';
+import Pressable from '../Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { BrowserBridge } from '@/src/class/browser-bridge';
@@ -203,7 +204,7 @@ export function SendTransaction(args: SendTransactionArgs) {
     if (bytes) {
       return (
         <View style={styles.buttonContainer}>
-          <TouchableOpacity
+          <Pressable
             style={[styles.button, styles.secondaryButton]}
             onPress={() => {
               setBytes('');
@@ -213,22 +214,22 @@ export function SendTransaction(args: SendTransactionArgs) {
             activeOpacity={0.8}
           >
             <ThemedText style={[styles.buttonText, styles.secondaryButtonText]}>Cancel</ThemedText>
-          </TouchableOpacity>
-          <TouchableOpacity style={[styles.button, styles.primaryButton]} onPress={broadcastTransaction} activeOpacity={0.8}>
+          </Pressable>
+          <Pressable style={[styles.button, styles.primaryButton]} onPress={broadcastTransaction} activeOpacity={0.8}>
             <ThemedText style={[styles.buttonText, styles.primaryButtonText]}>Confirm & Send</ThemedText>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       );
     }
 
     return (
       <View style={styles.buttonContainer}>
-        <TouchableOpacity style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
+        <Pressable style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.secondaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Deny'}</ThemedText>
-        </TouchableOpacity>
-        <TouchableOpacity style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
+        </Pressable>
+        <Pressable style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.primaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Allow'}</ThemedText>
-        </TouchableOpacity>
+        </Pressable>
       </View>
     );
   };

--- a/mobile/components/action/SwitchEthereumChain.tsx
+++ b/mobile/components/action/SwitchEthereumChain.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
-import { Alert, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, StyleSheet, View } from 'react-native';
+import Pressable from '../Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { BrowserBridge } from '@/src/class/browser-bridge';
@@ -69,12 +70,12 @@ export function SwitchEthereumChain(args: SwitchEthereumChainArgs) {
       </View>
 
       <View style={styles.buttonContainer}>
-        <TouchableOpacity style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
+        <Pressable style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.secondaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Deny'}</ThemedText>
-        </TouchableOpacity>
-        <TouchableOpacity style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
+        </Pressable>
+        <Pressable style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.primaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Allow'}</ThemedText>
-        </TouchableOpacity>
+        </Pressable>
       </View>
     </View>
   );

--- a/mobile/components/action/WalletRequestPermissions.tsx
+++ b/mobile/components/action/WalletRequestPermissions.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
-import { Alert, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Alert, StyleSheet, View } from 'react-native';
+import Pressable from '../Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { BrowserBridge } from '@/src/class/browser-bridge';
@@ -77,12 +78,12 @@ export function WalletRequestPermissions(args: WalletRequestPermissionsArgs) {
       </View>
 
       <View style={styles.buttonContainer}>
-        <TouchableOpacity style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
+        <Pressable style={[styles.button, styles.secondaryButton, isLoading && styles.disabledButton]} onPress={onDenyClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.secondaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Deny'}</ThemedText>
-        </TouchableOpacity>
-        <TouchableOpacity style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
+        </Pressable>
+        <Pressable style={[styles.button, styles.primaryButton, isLoading && styles.disabledButton]} onPress={onAllowClick} disabled={isLoading} activeOpacity={0.8}>
           <ThemedText style={[styles.buttonText, styles.primaryButtonText, isLoading && styles.disabledButtonText]}>{isLoading ? 'Processing...' : 'Allow'}</ThemedText>
-        </TouchableOpacity>
+        </Pressable>
       </View>
     </View>
   );

--- a/mobile/components/navigation/BackButton.tsx
+++ b/mobile/components/navigation/BackButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { TouchableOpacity, StyleSheet, ViewStyle } from 'react-native';
+import { StyleSheet, ViewStyle } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
+import Pressable from '../Pressable';
 
 interface BackButtonProps {
   onPress?: () => void;
@@ -11,9 +12,9 @@ interface BackButtonProps {
 const BackButton: React.FC<BackButtonProps> = ({ onPress, style }) => {
   const router = useRouter();
   return (
-    <TouchableOpacity style={[styles.backButton, style]} onPress={onPress ? onPress : () => router.back()} accessibilityLabel="Go back">
+    <Pressable style={[styles.backButton, style]} onPress={onPress ? onPress : () => router.back()} accessibilityLabel="Go back">
       <Ionicons name="chevron-back" size={24} color="#fff" />
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/mobile/components/navigation/ScreenSendHeader.tsx
+++ b/mobile/components/navigation/ScreenSendHeader.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { StyleSheet, View, ViewStyle, TouchableOpacity } from 'react-native';
+import { StyleSheet, View, ViewStyle } from 'react-native';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { ThemedText } from '../ThemedText';
 import { getNetworkImageAsset } from '@/utils/networkAssets';
+import Pressable from '../Pressable';
 
 interface ScreenSendHeaderProps {
   title: string;
@@ -32,9 +33,9 @@ const ScreenSendHeader: React.FC<ScreenSendHeaderProps> = ({ title, network, sho
       <View style={styles.headerContent}>
         {/* Back Button */}
         {showBackButton && (
-          <TouchableOpacity style={styles.backButton} onPress={handleBackPress} accessibilityLabel="Go back">
+          <Pressable style={styles.backButton} onPress={handleBackPress} accessibilityLabel="Go back">
             <Ionicons name="chevron-back" size={20} color="#fff" />
-          </TouchableOpacity>
+          </Pressable>
         )}
 
         {/* Network Icon + Title */}


### PR DESCRIPTION
Only on expo for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates tap interactions to a custom `Pressable` to work reliably on Expo, touching most screens and common components.
> 
> - Replaces `TouchableOpacity` with `Pressable` imports/usages across many files (e.g., `Home`, `DAppBrowser`, `Send*`, `Receive*`, `Nft*`, `Swap*`, `Settings`, onboarding, etc.)
> - Updates handlers/props accordingly (e.g., adds `GestureResponderEvent` types, preserves `activeOpacity`, `disabled`, `testID`)
> - Adjusts navigation calls in a few places (e.g., `router.push({...})`) and minor import cleanups
> - Changes `ActionPopupButton` child prop from `TouchableOpacityProps` to `PressableProps`
> 
> Scope/Risk: Broad UI touch targets refactor; verify button/overlay interactions, long-press behavior, and accessibility remain intact in key flows (send/receive, browser nav, onboarding).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7063731dc41e65c314cffe2a8168f20797179d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->