### PR TITLE
ci: build release apk as well

### DIFF
--- a/mobile/.eas/workflows/submit-android.yml
+++ b/mobile/.eas/workflows/submit-android.yml
@@ -10,6 +10,16 @@ jobs:
       platform: android
       profile: production
 
+  build_android_apk:
+    name: Build Android release APK
+    # Build the GitHub-release APK after the store build so both artifacts share the
+    # same remote Android version bump from the production profile's autoIncrement.
+    needs: [build_android]
+    type: build
+    params:
+      platform: android
+      profile: production-apk
+
   submit_android:
     name: Submit to Google Play Store
     needs: [build_android]

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -37,6 +37,13 @@
     "production": {
       "extends": "base",
       "autoIncrement": true
+    },
+    "production-apk": {
+      "extends": "production",
+      "autoIncrement": false,
+      "android": {
+        "buildType": "apk"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only changes to EAS build configuration; main risk is misconfiguration causing failed builds or mismatched artifacts.
> 
> **Overview**
> The Android EAS workflow now runs an additional build job (`build_android_apk`) after the Play Store build to produce a release APK artifact intended for GitHub releases.
> 
> Adds a new `production-apk` EAS build profile that inherits from `production` but disables `autoIncrement` and sets Android `buildType: apk`, so the APK build reuses the version bump from the preceding store build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2ff5f2c8b106fbfeb22ff8ea05559d1b45dd1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->