### PR TITLE
refactor: error logging

### DIFF
--- a/ext/src/modules/error-handler.ts
+++ b/ext/src/modules/error-handler.ts
@@ -1,0 +1,3 @@
+export const handleError = async function (_error: unknown, _context: string = 'unknown'): Promise<void> {};
+
+globalThis.handleError = handleError;

--- a/ext/src/pages/Background/index.js
+++ b/ext/src/pages/Background/index.js
@@ -1,4 +1,5 @@
 import '../../modules/breeze-adapter'; // needed to be imported before we can use BreezWallet
+import '../../modules/error-handler';
 import { handleMessage } from '../../modules/background-message-controller';
 
 console.log('LZ background script running...');

--- a/ext/src/pages/Popup/Popup.tsx
+++ b/ext/src/pages/Popup/Popup.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, HashRouter as Router, Routes, useNavigate } from 'reac
 import { SWRConfig } from 'swr';
 
 import '../../modules/breeze-adapter'; // needed to be imported before we can use BreezWallet
+import '../../modules/error-handler';
 import '../../modules/spark-adapter'; // needed to be imported before we can use SparkWallet
 
 import { AccountNumberContextProvider } from '@shared/hooks/AccountNumberContext';

--- a/ext/src/typings/globals.d.ts
+++ b/ext/src/typings/globals.d.ts
@@ -6,4 +6,5 @@ declare function alert(message: string): void;
 declare global {
   var breezAdapter: IBreezAdapter;
   var sparkAdapter: ISparkAdapter;
+  var handleError: ((error: unknown, context?: string) => void | Promise<void>) | undefined;
 }

--- a/ext/vitest.config.mts
+++ b/ext/vitest.config.mts
@@ -8,6 +8,7 @@ export default defineConfig({
       '../shared/tests/setup-vi.js',
       '../ext/src/modules/spark-adapter.ts',
       '../ext/src/modules/breeze-adapter.ts',
+      '../ext/src/modules/error-handler.ts',
     ],
     testTimeout: 120_000,
     dangerouslyIgnoreUnhandledErrors: true, // breez test throws unhandled errors

--- a/mobile/app/DAppBrowser.tsx
+++ b/mobile/app/DAppBrowser.tsx
@@ -18,6 +18,7 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { getNetworkImageAsset } from '@/utils/networkAssets';
 import { DAppBrowserTabs } from './DAppBrowserTabs';
 import { useWebViewPreviewManager } from './hooks/useWebViewPreviewManager';
+import { handleError } from '@/src/modules/error-handler';
 
 export const BROWSER_CONSTANTS = {
   ANIMATION: {
@@ -654,7 +655,7 @@ const DAppBrowser: React.FC = () => {
 
   const createNewTab = async () => {
     if (activeTabId) {
-      await captureTabScreenshot(activeTabId, 50).catch(() => {});
+      await captureTabScreenshot(activeTabId, 50).catch((error) => handleError(error, 'captureTabScreenshot'));
     }
 
     const newTab = createHomeTab(network);
@@ -707,7 +708,7 @@ const DAppBrowser: React.FC = () => {
 
     // Capture screenshot of current active tab before switching
     if (activeTabId) {
-      await captureTabScreenshot(activeTabId, 50).catch(() => {});
+      await captureTabScreenshot(activeTabId, 50).catch((error) => handleError(error, 'captureTabScreenshot'));
     }
 
     setActiveTabId(tabId);
@@ -728,7 +729,7 @@ const DAppBrowser: React.FC = () => {
 
     // Capture current tab screenshot
     if (activeTabId) {
-      captureTabScreenshot(activeTabId).catch(() => {});
+      captureTabScreenshot(activeTabId).catch((error) => handleError(error, 'captureTabScreenshot'));
     }
 
     // Ensure all tabs have screenshots (stagger to avoid overwhelming the system)
@@ -736,7 +737,7 @@ const DAppBrowser: React.FC = () => {
       if (!tab.screenshot) {
         setTimeout(
           () => {
-            ensureTabPreview(tab.id, false).catch(() => {});
+            ensureTabPreview(tab.id, false).catch((error) => handleError(error, 'ensureTabPreview'));
           },
           500 + index * 300
         ); // Start after 500ms, then 300ms delay between each tab

--- a/mobile/app/SendEvm.tsx
+++ b/mobile/app/SendEvm.tsx
@@ -22,6 +22,7 @@ import { formatBalance } from '@shared/modules/string-utils';
 import { NETWORK_BITCOIN } from '@shared/types/networks';
 import { StringNumber } from '@shared/types/string-number';
 import { TransactionSuccessProps } from './TransactionSuccessEvm';
+import { handleError } from '@/src/modules/error-handler';
 
 export type SendEvmParams = {
   toAddress?: string;
@@ -52,6 +53,7 @@ export default function SendScreen() {
         setAddress(addressResponse);
       })
       .catch((error) => {
+        handleError(error, 'SendEvm');
         setErrorMessage('Error fetching address: ' + error.message);
       });
   }, [accountNumber, network]);

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -34,14 +34,14 @@ LogBox.ignoreLogs(['Require cycle:', 'Open debugger to view warnings.']);
 
 const onJSError = (error: unknown) => handleError(error, 'JAVASCRIPT_ERROR');
 
-console.log('applogFilePath:', applogFilePath);
 const consoleLogOrig = console.log;
 if (!__DEV__) {
+  console.log('applogFilePath:', applogFilePath);
   const _log = (...args: unknown[]) => {
     appendLog(args, 'log');
     consoleLogOrig(...args);
   };
-  console.log = console.warn = console.error = _log;
+  console.log = console.warn = console.error = console.debug = _log;
 }
 
 export default function RootLayout() {

--- a/mobile/app/onboarding/tos.tsx
+++ b/mobile/app/onboarding/tos.tsx
@@ -12,6 +12,7 @@ import { useSequentialSpringAnimation } from '@/hooks/useCustomTransitions';
 import { Image } from 'expo-image';
 import { EStep, InitializationContext } from '@shared/hooks/InitializationContext';
 import Pressable from '../../components/Pressable';
+import { getErrorMessage } from '@/src/modules/error-handler';
 
 export default function TermsOfServiceScreen() {
   const router = useRouter();
@@ -44,7 +45,7 @@ export default function TermsOfServiceScreen() {
       router.replace('/Home?fromOnboarding=true');
     } catch (error) {
       console.error('Error accepting terms:', error);
-      Alert.alert('Error', 'Failed to accept terms. Please try again.');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to accept terms. Please try again.');
     } finally {
       setIsLoading(false);
     }
@@ -63,7 +64,7 @@ export default function TermsOfServiceScreen() {
       await Linking.openURL('https://layerzwallet.com/tos');
     } catch (error) {
       console.error('Failed to open Terms of Service URL:', error);
-      Alert.alert('Error', 'Failed to open Terms of Service. Please try again.');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to open Terms of Service. Please try again.');
     }
   };
 

--- a/mobile/components/ErrorBoundary.tsx
+++ b/mobile/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@
  * PORTED FROM  https://github.com/krakenfx/wallet
  * LICENSE: MIT
  */
+import { handleError } from '@/src/modules/error-handler';
 import React from 'react';
 
 interface ErrorBoundaryProps {
@@ -25,6 +26,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
   componentDidCatch(error: Error): void {
     console.log('ErrorBoundary encountered fatal error in render tree', error);
+    handleError(error, 'ErrorBoundary');
     this.props.onError?.(error);
     if (this.state.error && !this.props.fallback) {
       setTimeout(() => this.setState({ error: undefined }));

--- a/mobile/components/action/EthRequestAccounts.tsx
+++ b/mobile/components/action/EthRequestAccounts.tsx
@@ -8,6 +8,7 @@ import { BrowserBridge } from '@/src/class/browser-bridge';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
+import { getErrorMessage } from '@/src/modules/error-handler';
 
 interface EthRequestAccountsArgs {
   params: any[];
@@ -43,7 +44,7 @@ export function EthRequestAccounts(args: EthRequestAccountsArgs) {
       BrowserBridge.instance?.sendMessage({ for: 'webpage', id: args.id, response: [address] });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to grant access');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to grant access');
     } finally {
       setIsLoading(false);
     }
@@ -58,7 +59,7 @@ export function EthRequestAccounts(args: EthRequestAccountsArgs) {
       });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to reject request');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to reject request');
       router.back();
     }
   };

--- a/mobile/components/action/EthSignTypedData.tsx
+++ b/mobile/components/action/EthSignTypedData.tsx
@@ -9,6 +9,7 @@ import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import assert from 'assert';
 import { EvmWallet } from '@shared/class/evm-wallet';
+import { getErrorMessage } from '@/src/modules/error-handler';
 
 interface EthSignTypedDataArgs {
   params: any[];
@@ -37,7 +38,7 @@ export function EthSignTypedData(args: EthSignTypedDataArgs) {
       BrowserBridge.instance?.sendMessage({ for: 'webpage', id: args.id, response: bytes });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to sign typed data');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to sign typed data');
     } finally {
       setIsLoading(false);
     }
@@ -52,7 +53,7 @@ export function EthSignTypedData(args: EthSignTypedDataArgs) {
       });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to reject request');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to reject request');
       router.back();
     }
   };

--- a/mobile/components/action/PersonalSign.tsx
+++ b/mobile/components/action/PersonalSign.tsx
@@ -7,8 +7,8 @@ import { ThemedText } from '@/components/ThemedText';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { BrowserBridge } from '@/src/class/browser-bridge';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
-import assert from 'assert';
 import { EvmWallet } from '@shared/class/evm-wallet';
+import { getErrorMessage } from '@/src/modules/error-handler';
 
 interface PersonalSignArgs {
   params: any[];
@@ -36,7 +36,7 @@ export function PersonalSign(args: PersonalSignArgs) {
       BrowserBridge.instance?.sendMessage({ for: 'webpage', id: args.id, response: bytes });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to sign message');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to sign message');
     } finally {
       setIsLoading(false);
     }
@@ -51,7 +51,7 @@ export function PersonalSign(args: PersonalSignArgs) {
       });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to reject request');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to reject request');
       router.back();
     }
   };

--- a/mobile/components/action/SendTransaction.tsx
+++ b/mobile/components/action/SendTransaction.tsx
@@ -14,6 +14,7 @@ import { formatBalance, hexToDec } from '@shared/modules/string-utils';
 import { StringNumber } from '@shared/types/string-number';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import assert from 'assert';
+import { getErrorMessage } from '@/src/modules/error-handler';
 
 interface SendTransactionArgs {
   params: any[];
@@ -96,7 +97,7 @@ export function SendTransaction(args: SendTransactionArgs) {
       Alert.alert('Error', 'Cannot get transaction parameters');
       router.back();
     } catch (err: any) {
-      setError(err.message);
+      setError((await getErrorMessage(err)) || 'Failed to get transaction parameters');
     } finally {
       setIsLoading(false);
     }
@@ -111,7 +112,7 @@ export function SendTransaction(args: SendTransactionArgs) {
       });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to reject request');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to reject request');
       router.back();
     }
   };

--- a/mobile/components/action/SwitchEthereumChain.tsx
+++ b/mobile/components/action/SwitchEthereumChain.tsx
@@ -5,6 +5,7 @@ import Pressable from '../Pressable';
 
 import { ThemedText } from '@/components/ThemedText';
 import { BrowserBridge } from '@/src/class/browser-bridge';
+import { getErrorMessage } from '@/src/modules/error-handler';
 
 interface SwitchEthereumChainArgs {
   params: any[];
@@ -23,7 +24,7 @@ export function SwitchEthereumChain(args: SwitchEthereumChainArgs) {
       BrowserBridge.instance?.sendMessage({ for: 'webpage', id: args.id, response: null });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to switch network');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to switch network');
     } finally {
       setIsLoading(false);
     }
@@ -38,7 +39,7 @@ export function SwitchEthereumChain(args: SwitchEthereumChainArgs) {
       });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to reject request');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to reject request');
       router.back();
     }
   };

--- a/mobile/components/action/WalletRequestPermissions.tsx
+++ b/mobile/components/action/WalletRequestPermissions.tsx
@@ -7,6 +7,7 @@ import { ThemedText } from '@/components/ThemedText';
 import { BrowserBridge } from '@/src/class/browser-bridge';
 import { LayerzStorage } from '@/src/class/layerz-storage';
 import { DappPermissions, PermissionRequest } from '@shared/class/dapp-permissions';
+import { getErrorMessage } from '@/src/modules/error-handler';
 
 interface WalletRequestPermissionsArgs {
   params: any[];
@@ -31,7 +32,7 @@ export function WalletRequestPermissions(args: WalletRequestPermissionsArgs) {
       BrowserBridge.instance?.sendMessage({ for: 'webpage', id, response });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to grant permissions');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to grant permissions');
     } finally {
       setIsLoading(false);
     }
@@ -46,7 +47,7 @@ export function WalletRequestPermissions(args: WalletRequestPermissionsArgs) {
       });
       router.back();
     } catch (error: any) {
-      Alert.alert('Error', error.message || 'Failed to reject request');
+      Alert.alert('Error', (await getErrorMessage(error)) || 'Failed to reject request');
       router.back();
     }
   };

--- a/mobile/entry.js
+++ b/mobile/entry.js
@@ -6,6 +6,7 @@ import 'react-native-get-random-values';
 import Bugsnag from '@bugsnag/expo';
 import { getDeviceIdentifier } from './src/utils/device-id';
 import { isMaestroMode } from './src/hooks/AuthStateContext';
+import { handleError } from './src/modules/error-handler';
 
 let Buffer = require('buffer/').Buffer;
 global.Buffer = Buffer;
@@ -27,6 +28,7 @@ if (BUGSNAG_API_KEY && !isMaestroMode()) {
       console.debug('Bugsnag initialized successfully');
     })
     .catch((error) => {
+      handleError(error, 'entry.js');
       console.error('Failed to get device identifier, Bugsnag not initialized:', error);
     });
 } else {

--- a/mobile/src/modules/error-handler.ts
+++ b/mobile/src/modules/error-handler.ts
@@ -4,14 +4,12 @@
  */
 import { File, Paths } from 'expo-file-system';
 // @ts-ignore no types for this
-import { serializeError } from 'serialize-error';
+import * as serializeErrorModule from 'serialize-error';
 // @ts-ignore no types for this
 import type { ErrorObject } from 'serialize-error';
 
 const applogFile = new File(Paths.document, 'app.log');
 export const applogFilePath = applogFile.uri;
-
-export const recentErrors: { timestamp: Date; error: ErrorObject; context: string }[] = [];
 
 const logfileSizeCutoff = 100 * 1024 * 1024;
 
@@ -74,16 +72,26 @@ export function createErrorHandlerWithContext(context: string) {
   return (reason: unknown) => handleError(reason, context);
 }
 
-export const handleError = async function (error: unknown, context: string = 'unknown'): Promise<void> {
-  console.log('exception caught:', context, error);
-  recentErrors.push({
-    error: serializeError(error),
-    context,
-    timestamp: new Date(),
-  });
-
-  appendLog(JSON.stringify(serializeError(error)), context);
+const getSerializeError = () => {
+  const candidate = (serializeErrorModule as any)?.serializeError ?? (serializeErrorModule as any)?.default ?? serializeErrorModule;
+  return typeof candidate === 'function' ? candidate : undefined;
 };
+
+const safeSerializeError = (error: unknown): ErrorObject => {
+  const serializer = getSerializeError();
+  if (serializer) {
+    return serializer(error);
+  }
+  return { message: String(error) };
+};
+
+export const handleError = async function (error: unknown, context: string = 'unknown'): Promise<void> {
+  console.log('exception caught:', context, await getErrorMessage(error));
+
+  appendLog(JSON.stringify(safeSerializeError(error)), context);
+};
+
+globalThis.handleError = handleError;
 
 const cleanHTMLTags = (str: string) => {
   return str

--- a/mobile/src/types.d.ts
+++ b/mobile/src/types.d.ts
@@ -5,4 +5,6 @@ declare global {
   var breezAdapter: IBreezAdapter;
 
   var sparkAdapter: ISparkAdapter;
+
+  var handleError: ((error: unknown, context?: string) => void | Promise<void>) | undefined;
 }

--- a/mobile/vitest.config.mts
+++ b/mobile/vitest.config.mts
@@ -8,6 +8,7 @@ export default defineConfig({
       '../shared/tests/setup-vi.js',
       '../ext/src/modules/spark-adapter.ts',
       '../ext/src/modules/breeze-adapter.ts',
+      '../ext/src/modules/error-handler.ts',
     ],
     testTimeout: 120_000,
     dangerouslyIgnoreUnhandledErrors: true, // breez test throws unhandled errors

--- a/shared/blue_modules/BlueElectrum.ts
+++ b/shared/blue_modules/BlueElectrum.ts
@@ -225,6 +225,7 @@ export async function connectMain(): Promise<void> {
       }
     }
   } catch (e) {
+    globalThis.handleError?.(e, 'BlueElectrum.ts');
     mainConnected = false;
     console.log('bad connection:', JSON.stringify(usingPeer), e);
   }
@@ -621,6 +622,7 @@ export async function multiGetTransactionByTxid<T extends boolean>(txids: string
       try {
         ret[txid] = JSON.parse(jsonString.cache_value as string);
       } catch (error) {
+        globalThis.handleError?.(error, 'BlueElectrum.ts');
         console.log(error, 'cache failed to parse', jsonString.cache_value);
       }
     }
@@ -671,6 +673,7 @@ export async function multiGetTransactionByTxid<T extends boolean>(txids: string
               tx = txhexToElectrumTransaction(tx);
               results.push({ result: tx, param: txid });
             } catch (err) {
+              globalThis.handleError?.(err, 'BlueElectrum.ts');
               console.log(err);
             }
           }
@@ -687,6 +690,7 @@ export async function multiGetTransactionByTxid<T extends boolean>(txids: string
               }
               results.push({ result: tx, param: txid });
             } catch (err) {
+              globalThis.handleError?.(err, 'BlueElectrum.ts');
               console.log(err);
             }
           }
@@ -905,6 +909,7 @@ export const broadcast = async function (hex: string) {
     const res = await mainClient.blockchainTransaction_broadcast(hex);
     return res;
   } catch (error) {
+    globalThis.handleError?.(error, 'BlueElectrum.ts');
     return error;
   }
 };

--- a/shared/class/wallets/ark-wallet.ts
+++ b/shared/class/wallets/ark-wallet.ts
@@ -133,6 +133,7 @@ export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLigh
         console.log('Renewal transaction:', renewTxid);
       }
     } catch (error) {
+      globalThis.handleError?.(error, 'ark-wallet.ts');
       console.log('ARK Error renewing VTXOs:', error);
     }
 
@@ -155,6 +156,7 @@ export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLigh
           await arkadeLightning.claimVHTLC(swap);
           console.log(`${swap.id} claimed!`);
         } catch (error: any) {
+          globalThis.handleError?.(error, 'ark-wallet.ts');
           console.log(`could not claim ${swap.id}:`, error?.message ?? error);
         }
       })

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -205,6 +205,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet, 
             network: 'MAINNET',
           });
         } catch (error) {
+          globalThis.handleError?.(error, 'spark-wallet.ts');
           console.error('Failed to encode Spark counterparty address:', error);
           // Fallback: use identity public key as identifier if encoding fails
           counterparty = counterpartyIdentityPublicKey;

--- a/shared/class/wallets/stacks-wallet.ts
+++ b/shared/class/wallets/stacks-wallet.ts
@@ -165,6 +165,7 @@ export class StacksWallet implements InterfaceAccountBasedWallet, InterfaceCanHa
           await this._storage?.setItem(cacheKey, JSON.stringify(tokenMetadata));
         }
       } catch (error) {
+        globalThis.handleError?.(error, 'stacks-wallet.ts');
         console.error('Failed to fetch NFT metadata from Gamma:', error);
       }
 

--- a/shared/hooks/AccountNumberContext.tsx
+++ b/shared/hooks/AccountNumberContext.tsx
@@ -100,6 +100,7 @@ export const AccountNumberContextProvider: React.FC<AccountNumberContextProvider
             arg: [addressResponse],
           });
         } catch (error: any) {
+          globalThis.handleError?.(error, 'AccountNumberContext.tsx');
           console.error(error.message);
         }
       })();

--- a/shared/hooks/SettingsContext.tsx
+++ b/shared/hooks/SettingsContext.tsx
@@ -92,6 +92,7 @@ export const SettingsContextProvider: React.FC<SettingsContextProviderProps> = (
         }
         setIsSettingsLoaded(true);
       } catch (error) {
+        globalThis.handleError?.(error, 'SettingsContext.tsx');
         console.error('Error loading settings, using defaults:', error);
         setSettings(DEFAULT_SETTINGS);
         setIsSettingsLoaded(true);
@@ -107,6 +108,7 @@ export const SettingsContextProvider: React.FC<SettingsContextProviderProps> = (
     try {
       await props.storage.setItem(STORAGE_KEY_SETTINGS, JSON.stringify(newSettings));
     } catch (error) {
+      globalThis.handleError?.(error, 'SettingsContext.tsx');
       console.error('Error saving settings:', error);
     }
   };
@@ -117,6 +119,7 @@ export const SettingsContextProvider: React.FC<SettingsContextProviderProps> = (
     try {
       await props.storage.setItem(STORAGE_KEY_SETTINGS, JSON.stringify(DEFAULT_SETTINGS));
     } catch (error) {
+      globalThis.handleError?.(error, 'SettingsContext.tsx');
       console.error('Error saving default settings:', error);
     }
   };

--- a/shared/hooks/useBalance.ts
+++ b/shared/hooks/useBalance.ts
@@ -41,7 +41,7 @@ function keyCleanupMiddleware(useSWRNext: any) {
       delete newKey.backgroundCaller;
     }
 
-    console.log(`useBalance(${JSON.stringify(newKey)})`); // logging
+    // console.log(`useBalance(${JSON.stringify(newKey)})`); // logging
 
     return useSWRNext(newKey, () => fetcher(key), config);
   };

--- a/shared/hooks/useExchangeRate.ts
+++ b/shared/hooks/useExchangeRate.ts
@@ -14,7 +14,7 @@ interface exchangeRateFetcherArg {
 
 function middleware(useSWRNext: any) {
   return (key: any, fetcher: any, config: any) => {
-    console.log(`useExchangeRate(${JSON.stringify(key)})`); // logging
+    // console.log(`useExchangeRate(${JSON.stringify(key)})`); // logging
 
     return useSWRNext(key, () => fetcher(key), config);
   };

--- a/shared/hooks/useSwaps.ts
+++ b/shared/hooks/useSwaps.ts
@@ -48,6 +48,7 @@ export const swapFetcher = async (arg: swapFetcherArg): Promise<CommonSwap[]> =>
     // For now, only Spark wallet is supported
     return [];
   } catch (error) {
+    globalThis.handleError?.(error, 'useSwaps.ts');
     console.error('swap fetch error', error);
     throw error;
   }

--- a/shared/hooks/useTokenBalance.ts
+++ b/shared/hooks/useTokenBalance.ts
@@ -8,7 +8,6 @@ import { IBackgroundCaller } from '../types/IBackgroundCaller';
 import { getIsEVM, getRpcProvider } from '../models/network-getters';
 import { BreezWallet } from '../class/wallets/breez-wallet';
 import { walletCanHaveTokens } from '../class/wallets/interface-can-have-tokens';
-import { SparkWallet } from '@shared/class/wallets/spark-wallet';
 import { AbstractWallet } from '@shared/class/wallets/abstract-wallet';
 
 interface tokenBalanceFetcherArg {
@@ -31,7 +30,7 @@ function keyCleanupMiddleware(useSWRNext: any) {
       delete newKey.backgroundCaller;
     }
 
-    console.log(`tokenBalance(${JSON.stringify(newKey)})`); // logging
+    // console.log(`tokenBalance(${JSON.stringify(newKey)})`); // logging
 
     return useSWRNext(newKey, () => fetcher(key), config);
   };
@@ -108,6 +107,7 @@ export const tokenBalanceFetcher = async (arg: tokenBalanceFetcherArg): Promise<
 
     return String(balance);
   } catch (error: any) {
+    globalThis.handleError?.(error, 'useTokenBalance.ts');
     console.log('tokenBalanceFetcher error = ', error.message);
     return undefined;
   }

--- a/shared/hooks/useTokenExchangeRate.ts
+++ b/shared/hooks/useTokenExchangeRate.ts
@@ -15,14 +15,14 @@ interface tokenExchangeRateFetcherArg {
 
 function middleware(useSWRNext: any) {
   return (key: any, fetcher: any, config: any) => {
-    console.log(`useTokenExchangeRate(${JSON.stringify(key)})`); // logging
+    // console.log(`useTokenExchangeRate(${JSON.stringify(key)})`); // logging
 
     return useSWRNext(key, () => fetcher(key), config);
   };
 }
 
 export const tokenExchangeRateFetcher = async (arg: tokenExchangeRateFetcherArg): Promise<number> => {
-  const { network, tokenId, fiat } = arg;
+  const { network, tokenId } = arg;
 
   if (getIsTestnet(network)) {
     return 0;
@@ -67,6 +67,7 @@ export const tokenExchangeRateFetcher = async (arg: tokenExchangeRateFetcherArg)
 
       return 0;
     } catch (error) {
+      globalThis.handleError?.(error, 'useTokenExchangeRate.ts');
       console.error('Error fetching STX exchange rate:', error);
       return 0;
     }

--- a/shared/hooks/useTransactions.ts
+++ b/shared/hooks/useTransactions.ts
@@ -124,6 +124,7 @@ export const txFetcher = async (arg: txFetcherArg): Promise<CommonTransaction[]>
 
     return [];
   } catch (error) {
+    globalThis.handleError?.(error, 'useTransactions.ts');
     console.error('tx fetch error', error);
     throw error;
   }

--- a/shared/modules/rpc-controller.ts
+++ b/shared/modules/rpc-controller.ts
@@ -166,6 +166,7 @@ export async function processRPC(LayerzStorage: IStorage, BackgroundCaller: IBac
         const response = await rpc.send(method, params);
         await sendResponse({ for: 'webpage', id, response });
       } catch (e: any) {
+        globalThis.handleError?.(e, 'rpc-controller.ts');
         console.warn('rpc error for', method, ':', e);
         await sendResponse({ for: 'webpage', id, error: e.error });
       }

--- a/shared/modules/wallet-utils.ts
+++ b/shared/modules/wallet-utils.ts
@@ -79,6 +79,7 @@ export async function saveWalletState(storage: IStorage, wallet: WatchOnlyWallet
     const storageKey = getSerializedStorageKey(network, accountNumber);
     await storage.setItem(storageKey, serialized);
   } catch (error) {
+    globalThis.handleError?.(error, 'wallet-utils.ts');
     console.error('Error saving wallet state:', error);
   }
 }
@@ -212,6 +213,7 @@ export async function lazyInitWallet(network: TSupportedLazyInitWalletNetworks, 
         return wallet;
       }
     } catch (e) {
+      globalThis.handleError?.(e, 'wallet-utils.ts');
       console.error(`Failed to deserialize wallet for ${network} account ${accountNumber}:`, e);
     }
     // create brand new wallet instance
@@ -232,6 +234,7 @@ export async function lazyInitWallet(network: TSupportedLazyInitWalletNetworks, 
     await saveWalletState(storage, wallet, network, accountNumber);
     return wallet;
   } catch (e) {
+    globalThis.handleError?.(e, 'wallet-utils.ts');
     console.error(`Failed to initialize wallet for ${network} account ${accountNumber}:`, e);
     throw e;
   } finally {
@@ -303,6 +306,7 @@ export function validateAddress(network: Networks, address: string): boolean {
         return false;
     }
   } catch (error) {
+    globalThis.handleError?.(error, 'wallet-utils.ts');
     // If any error occurs during validation, consider the address invalid
     return false;
   }


### PR DESCRIPTION
tbh i thought we have more try-catches.

anyway, thats the idea - we always handle errors (and regular logs) and stream is into a file. should make debugging easier when weird shit is happening in runtime

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves observability by routing previously swallowed or console-only errors through the centralized `handleError` and expanding production logging.
> 
> - DAppBrowser: report errors from `captureTabScreenshot` and `ensureTabPreview` to `handleError`; no behavior change to core browsing
> - SendEvm: on address fetch failure, call `handleError` before setting UI error
> - ErrorBoundary: invoke `handleError` in `componentDidCatch`
> - entry.js: on Bugsnag init failure, call `handleError`
> - _layout: in production, route `console.log/warn/error/debug` through `appendLog` for file-backed logs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48f086156aedbd459775aa99a8f13e893879976f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->