### PR TITLE
Feat lnurl support

### DIFF
--- a/mobile/app/SendLightning.tsx
+++ b/mobile/app/SendLightning.tsx
@@ -69,10 +69,12 @@ const SendLightning: React.FC = () => {
           invoice2use = merchantLightningAddress;
         }
 
-        if (Lnurl.isLightningAddress(invoice2use)) {
+        if (Lnurl.isLightningAddressOrLnurl(invoice2use)) {
           try {
             // need to fetch details, like minimum and maximum sat payment
-            invoice2use = encodeURIComponent(invoice2use.split('@')[0]) + '@' + invoice2use.split('@')[1]; // copensating for router automatically urldecoding the ln address in param
+            if (Lnurl.isLightningAddress(invoice2use)) {
+              invoice2use = encodeURIComponent(invoice2use.split('@')[0]) + '@' + invoice2use.split('@')[1]; // compensating for router automatically urldecoding the ln address in param
+            }
             const ln = new Lnurl(invoice2use);
             const response = await ln.callLnurlPayService();
             if (response) {
@@ -84,8 +86,8 @@ const SendLightning: React.FC = () => {
               return;
             }
           } catch (error: any) {
-            console.log('Lightning Address fetch error:', error.message);
-            setError('Lightning Address fetch error: ' + error.message);
+            console.log('LNURL fetch error:', error.message);
+            setError('LNURL fetch error: ' + error.message);
           }
           return;
         }
@@ -290,7 +292,7 @@ const SendLightning: React.FC = () => {
               <View style={styles.invoiceContainer}>
                 <TextInput
                   style={styles.invoiceInput}
-                  placeholder="Lightning invoice or Lightning address here"
+                  placeholder="Lightning invoice, LNURL, or Lightning address here"
                   placeholderTextColor="rgba(255, 255, 255, 0.6)"
                   onChangeText={onInvoiceInput}
                   value={invoice}
@@ -307,7 +309,7 @@ const SendLightning: React.FC = () => {
           {isPayingToLightningAddress && (
             <>
               <View style={styles.detailsContainer}>
-                <ThemedText style={styles.detailsTitle}>Paying to Lightning Address</ThemedText>
+                <ThemedText style={styles.detailsTitle}>Paying to Lightning Address or LNURL</ThemedText>
 
                 {lnurlPayServicePayload[invoice]?.min && lnurlPayServicePayload[invoice]?.max && (
                   <>

--- a/mobile/app/send/_layout.tsx
+++ b/mobile/app/send/_layout.tsx
@@ -262,6 +262,7 @@ export default function SendLayout() {
         <Stack.Screen name="send-confirm" />
         <Stack.Screen name="send-address-usdt" />
         <Stack.Screen name="send-amount-usdt" />
+        <Stack.Screen name="withdraw-lightning" />
       </Stack>
     </SendFlowProvider>
   );

--- a/mobile/app/send/send-address-lightning.tsx
+++ b/mobile/app/send/send-address-lightning.tsx
@@ -32,6 +32,7 @@ const SendAddressLightning: React.FC = () => {
   const [localInvoice, setLocalInvoice] = useState(address);
   const [validating, setValidating] = useState<{ [invoice: string]: boolean }>({});
   const [errorMessages, setErrorMessages] = useState<{ [invoice: string]: string }>({});
+  const [resolvedInvoice, setResolvedInvoice] = useState<{ [invoice: string]: string }>({});
   const [lnurlPayServicePayload, setLnurlPayServicePayload] = useState<{ [invoice: string]: LnurlPayServicePayload }>({});
   const [lnurlInstance, setLnurlInstance] = useState<{ [invoice: string]: Lnurl | undefined }>({});
   const [decodedInvoice, setDecodedInvoice] = useState<{ [invoice: string]: DecodedInvoice | undefined }>({});
@@ -56,21 +57,22 @@ const SendAddressLightning: React.FC = () => {
 
   const validateInvoice = useCallback(
     async (i: string) => {
-      let invoice = i.trim();
+      const input = i.trim();
+      let invoice = input;
 
       try {
-        setValidating((prev) => ({ ...prev, [invoice]: true }));
+        setValidating((prev) => ({ ...prev, [input]: true }));
         setErrorMessages((prev) => {
-          const { [invoice]: _, ...newErrors } = prev;
+          const { [input]: _, ...newErrors } = prev;
           return newErrors;
         });
 
         if (!invoice) {
-          setErrorMessages((prev) => ({ ...prev, [invoice]: 'Please enter a lightning invoice or address' }));
+          setErrorMessages((prev) => ({ ...prev, [input]: 'Please enter a lightning invoice, LNURL, or address' }));
           return;
         }
         if (!layer) {
-          setErrorMessages((prev) => ({ ...prev, [invoice]: 'Please select a Layer' }));
+          setErrorMessages((prev) => ({ ...prev, [input]: 'Please select a Layer' }));
           return;
         }
 
@@ -83,18 +85,19 @@ const SendAddressLightning: React.FC = () => {
         }
 
         // Handle Lightning Address (LNURL)
-        if (Lnurl.isLightningAddress(invoice)) {
+        if (Lnurl.isLightningAddressOrLnurl(invoice)) {
           try {
-            invoice = encodeURIComponent(invoice.split('@')[0]) + '@' + invoice.split('@')[1];
-            const ln = new Lnurl(invoice);
+            const invoiceToUse = Lnurl.isLightningAddress(invoice) ? encodeURIComponent(invoice.split('@')[0]) + '@' + invoice.split('@')[1] : invoice;
+            const ln = new Lnurl(invoiceToUse);
             const response = await ln.callLnurlPayService();
             if (response) {
-              setLnurlInstance((prev) => ({ ...prev, [invoice]: ln }));
-              setLnurlPayServicePayload((prev) => ({ ...prev, [invoice]: response }));
+              setResolvedInvoice((prev) => ({ ...prev, [input]: invoiceToUse }));
+              setLnurlInstance((prev) => ({ ...prev, [input]: ln }));
+              setLnurlPayServicePayload((prev) => ({ ...prev, [input]: response }));
               return;
             }
           } catch (error: any) {
-            setErrorMessages((prev) => ({ ...prev, [invoice]: 'Lightning Address fetch error: ' + error.message }));
+            setErrorMessages((prev) => ({ ...prev, [input]: 'LNURL fetch error: ' + error.message }));
             return;
           }
         }
@@ -112,20 +115,21 @@ const SendAddressLightning: React.FC = () => {
         // Decode BOLT11 invoice
         const decoded = bolt11.decode(invoice);
         if (!decoded.satoshis) {
-          setErrorMessages((prev) => ({ ...prev, [invoice]: 'Zero amount invoices are not supported' }));
+          setErrorMessages((prev) => ({ ...prev, [input]: 'Zero amount invoices are not supported' }));
           return;
         }
-        setDecodedInvoice((prev) => ({ ...prev, [invoice]: decoded }));
+        setResolvedInvoice((prev) => ({ ...prev, [input]: invoice }));
+        setDecodedInvoice((prev) => ({ ...prev, [input]: decoded }));
 
         // Extract memo
         const memoTag = decoded.tags.find((tag: any) => tag.tagName === 'description');
         if (memoTag) {
-          setMemo((prev) => ({ ...prev, [invoice]: String(memoTag.data) }));
+          setMemo((prev) => ({ ...prev, [input]: String(memoTag.data) }));
         }
       } catch (error: any) {
-        setErrorMessages((prev) => ({ ...prev, [invoice]: error.message || 'Invalid lightning invoice or address' }));
+        setErrorMessages((prev) => ({ ...prev, [input]: error.message || 'Invalid lightning invoice, LNURL, or address' }));
       } finally {
-        setValidating((prev) => ({ ...prev, [invoice]: false }));
+        setValidating((prev) => ({ ...prev, [input]: false }));
       }
     },
     [layer, network]
@@ -158,6 +162,7 @@ const SendAddressLightning: React.FC = () => {
         return;
       }
 
+      const invoiceToUse = resolvedInvoice[invoice] ?? invoice;
       const decoded = decodedInvoice[invoice];
       const lnurlPSPayload = lnurlPayServicePayload[invoice];
       const lnurlInst = lnurlInstance[invoice];
@@ -176,7 +181,7 @@ const SendAddressLightning: React.FC = () => {
       if (redirectToAmountScreen) {
         router.push('/send/send-amount-lightning');
       } else {
-        lightning.setInvoice(invoice);
+        lightning.setInvoice(invoiceToUse);
         router.push('/send/send-confirm-lightning');
       }
     } catch (error: any) {
@@ -207,7 +212,7 @@ const SendAddressLightning: React.FC = () => {
                 <TextInput
                   ref={inputRef}
                   style={styles.input}
-                  placeholder="Enter lightning invoice or address"
+                  placeholder="Enter lightning invoice, LNURL, or address"
                   placeholderTextColor="rgba(255, 255, 255, 0.8)"
                   autoCapitalize="none"
                   autoCorrect={false}
@@ -233,7 +238,7 @@ const SendAddressLightning: React.FC = () => {
           {isLightningAddress && lnurlPayServicePayload[invoice] && (
             <View style={styles.lightningAddressInfo}>
               <Ionicons name="information-circle" size={20} color="rgba(255, 255, 255, 0.8)" />
-              <ThemedText style={styles.lightningAddressText}>{lnurlPayServicePayload[invoice]?.description || 'Lightning Address detected'}</ThemedText>
+              <ThemedText style={styles.lightningAddressText}>{lnurlPayServicePayload[invoice]?.description || 'Lightning Address or LNURL pay request detected'}</ThemedText>
             </View>
           )}
 

--- a/mobile/app/send/send-address-lightning.tsx
+++ b/mobile/app/send/send-address-lightning.tsx
@@ -24,7 +24,7 @@ const SendAddressLightning: React.FC = () => {
   const { scanQr } = useContext(ScanQrContext);
   const router = useRouter();
   const { network } = useContext(NetworkContext);
-  const { lightning, address } = useSendFlow();
+  const { lightning, address, setAddress } = useSendFlow();
   assert(lightning, 'Lightning context not found');
   const { layer } = lightning;
 
@@ -174,6 +174,7 @@ const SendAddressLightning: React.FC = () => {
       if (lnurlPSPayload) {
         lightning.setLnurlPayServicePayload(lnurlPSPayload);
       }
+      setAddress(lnurlPSPayload && Lnurl.isLightningAddress(invoice) ? invoice : '');
       if (lnurlInst) {
         lightning.setLnurlInstance(lnurlInst);
       }

--- a/mobile/app/send/send-address-lightning.tsx
+++ b/mobile/app/send/send-address-lightning.tsx
@@ -212,7 +212,7 @@ const SendAddressLightning: React.FC = () => {
                 <TextInput
                   ref={inputRef}
                   style={styles.input}
-                  placeholder="Enter lightning invoice, LNURL, or address"
+                  placeholder="Enter lightning invoice or address"
                   placeholderTextColor="rgba(255, 255, 255, 0.8)"
                   autoCapitalize="none"
                   autoCorrect={false}

--- a/mobile/app/send/send-confirm-lightning.tsx
+++ b/mobile/app/send/send-confirm-lightning.tsx
@@ -35,7 +35,7 @@ const SuccessRiveAnimation = () => {
 
 const SendConfirmLightning: React.FC = () => {
   const router = useRouter();
-  const { lightning, network } = useSendFlow();
+  const { lightning, network, address } = useSendFlow();
   const { accountNumber } = useContext(AccountNumberContext);
   const { exchangeRate } = useCachedExchangeRate(NETWORK_BITCOIN, 'USD');
 
@@ -172,6 +172,12 @@ const SendConfirmLightning: React.FC = () => {
     invoiceDisplay = lightning.invoice.substring(0, 10) + '...' + lightning.invoice.substring(lightning.invoice.length - 10);
   }
 
+  const lightningAddress = address;
+  let lightningAddressDisplay = lightningAddress;
+  if (lightningAddress && lightningAddress.length > 40) {
+    lightningAddressDisplay = lightningAddress.substring(0, 20) + '...' + lightningAddress.substring(lightningAddress.length - 10);
+  }
+
   return (
     <RadialGradientScreen network={network} scroll={false}>
       <Stack.Screen options={{ headerShown: false }} />
@@ -250,6 +256,17 @@ const SendConfirmLightning: React.FC = () => {
                       )}
                     </View>
                   </Animated.View>
+
+                  {lightningAddress && (
+                    <Animated.View style={[styles.sendToSection, sendToAnimatedStyle]}>
+                      <View style={styles.sectionHeader}>
+                        <ThemedText style={styles.sectionHeaderText}>Lightning Address</ThemedText>
+                      </View>
+                      <View style={styles.addressCard}>
+                        <ThemedText style={styles.invoiceDisplay}>{lightningAddressDisplay}</ThemedText>
+                      </View>
+                    </Animated.View>
+                  )}
 
                   {/* Send to Section */}
                   <Animated.View style={[styles.sendToSection, sendToAnimatedStyle]}>

--- a/mobile/app/send/withdraw-lightning.tsx
+++ b/mobile/app/send/withdraw-lightning.tsx
@@ -1,0 +1,331 @@
+import { Ionicons } from '@expo/vector-icons';
+import BigNumber from 'bignumber.js';
+import { Stack, useLocalSearchParams } from 'expo-router';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+
+import Pressable from '../../components/Pressable';
+import { BalanceLightning } from '@/components/Balance';
+import RadialGradientScreen from '@/components/RadialGradientScreen';
+import ScreenSendHeader from '@/components/navigation/ScreenSendHeader';
+import { ThemedText } from '@/components/ThemedText';
+import { BackgroundExecutor } from '@/src/modules/background-executor';
+import { NetworkContext } from '@shared/hooks/NetworkContext';
+import Lnurl from '@shared/class/lnurl';
+import { walletSupportsLightning } from '@shared/class/wallets/interface-lightning-wallet';
+import { overlayBackgroundDeeper } from '@shared/constants/Colors';
+import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
+import { getTickerByNetwork } from '@shared/models/network-getters';
+import { fetch } from '@shared/util/fetch';
+import { NETWORK_LIGHTNING, Networks } from '@shared/types/networks';
+import { LightningLayer } from './_layout';
+
+export type WithdrawLightningParams = {
+  lnurl: string;
+  network: Networks;
+};
+
+type LnurlWithdrawRequestPayload = {
+  callback: string;
+  defaultDescription?: string;
+  k1: string;
+  maxWithdrawable: number;
+  minWithdrawable: number;
+  tag: string;
+};
+
+const formatSatsFromMsats = (msats: number): string => {
+  const sats = new BigNumber(msats).dividedBy(1000);
+
+  if (sats.isInteger()) {
+    return sats.toFormat(0);
+  }
+
+  return sats.toFixed(3).replace(/\.?0+$/, '');
+};
+
+const getWithdrawAmountSats = (payload: LnurlWithdrawRequestPayload): number => {
+  const sats = new BigNumber(payload.maxWithdrawable).dividedBy(1000);
+
+  if (!sats.isInteger()) {
+    throw new Error('LNURL withdraw amount must be a whole number of sats');
+  }
+
+  return sats.toNumber();
+};
+
+const WithdrawLightning: React.FC = () => {
+  const params = useLocalSearchParams<WithdrawLightningParams>();
+  const { network, setNetwork } = useContext(NetworkContext);
+  const { accountNumber } = useContext(AccountNumberContext);
+  const requestedNetwork = typeof params.network === 'string' ? (params.network as Networks) : NETWORK_LIGHTNING;
+  const lnurl = typeof params.lnurl === 'string' ? params.lnurl.trim() : '';
+
+  const [selectedLayer, setSelectedLayer] = useState<LightningLayer | undefined>(undefined);
+  const [payload, setPayload] = useState<LnurlWithdrawRequestPayload | undefined>(undefined);
+  const [error, setError] = useState<string>('');
+  const [isLoadingRequest, setIsLoadingRequest] = useState(false);
+  const [withdrawState, setWithdrawState] = useState<'idle' | 'withdrawing' | 'success'>('idle');
+
+  useEffect(() => {
+    if (network !== requestedNetwork) {
+      setNetwork(requestedNetwork);
+    }
+  }, [network, requestedNetwork, setNetwork]);
+
+  const loadWithdrawRequest = useCallback(async () => {
+    if (!lnurl) {
+      setPayload(undefined);
+      setError('Missing LNURL withdraw request');
+      return;
+    }
+
+    setIsLoadingRequest(true);
+    setError('');
+
+    try {
+      const url = Lnurl.getUrlFromLnurl(lnurl);
+      if (!url) {
+        throw new Error('Invalid LNURL');
+      }
+
+      const response = await fetch(url, { method: 'GET' });
+      if (response.status >= 300) {
+        throw new Error('Bad response from server');
+      }
+
+      const reply = (await response.json()) as LnurlWithdrawRequestPayload & { status?: string; reason?: string };
+
+      if (reply.status === 'ERROR') {
+        throw new Error(reply.reason || 'Reply from server indicated an error');
+      }
+      if (reply.tag !== Lnurl.TAG_WITHDRAW_REQUEST) {
+        throw new Error(`lnurl-withdraw expected, found tag ${reply.tag}`);
+      }
+
+      setPayload(reply);
+    } catch (err: any) {
+      setPayload(undefined);
+      setError(err.message || 'Failed to load LNURL withdraw request');
+    } finally {
+      setIsLoadingRequest(false);
+    }
+  }, [lnurl]);
+
+  useEffect(() => {
+    loadWithdrawRequest();
+  }, [loadWithdrawRequest]);
+
+  const handleLayerSelect = (selectedNetwork: Networks) => {
+    if (withdrawState === 'success') {
+      return;
+    }
+
+    setSelectedLayer((current) => {
+      const nextLayer = selectedNetwork as LightningLayer;
+      return current === nextLayer ? undefined : nextLayer;
+    });
+  };
+
+  const handleWithdraw = async () => {
+    if (!payload || !selectedLayer) {
+      return;
+    }
+
+    setWithdrawState('withdrawing');
+    setError('');
+
+    try {
+      const wallet = await BackgroundExecutor.lazyInitWallet(selectedLayer, accountNumber);
+      if (!walletSupportsLightning(wallet)) {
+        throw new Error('Selected network does not support Lightning withdrawals');
+      }
+
+      const amountSats = getWithdrawAmountSats(payload);
+      const invoiceResponse = await wallet.createLightningInvoice(amountSats, payload.defaultDescription || 'Layerzwallet LNURL withdraw');
+      const separator = payload.callback.includes('?') ? '&' : '?';
+      const callbackUrl = `${payload.callback}${separator}k1=${encodeURIComponent(payload.k1)}&pr=${encodeURIComponent(invoiceResponse.invoice)}`;
+
+      const response = await fetch(callbackUrl, { method: 'GET' });
+      if (response.status >= 300) {
+        throw new Error('Bad response from withdraw callback');
+      }
+
+      const reply = (await response.json()) as { status?: string; reason?: string };
+      if (reply.status === 'ERROR') {
+        throw new Error(reply.reason || 'Withdraw callback returned an error');
+      }
+
+      setWithdrawState('success');
+    } catch (err: any) {
+      setWithdrawState('idle');
+      setError(err.message || 'Failed to withdraw');
+    }
+  };
+
+  const amountDisplay = useMemo(() => {
+    if (!payload) {
+      return '—';
+    }
+
+    const minSats = formatSatsFromMsats(payload.minWithdrawable);
+    const maxSats = formatSatsFromMsats(payload.maxWithdrawable);
+
+    return maxSats ? maxSats : minSats; // for an edge case if no max provided (should never happen)
+  }, [payload]);
+
+  const withdrawDisabled = isLoadingRequest || withdrawState !== 'idle' || !payload || !selectedLayer || !!error;
+
+  return (
+    <RadialGradientScreen network={requestedNetwork} scroll={true}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <ScreenSendHeader network={requestedNetwork} title={`Withdraw ${getTickerByNetwork(requestedNetwork)}`} />
+
+      <View style={styles.container}>
+        <View style={styles.content}>
+          <View style={styles.amountCard}>
+            <ThemedText style={styles.amountLabel}>You will receive</ThemedText>
+            {isLoadingRequest ? (
+              <View style={styles.loadingContainer}>
+                <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" />
+                <ThemedText style={styles.loadingText}>Loading withdraw request...</ThemedText>
+              </View>
+            ) : (
+              <>
+                <ThemedText type="sfProRounded" style={styles.amountValue} adjustsFontSizeToFit={true} numberOfLines={1}>
+                  {amountDisplay}
+                </ThemedText>
+                <ThemedText style={styles.amountTicker}>sats</ThemedText>
+              </>
+            )}
+          </View>
+
+          {payload?.defaultDescription && (
+            <View style={styles.infoCard}>
+              <Ionicons name="information-circle" size={20} color="rgba(255, 255, 255, 0.8)" />
+              <ThemedText style={styles.infoText}>{payload.defaultDescription}</ThemedText>
+            </View>
+          )}
+
+          {error ? (
+            <View style={styles.errorContainer}>
+              <Ionicons name="close" size={16} color="white" />
+              <ThemedText style={styles.errorText}>{error}</ThemedText>
+            </View>
+          ) : null}
+
+          <BalanceLightning onSelectNetwork={handleLayerSelect} selectedNetwork={selectedLayer} showTotalBalance={false} />
+        </View>
+
+        {withdrawState === 'success' ? (
+          <View style={styles.successState} testID="withdraw-lightning-success">
+            <Ionicons name="checkmark-circle" size={18} color="#4CAF50" />
+            <ThemedText style={styles.successText}>Success!</ThemedText>
+          </View>
+        ) : (
+          <Pressable style={[styles.withdrawButton, withdrawDisabled && styles.disabledButton]} onPress={handleWithdraw} disabled={withdrawDisabled} testID="withdraw-lightning-button">
+            {withdrawState === 'withdrawing' ? <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" /> : <ThemedText style={styles.withdrawButtonText}>Withdraw</ThemedText>}
+          </Pressable>
+        )}
+      </View>
+    </RadialGradientScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+    justifyContent: 'space-between',
+  },
+  content: {
+    gap: 16,
+  },
+  amountCard: {
+    alignItems: 'center',
+    backgroundColor: overlayBackgroundDeeper,
+    borderRadius: 24,
+    paddingHorizontal: 20,
+    paddingVertical: 28,
+  },
+  amountLabel: {
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontSize: 14,
+    marginBottom: 12,
+  },
+  amountValue: {
+    color: 'rgba(255, 255, 255, 0.95)',
+    fontSize: 42,
+    width: '100%',
+    textAlign: 'center',
+  },
+  amountTicker: {
+    color: 'rgba(255, 255, 255, 0.65)',
+    fontSize: 18,
+    marginTop: 8,
+  },
+  loadingContainer: {
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 10,
+  },
+  loadingText: {
+    color: 'rgba(255, 255, 255, 0.8)',
+    fontSize: 14,
+  },
+  infoCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: overlayBackgroundDeeper,
+    borderRadius: 12,
+    padding: 12,
+  },
+  infoText: {
+    color: 'rgba(255, 255, 255, 0.8)',
+    fontSize: 14,
+    flex: 1,
+  },
+  errorContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  errorText: {
+    color: 'white',
+    fontSize: 14,
+  },
+  withdrawButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.3)',
+    paddingVertical: 16,
+    borderRadius: 16,
+    marginTop: 'auto',
+    marginBottom: 24,
+  },
+  successState: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginTop: 'auto',
+    marginBottom: 24,
+    minHeight: 56,
+  },
+  successText: {
+    color: '#4CAF50',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  withdrawButtonText: {
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+});
+
+export default WithdrawLightning;

--- a/mobile/app/send/withdraw-lightning.tsx
+++ b/mobile/app/send/withdraw-lightning.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import BigNumber from 'bignumber.js';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
 
 import Pressable from '../../components/Pressable';
 import { BalanceLightning } from '@/components/Balance';
@@ -34,25 +34,9 @@ type LnurlWithdrawRequestPayload = {
   tag: string;
 };
 
-const formatSatsFromMsats = (msats: number): string => {
-  const sats = new BigNumber(msats).dividedBy(1000);
+const msatsToSatsFloor = (msats: number): number => new BigNumber(msats).dividedBy(1000).integerValue(BigNumber.ROUND_DOWN).toNumber();
 
-  if (sats.isInteger()) {
-    return sats.toFormat(0);
-  }
-
-  return sats.toFixed(3).replace(/\.?0+$/, '');
-};
-
-const getWithdrawAmountSats = (payload: LnurlWithdrawRequestPayload): number => {
-  const sats = new BigNumber(payload.maxWithdrawable).dividedBy(1000);
-
-  if (!sats.isInteger()) {
-    throw new Error('LNURL withdraw amount must be a whole number of sats');
-  }
-
-  return sats.toNumber();
-};
+const msatsToSatsCeil = (msats: number): number => new BigNumber(msats).dividedBy(1000).integerValue(BigNumber.ROUND_UP).toNumber();
 
 const WithdrawLightning: React.FC = () => {
   const params = useLocalSearchParams<WithdrawLightningParams>();
@@ -66,6 +50,15 @@ const WithdrawLightning: React.FC = () => {
   const [error, setError] = useState<string>('');
   const [isLoadingRequest, setIsLoadingRequest] = useState(false);
   const [withdrawState, setWithdrawState] = useState<'idle' | 'withdrawing' | 'success'>('idle');
+  const [customAmount, setCustomAmount] = useState<string>('');
+
+  const isFixedAmount = !!payload && payload.minWithdrawable === payload.maxWithdrawable;
+  const minSats = useMemo(() => (payload ? msatsToSatsCeil(payload.minWithdrawable) : 0), [payload]);
+  const maxSats = useMemo(() => (payload ? msatsToSatsFloor(payload.maxWithdrawable) : 0), [payload]);
+  // LNURL server requested an amount that cannot be represented in whole sats
+  // (e.g. fixed 1500 msats, or a tight [1500, 1999] msat range). Any invoice we
+  // could create would fall outside the server's [min, max] msat window.
+  const rangeIsUnsatisfiable = !!payload && minSats > maxSats;
 
   useEffect(() => {
     if (network !== requestedNetwork) {
@@ -127,8 +120,59 @@ const WithdrawLightning: React.FC = () => {
     });
   };
 
+  const resolveWithdrawAmountSats = (): number => {
+    if (!payload) {
+      throw new Error('Missing LNURL withdraw request');
+    }
+    if (rangeIsUnsatisfiable) {
+      throw new Error('Withdraw amount cannot be represented in whole sats');
+    }
+    if (isFixedAmount) {
+      return maxSats;
+    }
+
+    const trimmed = customAmount.trim();
+    if (!trimmed) {
+      throw new Error('Please enter an amount');
+    }
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error('Amount must be a whole number of sats');
+    }
+
+    const value = Number(trimmed);
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error('Amount must be greater than 0');
+    }
+    if (value < minSats) {
+      throw new Error(`Amount must be at least ${minSats} sats`);
+    }
+    if (value > maxSats) {
+      throw new Error(`Amount must be at most ${maxSats} sats`);
+    }
+
+    return value;
+  };
+
+  const handleCustomAmountChange = (text: string) => {
+    setCustomAmount(text.replace(/[^0-9]/g, ''));
+    setError('');
+  };
+
+  const handleMaxPress = () => {
+    setCustomAmount(String(maxSats));
+    setError('');
+  };
+
   const handleWithdraw = async () => {
     if (!payload || !selectedLayer) {
+      return;
+    }
+
+    let amountSats: number;
+    try {
+      amountSats = resolveWithdrawAmountSats();
+    } catch (err: any) {
+      setError(err.message || 'Invalid amount');
       return;
     }
 
@@ -141,7 +185,6 @@ const WithdrawLightning: React.FC = () => {
         throw new Error('Selected network does not support Lightning withdrawals');
       }
 
-      const amountSats = getWithdrawAmountSats(payload);
       const invoiceResponse = await wallet.createLightningInvoice(amountSats, payload.defaultDescription || 'Layerzwallet LNURL withdraw');
       const separator = payload.callback.includes('?') ? '&' : '?';
       const callbackUrl = `${payload.callback}${separator}k1=${encodeURIComponent(payload.k1)}&pr=${encodeURIComponent(invoiceResponse.invoice)}`;
@@ -163,76 +206,98 @@ const WithdrawLightning: React.FC = () => {
     }
   };
 
-  const amountDisplay = useMemo(() => {
-    if (!payload) {
+  const fixedAmountDisplay = useMemo(() => {
+    if (!payload || rangeIsUnsatisfiable) {
       return '—';
     }
+    return new BigNumber(maxSats).toFormat(0);
+  }, [payload, maxSats, rangeIsUnsatisfiable]);
 
-    const minSats = formatSatsFromMsats(payload.minWithdrawable);
-    const maxSats = formatSatsFromMsats(payload.maxWithdrawable);
-
-    return maxSats ? maxSats : minSats; // for an edge case if no max provided (should never happen)
-  }, [payload]);
-
-  const withdrawDisabled = isLoadingRequest || withdrawState !== 'idle' || !payload || !selectedLayer || !!error;
+  const displayedError = error || (rangeIsUnsatisfiable ? 'Withdraw amount cannot be represented in whole sats' : '');
+  const withdrawDisabled = isLoadingRequest || withdrawState !== 'idle' || !payload || !selectedLayer || rangeIsUnsatisfiable || (!isFixedAmount && !customAmount);
 
   return (
     <RadialGradientScreen network={requestedNetwork} scroll={true}>
       <Stack.Screen options={{ headerShown: false }} />
       <ScreenSendHeader network={requestedNetwork} title={`Withdraw ${getTickerByNetwork(requestedNetwork)}`} />
 
-      <View style={styles.container}>
-        <View style={styles.content}>
-          <View style={styles.amountCard}>
-            <ThemedText style={styles.amountLabel}>You will receive</ThemedText>
-            {isLoadingRequest ? (
-              <View style={styles.loadingContainer}>
-                <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" />
-                <ThemedText style={styles.loadingText}>Loading withdraw request...</ThemedText>
+      <KeyboardAvoidingView style={styles.keyboardAvoidingView} behavior={Platform.OS === 'ios' ? 'padding' : 'height'} keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}>
+        <View style={styles.container}>
+          <View style={styles.content}>
+            <View style={styles.amountCard}>
+              <ThemedText style={styles.amountLabel}>{isFixedAmount ? 'You will receive' : 'Enter amount'}</ThemedText>
+              {isLoadingRequest ? (
+                <View style={styles.loadingContainer}>
+                  <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" />
+                  <ThemedText style={styles.loadingText}>Loading withdraw request...</ThemedText>
+                </View>
+              ) : isFixedAmount || !payload || rangeIsUnsatisfiable ? (
+                <>
+                  <ThemedText type="sfProRounded" style={styles.amountValue} adjustsFontSizeToFit={true} numberOfLines={1}>
+                    {fixedAmountDisplay}
+                  </ThemedText>
+                  <ThemedText style={styles.amountTicker}>sats</ThemedText>
+                </>
+              ) : (
+                <>
+                  <TextInput
+                    style={styles.amountInput}
+                    value={customAmount}
+                    onChangeText={handleCustomAmountChange}
+                    keyboardType="number-pad"
+                    placeholder="0"
+                    placeholderTextColor="rgba(255, 255, 255, 0.35)"
+                    editable={withdrawState === 'idle'}
+                    testID="withdraw-lightning-amount-input"
+                  />
+                  <ThemedText style={styles.amountTicker}>sats</ThemedText>
+                  <View style={styles.rangeRow}>
+                    <ThemedText style={styles.rangeText}>{`Min ${minSats} • Max ${maxSats} sats`}</ThemedText>
+                    <Pressable style={styles.maxButton} onPress={handleMaxPress} disabled={withdrawState !== 'idle'} testID="withdraw-lightning-max-button">
+                      <ThemedText style={styles.maxButtonText}>MAX</ThemedText>
+                    </Pressable>
+                  </View>
+                </>
+              )}
+            </View>
+
+            {payload?.defaultDescription && (
+              <View style={styles.infoCard}>
+                <Ionicons name="information-circle" size={20} color="rgba(255, 255, 255, 0.8)" />
+                <ThemedText style={styles.infoText}>{payload.defaultDescription}</ThemedText>
               </View>
-            ) : (
-              <>
-                <ThemedText type="sfProRounded" style={styles.amountValue} adjustsFontSizeToFit={true} numberOfLines={1}>
-                  {amountDisplay}
-                </ThemedText>
-                <ThemedText style={styles.amountTicker}>sats</ThemedText>
-              </>
             )}
+
+            {displayedError ? (
+              <View style={styles.errorContainer}>
+                <Ionicons name="close" size={16} color="white" />
+                <ThemedText style={styles.errorText}>{displayedError}</ThemedText>
+              </View>
+            ) : null}
+
+            <BalanceLightning onSelectNetwork={handleLayerSelect} selectedNetwork={selectedLayer} showTotalBalance={false} />
           </View>
 
-          {payload?.defaultDescription && (
-            <View style={styles.infoCard}>
-              <Ionicons name="information-circle" size={20} color="rgba(255, 255, 255, 0.8)" />
-              <ThemedText style={styles.infoText}>{payload.defaultDescription}</ThemedText>
+          {withdrawState === 'success' ? (
+            <View style={styles.successState} testID="withdraw-lightning-success">
+              <Ionicons name="checkmark-circle" size={18} color="#4CAF50" />
+              <ThemedText style={styles.successText}>Success!</ThemedText>
             </View>
+          ) : (
+            <Pressable style={[styles.withdrawButton, withdrawDisabled && styles.disabledButton]} onPress={handleWithdraw} disabled={withdrawDisabled} testID="withdraw-lightning-button">
+              {withdrawState === 'withdrawing' ? <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" /> : <ThemedText style={styles.withdrawButtonText}>Withdraw</ThemedText>}
+            </Pressable>
           )}
-
-          {error ? (
-            <View style={styles.errorContainer}>
-              <Ionicons name="close" size={16} color="white" />
-              <ThemedText style={styles.errorText}>{error}</ThemedText>
-            </View>
-          ) : null}
-
-          <BalanceLightning onSelectNetwork={handleLayerSelect} selectedNetwork={selectedLayer} showTotalBalance={false} />
         </View>
-
-        {withdrawState === 'success' ? (
-          <View style={styles.successState} testID="withdraw-lightning-success">
-            <Ionicons name="checkmark-circle" size={18} color="#4CAF50" />
-            <ThemedText style={styles.successText}>Success!</ThemedText>
-          </View>
-        ) : (
-          <Pressable style={[styles.withdrawButton, withdrawDisabled && styles.disabledButton]} onPress={handleWithdraw} disabled={withdrawDisabled} testID="withdraw-lightning-button">
-            {withdrawState === 'withdrawing' ? <ActivityIndicator size="small" color="rgba(255, 255, 255, 0.8)" /> : <ThemedText style={styles.withdrawButtonText}>Withdraw</ThemedText>}
-          </Pressable>
-        )}
-      </View>
+      </KeyboardAvoidingView>
     </RadialGradientScreen>
   );
 };
 
 const styles = StyleSheet.create({
+  keyboardAvoidingView: {
+    flex: 1,
+  },
   container: {
     flex: 1,
     paddingHorizontal: 16,
@@ -259,10 +324,41 @@ const styles = StyleSheet.create({
     width: '100%',
     textAlign: 'center',
   },
+  amountInput: {
+    color: 'rgba(255, 255, 255, 0.95)',
+    fontSize: 42,
+    width: '100%',
+    textAlign: 'center',
+    padding: 0,
+    margin: 0,
+  },
   amountTicker: {
     color: 'rgba(255, 255, 255, 0.65)',
     fontSize: 18,
     marginTop: 8,
+  },
+  rangeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    marginTop: 16,
+  },
+  rangeText: {
+    color: 'rgba(255, 255, 255, 0.55)',
+    fontSize: 13,
+  },
+  maxButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255, 255, 255, 0.15)',
+  },
+  maxButtonText: {
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.5,
   },
   loadingContainer: {
     alignItems: 'center',

--- a/mobile/components/StickyHeader.tsx
+++ b/mobile/components/StickyHeader.tsx
@@ -47,7 +47,7 @@ const StickyHeader: React.FC<StickyHeaderProps> = ({ scrollY, onSettingsPress })
         return;
       }
 
-      handleQrIntent(result, router);
+      await handleQrIntent(result, router);
     } catch (error) {
       console.error('StickyHeader: QR scan failed', error);
     }

--- a/mobile/src/modules/scan-routing.ts
+++ b/mobile/src/modules/scan-routing.ts
@@ -5,8 +5,10 @@ import type { Router } from 'expo-router';
 
 import { PosMerchantParams } from '@/app/PosMerchant';
 import { SendParams } from '@/app/send';
+import { WithdrawLightningParams } from '@/app/send/withdraw-lightning';
 import { convertMerchantQRToLightningAddress } from '@shared/modules/merchants';
 import { NETWORK_LIGHTNING } from '@shared/types/networks';
+import Lnurl from '@shared/class/lnurl';
 
 type LightningIntent = {
   type: 'lightning';
@@ -160,11 +162,24 @@ export function parseQrIntent(rawInput: string): QrIntent {
   return { type: 'unknown', raw };
 }
 
-export function handleQrIntent(rawInput: string, router: Pick<Router, 'push'>): boolean {
+export async function handleQrIntent(rawInput: string, router: Pick<Router, 'push'>): Promise<boolean> {
   const intent = parseQrIntent(rawInput);
 
   switch (intent.type) {
     case 'lightning': {
+      try {
+        if (await Lnurl.isLnurlWithdrawRequest(intent.invoice)) {
+          const params: WithdrawLightningParams = {
+            lnurl: intent.invoice,
+            network: NETWORK_LIGHTNING,
+          };
+          router.push({
+            pathname: '/send/withdraw-lightning',
+            params,
+          });
+          return true;
+        }
+      } catch (_) {}
       const params: SendParams = { address: intent.invoice, network: NETWORK_LIGHTNING };
       router.push({ pathname: '/send', params });
       return true;

--- a/mobile/src/tests/unit-vi/scan-routing.test.ts
+++ b/mobile/src/tests/unit-vi/scan-routing.test.ts
@@ -111,23 +111,23 @@ describe('scan-routing parser', () => {
 });
 
 describe('scan-routing handler', () => {
-  test('routes lightning payloads to SendLightning', () => {
+  test('routes lightning payloads to SendLightning', async () => {
     const push = vi.fn();
     const router = { push };
     const invoice = 'lightning:lnurl1dp68gurn8ghj7mrww4exctnrda3k7mrww4excu0';
 
-    const handled = handleQrIntent(invoice, router);
+    const handled = await handleQrIntent(invoice, router);
 
     expect(handled).toBe(true);
     expect(push).toHaveBeenCalledWith({ pathname: '/send', params: { network: NETWORK_LIGHTNING, address: 'lnurl1dp68gurn8ghj7mrww4exctnrda3k7mrww4excu0' } });
   });
 
-  test('routes merchant QR code payloads to SendLightning', () => {
+  test('routes merchant QR code payloads to SendLightning', async () => {
     const push = vi.fn();
     const router = { push };
     const invoice = '00020129530023za.co.electrum.picknpay0122D57H4TMHFZ2TEZ/confirm520458125303710540115802ZA5916cryptoqrtestscan6002CT6304A440';
 
-    const handled = handleQrIntent(invoice, router);
+    const handled = await handleQrIntent(invoice, router);
 
     expect(handled).toBe(true);
     expect(push).toHaveBeenCalledWith({
@@ -136,28 +136,28 @@ describe('scan-routing handler', () => {
     });
   });
 
-  test('routes bitcoin payloads to send', () => {
+  test('routes bitcoin payloads to send', async () => {
     const push = vi.fn();
     const router = { push };
-    const handled = handleQrIntent('bitcoin:bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh?amount=0.25', router);
+    const handled = await handleQrIntent('bitcoin:bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh?amount=0.25', router);
 
     expect(handled).toBe(true);
     expect(push).toHaveBeenCalledWith({ pathname: '/send', params: { address: 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh', amount: '0.25' } });
   });
 
-  test('routes bitcoin payloads to send 2', () => {
+  test('routes bitcoin payloads to send 2', async () => {
     const push = vi.fn();
     const router = { push };
-    const handled = handleQrIntent('bitcoin:1DzJepHCRD2C9vpFjk11eXJi97juEZ3ftv?amount=0.004&message=wheres the money lebowski', router);
+    const handled = await handleQrIntent('bitcoin:1DzJepHCRD2C9vpFjk11eXJi97juEZ3ftv?amount=0.004&message=wheres the money lebowski', router);
 
     expect(handled).toBe(true);
     expect(push).toHaveBeenCalledWith({ pathname: '/send', params: { address: '1DzJepHCRD2C9vpFjk11eXJi97juEZ3ftv', amount: '0.004' } });
   });
 
-  test('returns false for malformed/unknown payloads', () => {
+  test('returns false for malformed/unknown payloads', async () => {
     const push = vi.fn();
     const router = { push };
-    const handled = handleQrIntent('invalid-qr-code-data', router);
+    const handled = await handleQrIntent('invalid-qr-code-data', router);
 
     expect(push).not.toHaveBeenCalled();
     expect(handled).toBe(false);

--- a/shared/class/lnurl.ts
+++ b/shared/class/lnurl.ts
@@ -101,6 +101,10 @@ export default class Lnurl {
     return Lnurl.findlnurl(url) !== null;
   }
 
+  static isLightningAddressOrLnurl(value: string): boolean {
+    return Lnurl.isLnurl(value) || Lnurl.isLightningAddress(value);
+  }
+
   static isOnionUrl(url: string): boolean {
     return Lnurl.parseOnionUrl(url) !== null;
   }

--- a/shared/class/lnurl.ts
+++ b/shared/class/lnurl.ts
@@ -339,4 +339,14 @@ export default class Lnurl {
     const splitted = address.split('@');
     return !!splitted[0].trim() && !!splitted[1].trim();
   }
+
+  static async isLnurlWithdrawRequest(lnurl: string): Promise<boolean> {
+    const url = Lnurl.getUrlFromLnurl(lnurl);
+    if (!url) throw new Error('Invalid LNURL');
+
+    const reply = await fetch(url, { method: 'GET' });
+    const payload = (await reply.json()) as LnurlPayServiceBolt11Payload;
+
+    return payload.tag === Lnurl.TAG_WITHDRAW_REQUEST;
+  }
 }

--- a/shared/tests/unit-vi/lnurl.test.ts
+++ b/shared/tests/unit-vi/lnurl.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import Lnurl from '../../class/lnurl';
 
 const { fetchMock } = vi.hoisted(() => ({
   fetchMock: vi.fn(),
@@ -7,8 +8,6 @@ const { fetchMock } = vi.hoisted(() => ({
 vi.mock('../../util/fetch', () => ({
   fetch: fetchMock,
 }));
-
-import Lnurl from '../../class/lnurl';
 
 const WITHDRAW_LNURL = 'LNURL1DP68GURN8GHJ7UMPW33XZUM99E3K7TN6VYHHWTE5V9NRSV35V33KVDRZV43NZENXXQ6XZVPNVVERVE3EVYEXVEPNXY8FZW5Q';
 const PAY_LNURL = 'LNURL1DP68GURN8GHJ7UMPW33XZUM99E3K7TN6VYHKVTE3V5EXZEF5VVCNGWPSXE3KGWPJVD3NJCFC8YMK2VFEXYURSVFSV54J6EE2';

--- a/shared/tests/unit-vi/lnurl.test.ts
+++ b/shared/tests/unit-vi/lnurl.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+
+import Lnurl from '../../class/lnurl';
+
+describe('Lnurl.isLightningAddressOrLnurl', () => {
+  test('accepts raw bech32 lnurl pay requests', () => {
+    expect(Lnurl.isLightningAddressOrLnurl('LNURL1DP68GURN8GHJ7MRWW4EXCTNRDA3K7MRWW4EXCU0')).toBe(true);
+  });
+
+  test('accepts lightning addresses', () => {
+    expect(Lnurl.isLightningAddressOrLnurl('r1n04h@layerz.me')).toBe(true);
+  });
+
+  test('rejects bolt11 invoices', () => {
+    expect(
+      Lnurl.isLightningAddressOrLnurl(
+        'lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4'
+      )
+    ).toBe(false);
+  });
+});

--- a/shared/tests/unit-vi/lnurl.test.ts
+++ b/shared/tests/unit-vi/lnurl.test.ts
@@ -1,6 +1,58 @@
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+}));
+
+vi.mock('../../util/fetch', () => ({
+  fetch: fetchMock,
+}));
 
 import Lnurl from '../../class/lnurl';
+
+const WITHDRAW_LNURL = 'LNURL1DP68GURN8GHJ7UMPW33XZUM99E3K7TN6VYHHWTE5V9NRSV35V33KVDRZV43NZENXXQ6XZVPNVVERVE3EVYEXVEPNXY8FZW5Q';
+const PAY_LNURL = 'LNURL1DP68GURN8GHJ7UMPW33XZUM99E3K7TN6VYHKVTE3V5EXZEF5VVCNGWPSXE3KGWPJVD3NJCFC8YMK2VFEXYURSVFSV54J6EE2';
+
+const lnurlResponses = new Map([
+  [
+    Lnurl.getUrlFromLnurl(WITHDRAW_LNURL),
+    {
+      callback: 'https://satbase.co.za/redeem/4af824dcf4bec1ff04a03c26f9a2fd31/callback',
+      defaultDescription: 'Redeem Voucher',
+      k1: '46f497bff874016f60a6eb967c66724b',
+      maxWithdrawable: 190000,
+      minWithdrawable: 190000,
+      tag: 'withdrawRequest',
+    },
+  ],
+  [
+    Lnurl.getUrlFromLnurl(PAY_LNURL),
+    {
+      callback: 'https://satbase.co.za/fund/1e2ae4c14806cd82cc9a897e1918810e/callback',
+      maxSendable: 999800000,
+      metadata: '[["text/plain","Fund a Voucher"]]',
+      minSendable: 1000,
+      tag: 'payRequest',
+    },
+  ],
+]);
+
+(globalThis as any).__DEV__ = true;
+
+beforeEach(() => {
+  fetchMock.mockImplementation(async (url: string) => {
+    const payload = lnurlResponses.get(url);
+
+    if (!payload) {
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }
+
+    return {
+      json: vi.fn().mockResolvedValue(payload),
+      status: 200,
+    };
+  });
+});
 
 describe('Lnurl.isLightningAddressOrLnurl', () => {
   test('accepts raw bech32 lnurl pay requests', () => {
@@ -17,5 +69,15 @@ describe('Lnurl.isLightningAddressOrLnurl', () => {
         'lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4'
       )
     ).toBe(false);
+  });
+});
+
+describe('Lnurl.isLnurlWithdrawRequest', () => {
+  test('accepts lnurl withdraw requests', async () => {
+    expect(await Lnurl.isLnurlWithdrawRequest(WITHDRAW_LNURL)).toBe(true);
+  });
+
+  test('rejects lnurl pay requests', async () => {
+    expect(await Lnurl.isLnurlWithdrawRequest(PAY_LNURL)).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds LNURL parsing/network calls and a new LNURL-withdraw flow that creates invoices and hits third-party callbacks; mistakes could misroute funds or break send/scan flows.
> 
> **Overview**
> Adds broader Lightning destination support by treating both LNURL and Lightning Addresses as LNURL-pay inputs (new `Lnurl.isLightningAddressOrLnurl`), updating send screens to fetch pay-service metadata for either format and clarifying UI/error messaging.
> 
> Introduces an **LNURL-withdraw** flow: QR scanning now asynchronously detects `withdrawRequest` LNURLs and routes to a new `withdraw-lightning` screen that loads the withdraw request, validates min/max (including msat→sat edge cases), creates an invoice on the selected Lightning layer, and calls the LNURL callback.
> 
> Enhances the send flow to preserve/display the original Lightning Address on the confirmation screen, and updates unit tests to cover the new helpers and async scan routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b4d851fb9de4fd7dd09fb2ec32cb6fd93dd6089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->