### PR TITLE
fix: impossible to navigate back if went to botanix yield from yield-…

### DIFF
--- a/mobile/app/YieldList.tsx
+++ b/mobile/app/YieldList.tsx
@@ -69,7 +69,7 @@ export default function YieldListScreen() {
         // botanix yield
         setNetwork(NETWORK_BOTANIX);
         await new Promise((res) => setTimeout(res, 100)); // propagate network change
-        router.push({ pathname: '/DAppBrowser', params: { url: 'https://yield.botanixlabs.com' } });
+        router.push({ pathname: '/(tabs)/explorer', params: { url: 'https://yield.botanixlabs.com' } });
         break;
       case USDB_YIELD_TOKEN_ID:
         router.push({


### PR DESCRIPTION
…list screen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-route navigation change in a UI flow; main risk is unintended differences in browser screen behavior due to using the tabbed wrapper.
> 
> **Overview**
> Fixes navigation when launching Botanix yield from the Earn/Yield list by routing to the tabbed explorer (`/(tabs)/explorer`) instead of the standalone `DAppBrowser` screen.
> 
> This ensures the yield site opens within the normal tab navigation stack, restoring expected back behavior after switching the network to Botanix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c6e6c7a50694a790dd689a3e037f4e8b9b9bbdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->