### PR TITLE
chore: bump ver

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Layerz Wallet",
     "slug": "layerzwallet",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "orientation": "portrait",
     "scheme": ["bitcoin", "liquidnetwork", "layerzwallet"],
     "userInterfaceStyle": "dark",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "layerzwallet",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "layerzwallet",
   "main": "./entry.js",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Manage your Bitcoin across multiple Layer 2 solutions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
last test to make sure that e2e runs dont bleed data to analytics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-bump only, but `package-lock.json` now has inconsistent version fields (`packages[""]` still at 1.5.3), which could confuse tooling or release automation.
> 
> **Overview**
> Bumps the mobile app version from **1.5.3** to **1.5.4** in `mobile/app.json` and `mobile/package.json`, and updates the top-level version in `mobile/package-lock.json` to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50447f9b3809e05f9e9b74ec29ecb0505c1d1cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->