### PR TITLE
fix: garden and ext tests

### DIFF
--- a/ext/src/tests/e2e/main.spec.ts
+++ b/ext/src/tests/e2e/main.spec.ts
@@ -188,11 +188,14 @@ test('can switch network', async ({ page, extensionId }) => {
   // await page.selectOption('[id="networkSelect"]', 'optimism');
   await page.getByRole('button', { name: 'Rootstock' }).click(); // allow connecting to the Dapp
 
-  // navigating back to the dapp to check current network
+  // navigating back to the dapp to check current network. reloading the dapp
+  // drops its EIP-6963 provider selection, so we must re-select it; the dapp
+  // then auto-reconnects since the permission is already granted.
   await page.goto('https://metamask.github.io/test-dapp/');
-  await sleep(4_000); // waiting for a page to interact with injected provider and load that stuff
-  const spanText2 = await page.locator('span[id="network"]').textContent();
-  expect(parseInt(String(spanText2))).toEqual(30); // current selected network is 10
+  await page.getByText(/Use Layerz Wallet/).click();
+
+  // selected network is now Rootstock (chainId 30)
+  await expect(page.locator('span[id="network"]')).toHaveText('30', { timeout: 30_000 });
 });
 
 test('onboarding: does not have mnemonic', async ({ page, extensionId }) => {

--- a/shared/tests/integration-vi/garden-transfer.test.ts
+++ b/shared/tests/integration-vi/garden-transfer.test.ts
@@ -18,7 +18,10 @@ const storage: IStorage = {
 const BTC_ASSET: AssetId = 'native:bitcoin';
 const BOTANIX_ASSET: AssetId = 'native:botanix';
 
-const isInsufficientLiquidity = (err: unknown): boolean => err instanceof GardenApiError && /insufficient liquidity/i.test(err.message);
+// Garden pairs come and go: a pair may have no liquidity, no solver route, or
+// reference an asset Garden doesn't list. All mean "try the next candidate /
+// skip" rather than fail — only genuine client/auth errors should throw.
+const isPairUnavailable = (err: unknown): boolean => err instanceof GardenApiError && /insufficient liquidity|no order pair found|invalid (to|from)_asset/i.test(err.message);
 
 // Candidate Garden pairs to probe. `serviceSendAsset`/`serviceReceiveAsset` are
 // set only when the pair is mapped in `garden-mappings.ts` — service-level
@@ -49,10 +52,10 @@ describe('Garden Finance API integration', () => {
         console.log(`Using working Garden pair: ${c.gardenFrom} → ${c.gardenTo}`);
         return;
       } catch (err) {
-        if (!isInsufficientLiquidity(err)) throw err;
+        if (!isPairUnavailable(err)) throw err;
       }
     }
-    console.warn('No Garden pair returned liquidity — skipping dependent tests');
+    console.warn('No Garden pair currently tradeable — skipping dependent tests');
   }, 30_000);
 
   it('GET /quote returns valid amounts for BTC→<dest>', async (ctx) => {


### PR DESCRIPTION
## fix: failing CI tests

Two unrelated CI failures.

### Garden integration test

`garden-transfer.test.ts` failed its whole suite when Garden Finance had no tradeable route for the probed pairs. The probe's skip-predicate matched only `"insufficient liquidity"`, so other "pair not tradeable" responses (`"No order pair found"`, `"invalid to_asset"`) re-threw.

Broadened the predicate to skip on all of Garden's pair/asset-unavailable responses; genuine client/auth errors still throw. Dependent tests skip cleanly, resume automatically once Garden routes a pair again.

### `can switch network` e2e test

`main.spec.ts` deterministically failed (`NaN` for the network span). The metamask test-dapp uses EIP-6963 provider selection; reloading the dapp drops that selection, leaving it disconnected so the network span never populated.

After the reload, re-select the Layerz provider (dapp auto-reconnects, permission already granted). Also replaced a fixed `sleep` + raw read with an auto-retrying `toHaveText` assertion.
