### PR TITLE
ci: build ios devclient for testflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,32 @@ We are also relying on Expo EAS for builds, so a generic workflow to run e2e tes
 
 * local android build: `eas build --platform android --profile preview --local`
 * ext build: `npm run build`
+
+## iOS Dev Client (TestFlight)
+
+A separate iOS app record exists on App Store Connect for distributing an
+Expo Dev Client build via TestFlight (bundle id `com.layerzwallet.mobile.devclient`,
+ASC app id `6762009368`). The binary is signed as a regular App Store build but
+embeds `expo-dev-client`, so once installed from TestFlight it can load any
+branch's JS bundle remotely from `expo start --dev-client`.
+
+The bundle id is swapped at prebuild time via the `APP_VARIANT=devclient`
+env var (see `mobile/app.config.js`); the production app's identity is
+unaffected.
+
+Build remotely on EAS and auto-submit to TestFlight in one shot:
+
+```
+cd mobile
+eas build --platform ios --profile development-device-ios --auto-submit-with-profile=devclient
+```
+
+Or in two steps if you want to inspect the build first:
+
+```
+eas build --platform ios --profile development-device-ios
+eas submit --platform ios --profile devclient --latest
+```
+
+Credentials (distribution cert + provisioning profile) are managed by EAS;
+first run will prompt for an Apple ID and create them automatically.

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,0 +1,25 @@
+// Dynamic Expo config. The static values still live in app.json; this file
+// only mutates them when we want to build a separate "variant" of the app
+// (currently: a TestFlight-distributable Expo Dev Client with its own
+// bundle id / app store record).
+//
+// Switch variants with the APP_VARIANT env var. EAS sets it per build profile
+// (see eas.json); locally you can run e.g.:
+//   APP_VARIANT=devclient npx expo prebuild
+
+const VARIANT = process.env.APP_VARIANT;
+
+module.exports = ({ config }) => {
+  if (VARIANT === 'devclient') {
+    return {
+      ...config,
+      name: 'Layerz Dev',
+      ios: {
+        ...config.ios,
+        bundleIdentifier: 'com.layerzwallet.mobile.devclient',
+      },
+    };
+  }
+
+  return config;
+};

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -15,6 +15,18 @@
       "developmentClient": true,
       "distribution": "internal"
     },
+    "development-device-ios": {
+      "extends": "base",
+      "developmentClient": true,
+      "distribution": "store",
+      "autoIncrement": true,
+      "env": {
+        "APP_VARIANT": "devclient"
+      },
+      "ios": {
+        "credentialsSource": "remote"
+      }
+    },
     "preview": {
       "extends": "base",
       "distribution": "internal",
@@ -53,6 +65,12 @@
       },
       "ios": {
         "ascAppId": "6745974808"
+      }
+    },
+    "devclient": {
+      "ios": {
+        "ascAppId": "6762009368",
+        "bundleIdentifier": "com.layerzwallet.mobile.devclient"
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes iOS build configuration, bundle identifiers, and App Store Connect submission settings, which can break EAS builds or accidentally submit under the wrong app record.
> 
> **Overview**
> Introduces a dedicated iOS *Dev Client* TestFlight variant by adding a dynamic Expo config (`mobile/app.config.js`) that swaps the app name and iOS bundle id when `APP_VARIANT=devclient`.
> 
> Updates `mobile/eas.json` with a new `development-device-ios` build profile (store distribution, auto-increment, remote credentials, sets `APP_VARIANT`) and a `submit.devclient` profile targeting a separate ASC app id/bundle id. README is expanded with the end-to-end EAS build/submit commands and TestFlight app metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e0089b221f6aa74fc49d373a93b0d958161a8cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->