### PR TITLE
fix: citrea integration

### DIFF
--- a/ext/src/pages/Popup/Action.tsx
+++ b/ext/src/pages/Popup/Action.tsx
@@ -79,6 +79,7 @@ const Action: React.FC = () => {
         return <WalletRequestPermissions {...componentProps} />;
       case 'eth_sendTransaction':
         return <SendTransaction {...componentProps} />;
+      case 'eth_accounts':
       case 'eth_requestAccounts':
         return <EthRequestAccounts {...componentProps} />;
       default:

--- a/mobile/app/Action.tsx
+++ b/mobile/app/Action.tsx
@@ -82,6 +82,7 @@ const Action: React.FC = () => {
       case 'eth_sendTransaction':
         return <SendTransaction {...componentProps} />;
       case 'eth_requestAccounts':
+      case 'eth_accounts':
         return <EthRequestAccounts {...componentProps} />;
       default:
         return (

--- a/shared/hooks/useCachedExchangeRate.ts
+++ b/shared/hooks/useCachedExchangeRate.ts
@@ -1,5 +1,17 @@
 import { useSWRConfig } from 'swr';
-import { NETWORK_ARK, NETWORK_BITCOIN, NETWORK_BOTANIX, NETWORK_LIGHTNING, NETWORK_LIQUID, NETWORK_ROOTSTOCK, NETWORK_SPARK, NETWORK_STACKS, NETWORK_USDT, Networks } from '../types/networks';
+import {
+  NETWORK_ARK,
+  NETWORK_BITCOIN,
+  NETWORK_BOTANIX,
+  NETWORK_CITREA,
+  NETWORK_LIGHTNING,
+  NETWORK_LIQUID,
+  NETWORK_ROOTSTOCK,
+  NETWORK_SPARK,
+  NETWORK_STACKS,
+  NETWORK_USDT,
+  Networks,
+} from '../types/networks';
 import { TFiat } from './useExchangeRate';
 import { StringNumber } from '../types/string-number';
 
@@ -33,6 +45,7 @@ export function useCachedExchangeRate(network: Networks, fiat: TFiat): { exchang
     case NETWORK_ARK:
     case NETWORK_LIQUID:
     case NETWORK_BOTANIX:
+    case NETWORK_CITREA:
     case NETWORK_ROOTSTOCK:
     case NETWORK_STACKS:
       network2use = NETWORK_BITCOIN;

--- a/shared/models/partners-list.ts
+++ b/shared/models/partners-list.ts
@@ -1,4 +1,4 @@
-import { Networks, NETWORK_BITCOIN, NETWORK_CITREA_TESTNET, NETWORK_BOTANIX, NETWORK_ROOTSTOCK } from '../types/networks';
+import { Networks, NETWORK_BITCOIN, NETWORK_CITREA_TESTNET, NETWORK_BOTANIX, NETWORK_ROOTSTOCK, NETWORK_CITREA } from '../types/networks';
 import { PartnerInfo } from '../types/partner-info';
 
 const partnersList: PartnerInfo[] = [
@@ -71,6 +71,20 @@ const partnersList: PartnerInfo[] = [
     url: 'https://oku.trade/?inputChain=rootstock',
     imgUrl: '',
     description: '',
+  },
+  {
+    name: 'Bridge',
+    network: NETWORK_CITREA,
+    url: 'https://citrea.xyz/bridge',
+    imgUrl: '',
+    description: '',
+  },
+  {
+    name: 'Citrea Dashboard',
+    network: NETWORK_CITREA,
+    url: 'https://app.citrea.xyz',
+    imgUrl: '',
+    description: 'Your Citrea mainnet usage tiers, reflected in the progress bars.',
   },
 ];
 

--- a/shared/modules/rpc-controller.ts
+++ b/shared/modules/rpc-controller.ts
@@ -38,13 +38,17 @@ export async function processRPC(LayerzStorage: IStorage, BackgroundCaller: IBac
         // Dapp is already whitelisted, so we can return addresses without showing approval screen
         const addressResponse = await BackgroundCaller.getAddress(NETWORK_ROOTSTOCK, accountNumber); // most likely dapp is interested in EVM address specifically, NOT of currently-selected network
         responseForEthAccounts.push(addressResponse);
+        await sendResponse({
+          for: 'webpage',
+          id,
+          response: responseForEthAccounts,
+        });
+        return { success: true };
       }
-      await sendResponse({
-        for: 'webpage',
-        id,
-        response: responseForEthAccounts,
-      });
-      return { success: true };
+      // theoretically, we should not fall-through to opening popup here (where user can manually approve the request),
+      // but empirically, doing so provides better user experience, as it allows the dapp to proceed with the request immediately, instead of
+      // circling back to `eth_requestAccounts`
+      break;
 
     case 'eth_requestAccounts':
       if (whitelist.includes(from)) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves Citrea integration and EVM account request handling.
> 
> - UI: handle `eth_accounts` the same as `eth_requestAccounts` in `Action.tsx` (auto-approve for whitelisted dapps).
> - RPC: `eth_accounts` now mirrors `eth_requestAccounts`—auto-responds if whitelisted; otherwise falls through to approval flow.
> - Exchange rates: add `NETWORK_CITREA` and treat it like BTC in `useCachedExchangeRate` to reuse cached rates.
> - Partners: add Citrea mainnet entries (Bridge, Citrea Dashboard) to `partners-list`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84a8378d556c3f375e44efd097435ddbbd71090e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->