### PR TITLE
chore: bump spark 0.6.4, arkade 0.3.13, breez 0.11.13

### DIFF
--- a/ext/package-lock.json
+++ b/ext/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.4.2",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.16",
-        "@arkade-os/sdk": "0.3.10",
+        "@arkade-os/boltz-swap": "0.2.20",
+        "@arkade-os/sdk": "0.3.13",
         "@bitcoinerlab/secp256k1": "1.2.0",
-        "@breeztech/breez-sdk-liquid": "0.11.11",
-        "@buildonspark/spark-sdk": "0.6.0",
+        "@breeztech/breez-sdk-liquid": "0.11.13",
+        "@buildonspark/spark-sdk": "0.6.4",
         "@metamask/eth-sig-util": "8.2.0",
         "@noble/hashes": "1.7.1",
         "@noble/secp256k1": "1.6.3",
@@ -125,12 +125,12 @@
       "license": "MIT"
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.16.tgz",
-      "integrity": "sha512-42vIGlDCvJry1UOifi8jKxfcD3jBjf5Ldfwjs+bz5jfjUZGflCBS2cqZxujtB3vlbANTNUIwP9qI0maE2cFV2A==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.20.tgz",
+      "integrity": "sha512-1aQ9TKKEoW3CZXwlmM+CbjEpiyDshqYEY8HBeCijUl4drQW16dxDKtXMwn7pYJdWwdBEkhBFsF3MN/J0ctTCxg==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.10",
+        "@arkade-os/sdk": "0.3.13",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -154,12 +154,13 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.10.tgz",
-      "integrity": "sha512-3O/ftt5h9equtbMuzBmWEbw2M8AeDrokoLSMQDvoQF4Lz9y8A0azZyVZjLZJlvNhQFL2ZVH+Y8urSI8YoHpJWg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.13.tgz",
+      "integrity": "sha512-eC6XGifqVf2Xu+sf/3T2duUgLiXlgh/IQXHD+v09wsu8ik/CZedH4gvQpetTjRMKti3DdY/QVLC1OQTKKWgvqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@marcbachmann/cel-js": "7.3.1",
         "@noble/curves": "2.0.0",
         "@noble/secp256k1": "3.0.0",
         "@scure/base": "2.0.0",
@@ -210,7 +211,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -856,7 +856,6 @@
       "integrity": "sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
       },
@@ -1782,7 +1781,6 @@
       "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-module-imports": "^7.28.6",
@@ -2311,9 +2309,9 @@
       }
     },
     "node_modules/@breeztech/breez-sdk-liquid": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-liquid/-/breez-sdk-liquid-0.11.11.tgz",
-      "integrity": "sha512-3kN5zqCro51vqw3lqcBEPZI1h5YF4zsiDqAmXcW3/W/Iy1qSbXeyJTY/ENMp7bemdtHBvPvpHkKlr5/kFTZjbg==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-liquid/-/breez-sdk-liquid-0.11.13.tgz",
+      "integrity": "sha512-faxjEkmFX2RwLORxVzW5oiBYAHssGw7ym3qG4IWEeu3S6puraDPR4xoQCzPzM/S9vq9hHNAJsjvwKZD5qbaWnw==",
       "license": "MIT"
     },
     "node_modules/@bufbuild/protobuf": {
@@ -2323,13 +2321,13 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@buildonspark/spark-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.6.0.tgz",
-      "integrity": "sha512-D9Rtz8GCBpSRVLqodAWNq6j8L7sfuwEK21/cGdx/D3vf1VF6QS54W7gh8WtoGPzyLxvnOA/ot4QjGWjDtpTK2g==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.6.4.tgz",
+      "integrity": "sha512-mtubNVaVVIepev3Yt2/Qtmc2eybapyi20IsLKk4i7aaYY/Axb1UPiwVZ7yfRc4mcnod0sDvtvFSccJpTupA4Bg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",
-        "@lightsparkdev/core": "^1.4.4",
+        "@lightsparkdev/core": "^1.4.9",
         "@noble/curves": "^1.8.0",
         "@noble/hashes": "^1.7.0",
         "@opentelemetry/api": "^1.9.0",
@@ -4221,20 +4219,59 @@
       "license": "MIT"
     },
     "node_modules/@lightsparkdev/core": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@lightsparkdev/core/-/core-1.4.8.tgz",
-      "integrity": "sha512-ZnDJPQS6nrjqaDb++PAfI3KV/cWgaca76zTrQNPZOKF8Uhya8v6O0fIWmjlZR8GmBXx825PI4mwbcycZdfq3bA==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@lightsparkdev/core/-/core-1.4.9.tgz",
+      "integrity": "sha512-nAtAq+oEITHF9C3o410Ll8RpAwsIaWElBXJBCYMDKK3JeHBMccKg7/1TkEOgD/YPQ8fXOFv0nMjQnvWCzExwGA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/curves": "^1.9.7",
         "dayjs": "^1.11.7",
         "graphql": "^16.6.0",
         "graphql-ws": "^5.11.3",
-        "secp256k1": "^5.0.1",
         "ws": "^8.12.1",
         "zen-observable-ts": "^1.1.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@lightsparkdev/core/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@lightsparkdev/core/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@marcbachmann/cel-js": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@marcbachmann/cel-js/-/cel-js-7.3.1.tgz",
+      "integrity": "sha512-P6o26TvjStT8V8+8EF+yq9Pp7ZFV00bpiUMbssr76XbIZGxaB+NNWeBp6WNxOrR9gp0JPzvJueCKHpOs5LE9PQ==",
+      "license": "MIT",
+      "bin": {
+        "cel-evaluate": "bin/cel-evaluate.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@metamask/abi-utils": {
@@ -4457,7 +4494,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6428,7 +6464,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6642,7 +6677,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
       "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6681,7 +6715,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -6894,7 +6927,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -7674,7 +7706,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7763,7 +7794,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9473,7 +9503,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -12117,7 +12146,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12174,7 +12202,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -13300,7 +13327,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14018,7 +14044,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -15632,7 +15657,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -19138,7 +19162,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -19306,7 +19329,6 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19705,7 +19727,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19715,7 +19736,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -19736,7 +19756,6 @@
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20498,7 +20517,6 @@
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -20629,27 +20647,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/secp256k1": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.1.tgz",
-      "integrity": "sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "elliptic": "^6.5.7",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/secp256k1/node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
-      "license": "MIT"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -22213,7 +22210,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22611,8 +22607,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -22643,7 +22638,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -22713,7 +22707,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -22824,7 +22817,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23224,7 +23216,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -23341,7 +23332,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23531,7 +23521,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -23581,7 +23570,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -23692,7 +23680,6 @@
       "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -23817,7 +23804,6 @@
       "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -24135,7 +24121,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/ext/package.json
+++ b/ext/package.json
@@ -21,11 +21,11 @@
     "prepare": "cd .. && husky ext/.husky"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.16",
-    "@arkade-os/sdk": "0.3.10",
+    "@arkade-os/boltz-swap": "0.2.20",
+    "@arkade-os/sdk": "0.3.13",
     "@bitcoinerlab/secp256k1": "1.2.0",
-    "@breeztech/breez-sdk-liquid": "0.11.11",
-    "@buildonspark/spark-sdk": "0.6.0",
+    "@breeztech/breez-sdk-liquid": "0.11.13",
+    "@buildonspark/spark-sdk": "0.6.4",
     "@metamask/eth-sig-util": "8.2.0",
     "@noble/hashes": "1.7.1",
     "@noble/secp256k1": "1.6.3",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.4.2",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.16",
-        "@arkade-os/sdk": "0.3.10",
+        "@arkade-os/boltz-swap": "0.2.20",
+        "@arkade-os/sdk": "0.3.13",
         "@bitcoinerlab/secp256k1": "1.2.0",
-        "@breeztech/breez-sdk-liquid": "0.11.11",
-        "@breeztech/react-native-breez-sdk-liquid": "0.11.11",
+        "@breeztech/breez-sdk-liquid": "0.11.13",
+        "@breeztech/react-native-breez-sdk-liquid": "0.11.13",
         "@bugsnag/expo": "^54.0.0",
-        "@buildonspark/spark-sdk": "0.6.0",
+        "@buildonspark/spark-sdk": "0.6.4",
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.8",
         "@metamask/eth-sig-util": "8.2.0",
@@ -147,12 +147,12 @@
       "license": "MIT"
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.16.tgz",
-      "integrity": "sha512-42vIGlDCvJry1UOifi8jKxfcD3jBjf5Ldfwjs+bz5jfjUZGflCBS2cqZxujtB3vlbANTNUIwP9qI0maE2cFV2A==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.20.tgz",
+      "integrity": "sha512-1aQ9TKKEoW3CZXwlmM+CbjEpiyDshqYEY8HBeCijUl4drQW16dxDKtXMwn7pYJdWwdBEkhBFsF3MN/J0ctTCxg==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.10",
+        "@arkade-os/sdk": "0.3.13",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -176,12 +176,13 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.10.tgz",
-      "integrity": "sha512-3O/ftt5h9equtbMuzBmWEbw2M8AeDrokoLSMQDvoQF4Lz9y8A0azZyVZjLZJlvNhQFL2ZVH+Y8urSI8YoHpJWg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.13.tgz",
+      "integrity": "sha512-eC6XGifqVf2Xu+sf/3T2duUgLiXlgh/IQXHD+v09wsu8ik/CZedH4gvQpetTjRMKti3DdY/QVLC1OQTKKWgvqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@marcbachmann/cel-js": "7.3.1",
         "@noble/curves": "2.0.0",
         "@noble/secp256k1": "3.0.0",
         "@scure/base": "2.0.0",
@@ -256,7 +257,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1679,15 +1679,15 @@
       }
     },
     "node_modules/@breeztech/breez-sdk-liquid": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-liquid/-/breez-sdk-liquid-0.11.11.tgz",
-      "integrity": "sha512-3kN5zqCro51vqw3lqcBEPZI1h5YF4zsiDqAmXcW3/W/Iy1qSbXeyJTY/ENMp7bemdtHBvPvpHkKlr5/kFTZjbg==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-liquid/-/breez-sdk-liquid-0.11.13.tgz",
+      "integrity": "sha512-faxjEkmFX2RwLORxVzW5oiBYAHssGw7ym3qG4IWEeu3S6puraDPR4xoQCzPzM/S9vq9hHNAJsjvwKZD5qbaWnw==",
       "license": "MIT"
     },
     "node_modules/@breeztech/react-native-breez-sdk-liquid": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.11.11.tgz",
-      "integrity": "sha512-FVK8fYlesmwNRxGmaJXy335pDPDdwXpSw0R2QhPcWslAHLSDyeJcYpNHAcpbAotiORtnGlQdhxjjw6Ot61fBAg==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.11.13.tgz",
+      "integrity": "sha512-UU7nci4hbJLVFarOXu8iVRGl08suBuXCFh5FrEv/bhG0chuevwJna/04Y2A5JcLTqYB7fLw24ceU3WGqeqbYOA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -1705,7 +1705,6 @@
       "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-8.6.0.tgz",
       "integrity": "sha512-94Jo443JegaiKV8z8NXMFdyTGubiUnwppWhq3kG2ldlYKtEvrmIaO5+JA58B6oveySvoRu3cCe2W9ysY7G7mDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -1899,13 +1898,13 @@
       }
     },
     "node_modules/@buildonspark/spark-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.6.0.tgz",
-      "integrity": "sha512-D9Rtz8GCBpSRVLqodAWNq6j8L7sfuwEK21/cGdx/D3vf1VF6QS54W7gh8WtoGPzyLxvnOA/ot4QjGWjDtpTK2g==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.6.4.tgz",
+      "integrity": "sha512-mtubNVaVVIepev3Yt2/Qtmc2eybapyi20IsLKk4i7aaYY/Axb1UPiwVZ7yfRc4mcnod0sDvtvFSccJpTupA4Bg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",
-        "@lightsparkdev/core": "^1.4.4",
+        "@lightsparkdev/core": "^1.4.9",
         "@noble/curves": "^1.8.0",
         "@noble/hashes": "^1.7.0",
         "@opentelemetry/api": "^1.9.0",
@@ -4897,20 +4896,59 @@
       }
     },
     "node_modules/@lightsparkdev/core": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@lightsparkdev/core/-/core-1.4.8.tgz",
-      "integrity": "sha512-ZnDJPQS6nrjqaDb++PAfI3KV/cWgaca76zTrQNPZOKF8Uhya8v6O0fIWmjlZR8GmBXx825PI4mwbcycZdfq3bA==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@lightsparkdev/core/-/core-1.4.9.tgz",
+      "integrity": "sha512-nAtAq+oEITHF9C3o410Ll8RpAwsIaWElBXJBCYMDKK3JeHBMccKg7/1TkEOgD/YPQ8fXOFv0nMjQnvWCzExwGA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/curves": "^1.9.7",
         "dayjs": "^1.11.7",
         "graphql": "^16.6.0",
         "graphql-ws": "^5.11.3",
-        "secp256k1": "^5.0.1",
         "ws": "^8.12.1",
         "zen-observable-ts": "^1.1.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@lightsparkdev/core/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@lightsparkdev/core/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@marcbachmann/cel-js": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@marcbachmann/cel-js/-/cel-js-7.3.1.tgz",
+      "integrity": "sha512-P6o26TvjStT8V8+8EF+yq9Pp7ZFV00bpiUMbssr76XbIZGxaB+NNWeBp6WNxOrR9gp0JPzvJueCKHpOs5LE9PQ==",
+      "license": "MIT",
+      "bin": {
+        "cel-evaluate": "bin/cel-evaluate.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@metamask/abi-utils": {
@@ -5084,7 +5122,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5517,7 +5554,6 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
       "integrity": "sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react-native": ">=0.59"
       }
@@ -5801,7 +5837,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.27.tgz",
       "integrity": "sha512-kW7LGP/RrisktpGyizTKw6HwSeQJdXnAN9L8GyQJcJAlgL9YtfEg6yEyD5n9RWH90CL8G0cRyUhphKIAFf4lVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.13.7",
         "escape-string-regexp": "^4.0.0",
@@ -6863,7 +6898,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -7026,7 +7060,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -7130,7 +7163,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -8055,7 +8087,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9711,7 +9742,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11902,7 +11932,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11996,7 +12025,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -12116,7 +12144,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -12785,7 +12812,6 @@
       "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
       "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "expo": "*"
       }
@@ -12852,7 +12878,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -12867,7 +12892,6 @@
       "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.8.tgz",
       "integrity": "sha512-aF7A914TB66WIlTJvl5J6/itejfY78O7dq3ibvFltL9vnTALJ/7LYHvLT4fwmx9yUNS6ekLBtDGWivFWnj2Fcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0"
       },
@@ -12953,7 +12977,6 @@
       "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-8.0.10.tgz",
       "integrity": "sha512-jd5BxjaF7382JkDMaC+P04aXXknB2UhWaVx5WiQKA05ugm/8GH5uaz9P9ckWdMKZGQVVEOC8MHaUADoT26KmFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ua-parser-js": "^0.7.33"
       },
@@ -12992,7 +13015,6 @@
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
       "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
@@ -13003,7 +13025,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.10.tgz",
       "integrity": "sha512-UqyNaaLKRpj4pKAP4HZSLnuDQqueaO5tB1c/NWu5vh1/LF9ulItyyg2kF/IpeOp0DeOLk0GY0HrIXaKUMrwB+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -13071,7 +13092,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
       "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.12",
         "invariant": "^2.2.4"
@@ -13489,7 +13509,6 @@
       "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.8.tgz",
       "integrity": "sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "expo": "*"
       }
@@ -14512,7 +14531,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -15741,7 +15759,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -20384,7 +20401,6 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -20490,7 +20506,6 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "asap": "~2.0.6"
       }
@@ -20928,7 +20943,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20969,7 +20983,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -21006,7 +21019,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -21064,7 +21076,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -21080,7 +21091,6 @@
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
       "integrity": "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-base64-decode": "^1.0.0"
       },
@@ -21119,7 +21129,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.6.tgz",
       "integrity": "sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -21160,7 +21169,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -21171,7 +21179,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -21187,7 +21194,6 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
       "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -21225,7 +21231,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -21258,7 +21263,6 @@
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
       "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -21362,7 +21366,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22206,7 +22209,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22237,21 +22239,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/secp256k1": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.1.tgz",
-      "integrity": "sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "elliptic": "^6.5.7",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -23805,7 +23792,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24296,7 +24282,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24977,7 +24962,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -25094,7 +25078,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -25290,7 +25273,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -25340,7 +25322,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -25789,7 +25770,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -34,13 +34,13 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.16",
-    "@arkade-os/sdk": "0.3.10",
+    "@arkade-os/boltz-swap": "0.2.20",
+    "@arkade-os/sdk": "0.3.13",
     "@bitcoinerlab/secp256k1": "1.2.0",
-    "@breeztech/breez-sdk-liquid": "0.11.11",
-    "@breeztech/react-native-breez-sdk-liquid": "0.11.11",
+    "@breeztech/breez-sdk-liquid": "0.11.13",
+    "@breeztech/react-native-breez-sdk-liquid": "0.11.13",
     "@bugsnag/expo": "^54.0.0",
-    "@buildonspark/spark-sdk": "0.6.0",
+    "@buildonspark/spark-sdk": "0.6.4",
     "@expo/vector-icons": "^15.0.3",
     "@gorhom/bottom-sheet": "^5.2.8",
     "@metamask/eth-sig-util": "8.2.0",

--- a/shared/class/wallets/ark-wallet.ts
+++ b/shared/class/wallets/ark-wallet.ts
@@ -338,8 +338,9 @@ export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLigh
     if (!this._wallet) throw new Error('Ark wallet not initialized');
 
     const boardingUtxos = (await this._wallet.getBoardingUtxos()).filter((utxo) => utxo.txid === txid);
+    const { fees } = await this._wallet.arkProvider.getInfo();
 
-    await new Ramps(this._wallet).onboard(boardingUtxos);
+    await new Ramps(this._wallet).onboard(fees, boardingUtxos);
   }
 
   /**

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -127,7 +127,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet, 
   getTokenBalances(): CachedTokenInfo[] {
     if (!this._sdkWallet) throw new Error('Spark wallet not initialized');
     const ret: CachedTokenInfo[] = [];
-    for (const [tokenIdentifier, { balance, tokenMetadata }] of this.tokenBalances.entries()) {
+    for (const [tokenIdentifier, { ownedBalance, tokenMetadata }] of this.tokenBalances.entries()) {
       if (this.isNft(tokenMetadata)) continue;
       ret.push({
         name: tokenMetadata.tokenName,
@@ -135,7 +135,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet, 
         chainId: 0, // N/A
         decimals: tokenMetadata.decimals,
         id: tokenIdentifier,
-        balance: balance.toString(),
+        balance: ownedBalance.toString(),
       });
     }
     return ret;
@@ -376,10 +376,10 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet, 
     await this.fetchTokenBalances(); // NFTS are just tokens with a special identifier and supply of 1
 
     const ret: NftInfo[] = [];
-    for (const [tokenIdentifier, { tokenMetadata, balance }] of this.tokenBalances.entries()) {
+    for (const [tokenIdentifier, { tokenMetadata, ownedBalance }] of this.tokenBalances.entries()) {
       if (!this.isNft(tokenMetadata)) continue;
 
-      if (balance === BigInt(0)) continue; // we dont have it actually, skip it
+      if (ownedBalance === BigInt(0)) continue; // we dont have it actually, skip it
 
       let bnftMetadata: ReturnType<typeof this.parseBNFTMetadata>;
       try {


### PR DESCRIPTION
## Summary
  - **Breez SDK Liquid** 0.11.11 → 0.11.13: fixes incoming swaps incorrectly marked as failed
  - **Spark SDK** 0.6.0 → 0.6.4: token balance API changed (`balance` → `ownedBalance`), auth improvements for mobile backgrounding, multi-token transfer support
  - **Arkade SDK** 0.3.10 → 0.3.13: fee estimator system, `Ramps.onboard()` now requires `feeInfo` param, dust threshold fixes
  - **Arkade boltz-swap** 0.2.16 → 0.2.20: `cel-js` Expo compatibility fix, error logging improvements

### Code changes
  - `spark-wallet.ts`: updated token balance destructuring from `{ balance }` to `{ ownedBalance }`
  - `ark-wallet.ts`: fetch `feeInfo` from ark provider before calling `Ramps.onboard()`