### PR TITLE
fix: onboarding scan qr seed was not working

### DIFF
--- a/mobile/components/ProtectedRouteStack.tsx
+++ b/mobile/components/ProtectedRouteStack.tsx
@@ -234,16 +234,6 @@ export function ProtectedRouteStack() {
           }}
         />
         <Stack.Screen
-          name="ScanQr"
-          options={{
-            presentation: 'fullScreenModal',
-            gestureEnabled: true,
-            fullScreenGestureEnabled: true,
-            animation: 'slide_from_bottom',
-            headerShown: false,
-          }}
-        />
-        <Stack.Screen
           name="TransactionDetails"
           options={{
             presentation: 'transparentModal',
@@ -289,6 +279,17 @@ export function ProtectedRouteStack() {
           }}
         />
       </Stack.Protected>
+
+      <Stack.Screen
+        name="ScanQr"
+        options={{
+          presentation: 'fullScreenModal',
+          gestureEnabled: true,
+          fullScreenGestureEnabled: true,
+          animation: 'slide_from_bottom',
+          headerShown: false,
+        }}
+      />
 
       <Stack.Screen name="+not-found" options={{ title: 'Not Found' }} />
     </Stack>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small navigation configuration change that only affects route availability/stack placement; risk is limited to unintended access to `ScanQr` or navigation regressions.
> 
> **Overview**
> Fixes onboarding QR scanning by moving the `ScanQr` screen definition out of the protected/app-only `Stack.Protected` block so it can be presented regardless of authentication/initialization guards, while keeping it as a full-screen modal with the same transition/gesture options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccc7b1dd6a8c35e130063a5b8424dee8d8216253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->