### PR TITLE
Feat more mcp calls

### DIFF
--- a/.agents/swap.md
+++ b/.agents/swap.md
@@ -164,6 +164,17 @@ Two tools expose Flashnet to remote AI agents. They run on `MCP_BALANCE_ACCOUNT_
 
 Adding more pairs is purely additive: extend `MCP_SWAP_ASSET_IDS` and ensure the relevant provider quotes the pair and implements `executeInstantSwap`. The manager routes by `executionOwners` so any such provider works without touching the MCP layer.
 
+### On-chain BTC → Spark (deposit + claim)
+
+Moving native (L1) BTC into the Spark balance is the `NativeDeposit` flow (deposit address + async claim), which does **not** fit `execute_swap`'s instant contract (same reason `SparkExit` is left out). Instead of routing through the TransferServiceManager, the MCP exposes two thin tools over `SparkWallet` (on `MCP_BALANCE_ACCOUNT_NUMBER`) and reuses the existing Bitcoin-send tools for the actual on-chain move:
+
+- **`get_spark_deposit_address()`** — `lazyInitWallet(NETWORK_SPARK, 4141)` (narrowed via `instanceof SparkWallet`) → `getOnchainDepositAddress()` (the SDK's static `bc1…` deposit address). Returns `{ deposit_address, deposit_chain: 'bitcoin', confirmations_required, next_step }`. `confirmations_required` comes from the canonical `SPARK_STATIC_DEPOSIT_CONFIRMATIONS` exported by `spark-wallet.ts` (same constant `getCommonSwaps` uses), not a local literal. Distinct from `get_receive_address('spark')`, which returns the `spark1…` Spark-native address.
+- **`claim_spark_deposit(txid?)`** — `getCommonSwaps()` → filter `status === 'claimable'` (≥3 confs) → for each, `getDepositQuote(txid)` + `claimDepositSpark(quote)`. Claims all claimable by default, or one when `txid` is given. Returns `{ claimed:[{txid, transfer_id, credited_base_units}], failed?, total_credited_base_units }`; when nothing is claimable it returns `{ claimed:[], pending:[{txid, confirmations, target_confirmations, amount_base_units}] }` so the agent can report wait time. Partial failures are collected; all-failed surfaces as an MCP error. Self-contained — does **not** depend on the UI `AutoClaimMonitor` (which is tied to the selected UI account, not 4141). Each successful claim fires a `swap_completed` analytics event (provider `Native`, `native:bitcoin → native:spark`) via the `deps.trackSwapCompleted` hook — this path bypasses the TransferServiceManager, so `onTransferCompleted` would otherwise never run for it.
+
+Full agent flow: `get_spark_deposit_address` → `get_bitcoin_send_quote`/`execute_bitcoin_send` (send to that address) → wait 3 confirmations → `claim_spark_deposit`.
+
+Tests: `shared/tests/unit-vi/mcp-calls-spark-deposit.test.ts`.
+
 ## Tests
 
 - `shared/tests/unit-vi/transfer-service-sideshift.test.ts`

--- a/desktop/src/mainview/features/mcp/modules/mcp-platform.ts
+++ b/desktop/src/mainview/features/mcp/modules/mcp-platform.ts
@@ -7,6 +7,8 @@
 import { LayerzStorage } from '../../../class/layerz-storage';
 import { AnalyticsEvents } from '@shared/types/analytics';
 
+import { buildSwapCompletedProperties } from '@shared/modules/swap-analytics';
+
 import { trackAnalyticsEvent } from '../../../modules/analytics';
 import { BackgroundCaller } from '../../../modules/background-caller';
 import { showDesktopNotification } from '../../../modules/notifications';
@@ -23,6 +25,9 @@ export const desktopMcpDeps: McpCallDeps = {
   trackToolCall: (toolName) => {
     console.log('[mcp] tool call:', toolName);
     trackAnalyticsEvent(AnalyticsEvents.McpCall, { tool_name: toolName });
+  },
+  trackSwapCompleted: (execution) => {
+    trackAnalyticsEvent(AnalyticsEvents.SwapCompleted, buildSwapCompletedProperties(execution));
   },
 };
 

--- a/mobile/src/features/mcp/modules/mcp-platform.ts
+++ b/mobile/src/features/mcp/modules/mcp-platform.ts
@@ -20,6 +20,7 @@ import { LayerzStorage } from '@/src/class/layerz-storage';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { trackAnalyticsEvent } from '@/src/modules/analytics';
 import { AnalyticsEvents } from '@shared/types/analytics';
+import { buildSwapCompletedProperties } from '@shared/modules/swap-analytics';
 
 import type { AppLifecycle, McpCallDeps } from '@shared/features/mcp/modules/mcp-deps';
 
@@ -37,6 +38,9 @@ export const mobileMcpDeps: McpCallDeps = {
   },
   trackToolCall: (toolName) => {
     trackAnalyticsEvent(AnalyticsEvents.McpCall, { tool_name: toolName });
+  },
+  trackSwapCompleted: (execution) => {
+    trackAnalyticsEvent(AnalyticsEvents.SwapCompleted, buildSwapCompletedProperties(execution));
   },
 };
 

--- a/shared/class/wallets/ark-wallet.ts
+++ b/shared/class/wallets/ark-wallet.ts
@@ -792,16 +792,28 @@ export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLigh
   }
 
   async isInvoicePaid(invoice: string): Promise<boolean> {
+    const { paymentHash } = decodeInvoice(invoice);
+    if (!paymentHash) throw new Error('Payment hash not found in invoice');
+    return this.isInvoicePaidByHash(paymentHash);
+  }
+
+  async isInvoicePaidByHash(preimageHash: string): Promise<boolean> {
     assert(this._arkadeLightning, 'Ark Lightning not initialized');
+    if (!preimageHash) throw new Error('No preimage hash provided');
 
     await this._attemptToClaimPendingVHTLCs();
 
+    const target = preimageHash.toLowerCase();
     for (const swap of (await this._arkadeLightning.getSwapHistory()) ?? []) {
-      if (swap.status === 'invoice.settled' && swap.type === 'reverse' && swap.response.invoice === invoice) {
-        return true;
+      if (swap.status !== 'invoice.settled' || swap.type !== 'reverse') continue;
+      try {
+        const { paymentHash } = decodeInvoice(swap.response.invoice);
+        if (paymentHash?.toLowerCase() === target) return true;
+      } catch {
+        // ignore malformed persisted invoices, dont let one bad record break the lookup
       }
     }
-    return Promise.resolve(false);
+    return false;
   }
 
   async payLightningInvoice(invoice: string): Promise<boolean> {

--- a/shared/class/wallets/breez-wallet.ts
+++ b/shared/class/wallets/breez-wallet.ts
@@ -187,9 +187,15 @@ export class BreezWallet implements InterfaceLightningWallet, InterfaceSendQuota
       throw new Error('Payment hash not found in invoice');
     }
 
+    return this.isInvoicePaidByHash(paymentHash);
+  }
+
+  async isInvoicePaidByHash(preimageHash: string): Promise<boolean> {
+    if (!preimageHash) throw new Error('No preimage hash provided');
+
     const paymentByHash = await this.adapter.api.getPayment(this.connection, {
       type: 'paymentHash', // unreliable, could not find type for it, had to find it in breez sources and hardcode it
-      paymentHash,
+      paymentHash: preimageHash,
     });
 
     switch (

--- a/shared/class/wallets/interface-lightning-wallet.ts
+++ b/shared/class/wallets/interface-lightning-wallet.ts
@@ -24,12 +24,23 @@ export interface InterfaceLightningWallet {
 
   isInvoicePaid(invoice: string): Promise<boolean>;
 
+  /**
+   * Checks whether an invoice that this wallet issued has been paid, looking it up by the BOLT11
+   * payment hash (aka preimage hash, i.e. `sha256(preimage)`, hex-encoded).
+   *
+   * The argument is intentionally hash-only so callers do not have to retain the full BOLT11
+   * string after creating the invoice.
+   */
+  isInvoicePaidByHash(preimageHash: string): Promise<boolean>;
+
   fetchLightningLimits(): Promise<LightningPaymentLimitsResponse>;
 
   allowLightning(): boolean;
 }
 
-const REQUIRED_METHODS = ['payLightningInvoice', 'createLightningInvoice', 'isInvoicePaid', 'fetchLightningLimits', 'allowLightning'] as const satisfies ReadonlyArray<keyof InterfaceLightningWallet>;
+const REQUIRED_METHODS = ['payLightningInvoice', 'createLightningInvoice', 'isInvoicePaid', 'isInvoicePaidByHash', 'fetchLightningLimits', 'allowLightning'] as const satisfies ReadonlyArray<
+  keyof InterfaceLightningWallet
+>;
 
 /**
  * type guard

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -28,6 +28,12 @@ export interface ISparkAdapter {
 const STORAGE_KEY_NFT = 'SPARK_NFT_METADATA';
 const STORAGE_KEY = 'SPARK_TOKEN_METADATA';
 
+/**
+ * On-chain confirmations a Bitcoin deposit to the static deposit address needs before Spark lets us
+ * claim it. Per Spark docs; not exposed by the SDK, so this is the canonical source for it.
+ */
+export const SPARK_STATIC_DEPOSIT_CONFIRMATIONS = 3;
+
 // Static cache for token icon URLs that we fetched from the API
 const _tokenIconCache: Record<string, string> = {};
 
@@ -521,7 +527,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet, 
       const tx = txs1[output.txid];
       const timestamp = tx.blocktime ? tx.blocktime * 1000 : new Date().getTime();
       const confirmations = tx.confirmations ?? 0;
-      const claimable = confirmations >= 3; // according to Spark docs, 3 confirmations are needed to claim a swap
+      const claimable = confirmations >= SPARK_STATIC_DEPOSIT_CONFIRMATIONS;
       return {
         network: NETWORK_SPARK,
         id: output.txid,
@@ -532,7 +538,7 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet, 
         explorerUrl: `${explorerBase}/tx/${output.txid}`,
         // we only want to show confirmations for 'pending' swaps
         confirmations: !claimable ? confirmations : undefined,
-        targetConfirmations: !claimable ? 3 : undefined,
+        targetConfirmations: !claimable ? SPARK_STATIC_DEPOSIT_CONFIRMATIONS : undefined,
       };
     });
     swaps.push(...unclaimedSwaps);

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -240,6 +240,36 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet, 
     const id = (await this._readLnInvoiceIdMap())[invoice];
     if (!id) return false;
 
+    return this._isReceiveRequestPaid(id);
+  }
+
+  async isInvoicePaidByHash(preimageHash: string): Promise<boolean> {
+    if (!this._sdkWallet) throw new Error('Spark wallet not initialized');
+    if (!preimageHash) throw new Error('No preimage hash provided');
+
+    // we only persist invoice->id, not hash->id, so we decode every issued invoice we know about
+    // and find the one whose payment hash matches. the map is bounded by how many invoices this
+    // account has ever created, so a linear scan is fine.
+    const target = preimageHash.toLowerCase();
+    const map = await this._readLnInvoiceIdMap();
+    for (const [invoice, id] of Object.entries(map)) {
+      try {
+        const decoded = bolt11.decode(invoice);
+        for (const tag of decoded.tags) {
+          if (tag.tagName === 'payment_hash' && String(tag.data).toLowerCase() === target) {
+            return this._isReceiveRequestPaid(id);
+          }
+        }
+      } catch {
+        // ignore malformed persisted invoices, dont let one bad record break the lookup
+      }
+    }
+    return false;
+  }
+
+  private async _isReceiveRequestPaid(id: string): Promise<boolean> {
+    if (!this._sdkWallet) throw new Error('Spark wallet not initialized');
+
     const lightningPaymentStatus = await this._sdkWallet.getLightningReceiveRequest(id);
 
     if (lightningPaymentStatus?.status === 'LIGHTNING_PAYMENT_RECEIVED') return true;

--- a/shared/features/mcp/modules/mcp-calls.ts
+++ b/shared/features/mcp/modules/mcp-calls.ts
@@ -2103,7 +2103,8 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
         'Returns a quote for swapping `send_amount_base_units` of `send_asset` into `receive_asset`. Currently only BTC↔USDB on Spark. The response includes a `quote_id` you must pass verbatim to `execute_swap` to actually trade. Quotes expire at `expires_at_unix` (typically 60s, TELL USER HOW MUCH TIME IS LEFT); call this tool again after expiry. **No funds move on this call** — it only stages the swap so the user/agent can review fees before committing.\n\n' +
         MCP_BASE_UNITS_GUIDANCE +
         '\n\n**Where `send_amount_base_units` comes from:** call `get_network_balance` on `spark` for `native:spark` (BTC/sats), or `list_tokens` on `spark` for `token:spark:usdb` — copy `balance_base_units` verbatim (or a smaller amount ≤ balance). The wallet converts base units → human amount internally; you must not multiply by `10^decimals` before calling this tool.\n\n' +
-        '**Present the EXACT outcome to the user with zero mental math.** `receive_amount_base_units`, `effective_exchange_rate`, and `rate` are all already net of the AMM fee — quote them verbatim, do **NOT** subtract anything on top.\n\n' +
+        '**Present the EXACT outcome to the user with zero mental math.** The response already contains both machine units (`*_base_units`) and ready-to-show decimal strings (`send_amount_human_readable`, `receive_amount_human_readable`); `receive_amount_*`, `effective_exchange_rate`, and `rate` are all already net of the AMM fee — quote them verbatim, do **NOT** subtract anything on top.\n\n' +
+        '- `send_amount_human_readable` / `receive_amount_human_readable`: precomputed decimal strings (e.g. "0.001", "99.5") for the send and receive amounts. **Quote these verbatim to the user** (with the asset ticker); never divide a `*_base_units` value by `10^decimals` yourself — the wallet has already done the decimal math.\n' +
         '- `effective_exchange_rate`: precomputed BTC price in USDB the user is actually paying, factoring in fees (e.g. "99500.00"). Always normalized to USDB-per-BTC regardless of swap direction, so the user can compare it directly to a market BTC price. Prefer this over `rate` when presenting — `rate` reads poorly in the USDB→BTC direction ("1 USDB = 0.00001 BTC").\n' +
         '- `effective_fee_rate`: precomputed `fee_base_units / send_amount_base_units × 100` as a percent string. Always surface it for transparency about what the AMM is keeping — but show it as transparency, **not** as a further deduction on top of the rate/amounts.\n\n' +
         'Good: "You\'ll send 0.001 BTC and receive 99.5 USDB (effective price: 99,500 USDB per BTC, includes a 0.4% AMM fee)."\n' +
@@ -2153,6 +2154,11 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
 
         const receiveAmountBaseUnits = new BigNumber(quote.receiveAmount).times(new BigNumber(10).pow(receiveInfo.decimals)).integerValue(BigNumber.ROUND_FLOOR).toFixed(0);
 
+        // Human-readable decimal strings derived from the exact base-unit values we return, so the
+        // two always agree. The agent must NOT recompute these — quote them verbatim to the user.
+        const sendAmountHumanReadable = mcpBaseUnitsToHumanReadable(send_amount_base_units, sendInfo.decimals);
+        const receiveAmountHumanReadable = mcpBaseUnitsToHumanReadable(receiveAmountBaseUnits, receiveInfo.decimals);
+
         // Trading fee as a percentage of the user's input (e.g. "0.4000" for 0.4%).
         // Kept as smallest-unit math (fee_base_units / send_amount_base_units) so it stays exact
         // regardless of asset decimals. `quote.rate` is already the post-fee effective rate,
@@ -2187,7 +2193,9 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
                   send_asset,
                   receive_asset,
                   send_amount_base_units,
+                  send_amount_human_readable: sendAmountHumanReadable,
                   receive_amount_base_units: receiveAmountBaseUnits,
+                  receive_amount_human_readable: receiveAmountHumanReadable,
                   fee_base_units: feeBaseUnitsStr,
                   fee_asset: send_asset,
                   fee_ticker: quote.feeTicker,
@@ -2221,7 +2229,7 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
     {
       title: 'Execute a previously quoted swap',
       description:
-        'Executes the swap staged by an earlier `get_swap_quote` call. Pass `quote_id` exactly as returned. The trade is atomic (a few seconds, no on-chain confirmations on Spark) and **irreversible** once it returns success. Each `quote_id` can only be executed **once**; expired or already-executed quotes return an error and you must re-quote. Slippage is capped at 3% (300 bps); execution fails rather than filling beyond that.',
+        'Executes the swap staged by an earlier `get_swap_quote` call. Pass `quote_id` exactly as returned. The trade is atomic (a few seconds, no on-chain confirmations on Spark) and **irreversible** once it returns success. Each `quote_id` can only be executed **once**; expired or already-executed quotes return an error and you must re-quote. Slippage is capped at 3% (300 bps); execution fails rather than filling beyond that.\n\nThe response returns both `*_base_units` and ready-to-show `send_amount_human_readable` / `receive_amount_human_readable` decimal strings — **quote the human-readable values verbatim** to the user; never divide base units by `10^decimals` yourself.',
       inputSchema: {
         quote_id: z.string().min(1).describe('Exact `quote_id` from `get_swap_quote` — copy verbatim. Leading/trailing whitespace is trimmed.'),
       },
@@ -2256,6 +2264,8 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
         const receiveInfo = getAssetInfo(completed.receiveAsset);
         const receiveBaseUnits = new BigNumber(completed.receiveAmount).times(new BigNumber(10).pow(receiveInfo.decimals)).integerValue(BigNumber.ROUND_FLOOR).toFixed(0);
         const sendBaseUnits = new BigNumber(completed.sendAmount).times(new BigNumber(10).pow(sendInfo.decimals)).integerValue(BigNumber.ROUND_FLOOR).toFixed(0);
+        const sendAmountHumanReadable = mcpBaseUnitsToHumanReadable(sendBaseUnits, sendInfo.decimals);
+        const receiveAmountHumanReadable = mcpBaseUnitsToHumanReadable(receiveBaseUnits, receiveInfo.decimals);
         const summary = `${completed.sendAmount} ${sendInfo.ticker} \u2192 ${completed.receiveAmount} ${receiveInfo.ticker}`;
 
         mcpCallLog(`execute_swap: ok - ${summary}`);
@@ -2272,7 +2282,9 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
                   send_asset: completed.sendAsset,
                   receive_asset: completed.receiveAsset,
                   send_amount_base_units: sendBaseUnits,
+                  send_amount_human_readable: sendAmountHumanReadable,
                   receive_amount_base_units: receiveBaseUnits,
+                  receive_amount_human_readable: receiveAmountHumanReadable,
                   service: completed.serviceName,
                 },
                 null,

--- a/shared/features/mcp/modules/mcp-calls.ts
+++ b/shared/features/mcp/modules/mcp-calls.ts
@@ -1688,7 +1688,7 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
     'create_lightning_invoice',
     {
       title: 'Create Lightning invoice (BOLT11)',
-      description: `Creates a BOLT11 receive invoice on \`network\`: ${MCP_LIGHTNING_PAY_NETWORKS.join(',')} (same layers as pay_lightning_invoice). \`sats\` is the amount to request. Optional \`memo\` is the invoice description. Response includes the bolt11 string in \`invoice\`. Handle \`invoice\` extra carefully - it must be passed exactly - malformed/mangled invoices will not work; dont rely on chat transcription, use EXACT values as returned by MCP.`,
+      description: `Creates a BOLT11 receive invoice on \`network\`: ${MCP_LIGHTNING_PAY_NETWORKS.join(',')} (same layers as pay_lightning_invoice). \`sats\` is the amount to request. Optional \`memo\` is the invoice description. Response includes the BOLT11 string in \`invoice\` and the BOLT11 payment hash in \`payment_hash\` (64 hex chars). Track payment status with \`is_invoice_paid\` using the \`payment_hash\`. Handle \`payment_hash\` extra carefully - it must be passed exactly - malformed/mangled strings will not work; dont rely on chat transcription, use EXACT values as returned by MCP.`,
       inputSchema: {
         sats: z.number().int().positive().describe('Requested amount in satoshis.'),
         memo: z.string().optional().describe('Optional description / memo on the invoice.'),
@@ -1714,7 +1714,9 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
         }
 
         const { invoice, serviceFeeSat } = await w.createLightningInvoice(sats, memo ?? '');
-        mcpCallLog(`create_lightning_invoice: ok - ${network}, ${sats} sats, service fee ${serviceFeeSat} sats, invoice starts ${bolt11Preview(invoice)}`);
+        const paymentHash = String(bolt11.decode(invoice).tags.find((t) => t.tagName === 'payment_hash')?.data ?? '');
+        if (!paymentHash) throw new Error('payment_hash tag not found in BOLT11 invoice');
+        mcpCallLog(`create_lightning_invoice: ok - ${network}, ${sats} sats, service fee ${serviceFeeSat} sats, invoice starts ${bolt11Preview(invoice)}, payment_hash ${paymentHash}`);
         showMcpSuccess(deps, 'Created Lightning invoice', `${memo ?? ''} ${network} · ${sats} sats`);
         return {
           content: [
@@ -1723,6 +1725,7 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
               text: JSON.stringify(
                 {
                   invoice,
+                  payment_hash: paymentHash,
                   network,
                   sats,
                   ...(memo != null && memo !== '' ? { memo } : {}),
@@ -1749,32 +1752,19 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
     'is_invoice_paid',
     {
       title: 'Check if Lightning invoice is paid',
-      description: `Returns whether the given BOLT11 invoice that we created has been paid, as seen by this wallet on \`network\` (${MCP_LIGHTNING_PAY_NETWORKS.join(',')}). Use the same network the invoice was created on.`,
+      description: `Returns whether an invoice that we created has been paid, looked up by its BOLT11 payment hash (the \`payment_hash\` field returned from \`create_lightning_invoice\`). Use the same network the invoice was created on (${MCP_LIGHTNING_PAY_NETWORKS.join(',')}).`,
       inputSchema: {
-        invoice: z.string().min(1).describe('BOLT11 invoice (lnbc…) or lightning:lnbc… URI.'),
+        payment_hash: z
+          .string()
+          .regex(/^[0-9a-fA-F]{64}$/, 'payment_hash must be 64 hex chars (the `payment_hash` field returned from create_lightning_invoice).')
+          .describe('BOLT11 payment hash, 64-char hex string. Returned as `payment_hash` from create_lightning_invoice.'),
         network: mcpLightningPayNetworkSchema.describe(`Wallet layer: ${MCP_LIGHTNING_PAY_NETWORKS.join(',')}.`),
       },
     },
-    async ({ invoice: invoiceRaw, network }) => {
-      const invoice = normalizeBolt11Invoice(invoiceRaw);
-      mcpCallLog(`is_invoice_paid: start - ${network}, invoice ${bolt11Preview(invoice)}`);
+    async ({ payment_hash: paymentHashRaw, network }) => {
+      const paymentHash = paymentHashRaw.trim().toLowerCase();
+      mcpCallLog(`is_invoice_paid: start - ${network}, payment_hash ${paymentHash}`);
       trackMcpCall(deps, 'is_invoice_paid');
-
-      try {
-        bolt11.decode(invoice);
-      } catch (e) {
-        const message = e instanceof Error ? e.message : String(e);
-        mcpCallLog(`is_invoice_paid: error - invalid BOLT11: ${message}`);
-        return {
-          isError: true,
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({ error: `Invalid BOLT11 invoice: ${message}`, network }, null, 2),
-            },
-          ],
-        };
-      }
 
       showMcpSuccess(deps, 'Checking if Lightning invoice is paid');
 
@@ -1793,13 +1783,13 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
           };
         }
 
-        const paid = await w.isInvoicePaid(invoice);
+        const paid = await w.isInvoicePaidByHash(paymentHash);
         mcpCallLog(`is_invoice_paid: ok - ${network}, paid=${paid}`);
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify({ paid, network }, null, 2),
+              text: JSON.stringify({ paid, network, payment_hash: paymentHash }, null, 2),
             },
           ],
         };

--- a/shared/features/mcp/modules/mcp-calls.ts
+++ b/shared/features/mcp/modules/mcp-calls.ts
@@ -16,6 +16,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as BlueElectrum from '../../../blue_modules/BlueElectrum';
 import { EvmWallet } from '../../../class/evm-wallet';
 import { BreezWallet, LBTC_ASSET_IDS } from '../../../class/wallets/breez-wallet';
+import { SparkWallet, SPARK_STATIC_DEPOSIT_CONFIRMATIONS } from '../../../class/wallets/spark-wallet';
 import { walletCanHaveNfts } from '../../../class/wallets/interface-can-have-nfts';
 import { walletCanHaveTokens } from '../../../class/wallets/interface-can-have-tokens';
 import { walletIsAccountBased } from '../../../class/wallets/interface-account-based-wallet';
@@ -47,7 +48,7 @@ import {
   NETWORK_USDT,
   type Networks,
 } from '../../../types/networks';
-import { EXECUTION_INSTANT } from '../../../types/transfer';
+import { EXECUTION_CLAIM, EXECUTION_INSTANT, type NativeClaimExecution } from '../../../types/transfer';
 
 import { pushMcpActivityLog } from './mcp-activity-log';
 import { MCP_LIGHTNING_PAY_MAX_FEE_PERCENT } from './mcp-constants';
@@ -1272,6 +1273,211 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
         return {
           isError: true,
           content: [{ type: 'text', text: JSON.stringify({ error: message, network: NETWORK_BITCOIN }, null, 2) }],
+        };
+      }
+    }
+  );
+
+  // ── On-chain BTC → Spark (deposit + claim) ──────────────────────────────────────────────────────
+  // Moving native (L1) BTC into the Spark balance is a deposit-address flow, not an instant swap, so
+  // it can't ride on get_swap_quote/execute_swap (those are Flashnet's atomic in-wallet trades). It
+  // composes the existing Bitcoin send tools instead: get_spark_deposit_address → get_bitcoin_send_quote
+  // → execute_bitcoin_send → (3 confirmations) → claim_spark_deposit. The deposit address is the
+  // SparkWallet's static on-chain address; claiming credits the confirmed UTXO(s) to the Spark balance.
+
+  mcp.registerTool(
+    'get_spark_deposit_address',
+    {
+      title: 'Get the on-chain Bitcoin deposit address for Spark',
+      description:
+        "Returns the wallet's **static on-chain Bitcoin deposit address** for funding the Spark balance with native (L1) BTC. This is NOT the same as `get_receive_address` for `spark` (which returns a `spark1…` address for Spark-native transfers) — this is a Bitcoin `bc1…` address you send on-chain BTC to.\n\n" +
+        'Full flow to move on-chain BTC into Spark:\n' +
+        '1. Call this tool to get the `deposit_address`.\n' +
+        '2. Send BTC to it on-chain with `get_bitcoin_send_quote` (`receiver_address` = this address) then `execute_bitcoin_send`. An external sender works too.\n' +
+        `3. Wait for **${SPARK_STATIC_DEPOSIT_CONFIRMATIONS} on-chain confirmations** (~30+ min).\n` +
+        '4. Call `claim_spark_deposit` to credit the funds to the Spark balance.\n\n' +
+        'The address is static and reusable — it can receive multiple deposits. Read-only; no funds move.',
+    },
+    async () => {
+      mcpCallLog('get_spark_deposit_address: start');
+      trackMcpCall(deps, 'get_spark_deposit_address');
+      try {
+        const w = await backgroundCaller.lazyInitWallet(NETWORK_SPARK, MCP_BALANCE_ACCOUNT_NUMBER);
+        if (!(w instanceof SparkWallet)) {
+          mcpCallLog('get_spark_deposit_address: error - wallet does not support Spark deposits');
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Wallet does not support on-chain Spark deposits.', network: NETWORK_SPARK }, null, 2) }],
+          };
+        }
+
+        const deposit_address = await w.getOnchainDepositAddress();
+        mcpCallLog(`get_spark_deposit_address: ok - ${deposit_address.slice(0, 16)}…`);
+        showMcpSuccess(deps, 'Spark deposit address', deposit_address.slice(0, 12) + '…');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  network: NETWORK_SPARK,
+                  deposit_address,
+                  deposit_chain: NETWORK_BITCOIN,
+                  confirmations_required: SPARK_STATIC_DEPOSIT_CONFIRMATIONS,
+                  next_step: `Send on-chain BTC to deposit_address via get_bitcoin_send_quote + execute_bitcoin_send, then call claim_spark_deposit once it has ${SPARK_STATIC_DEPOSIT_CONFIRMATIONS} confirmations.`,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        mcpCallLog(`get_spark_deposit_address: error - ${message}`);
+        return {
+          isError: true,
+          content: [{ type: 'text', text: JSON.stringify({ error: message, network: NETWORK_SPARK }, null, 2) }],
+        };
+      }
+    }
+  );
+
+  mcp.registerTool(
+    'claim_spark_deposit',
+    {
+      title: 'Claim on-chain BTC deposited to the Spark address',
+      description: `Credits on-chain BTC sent to the Spark deposit address (see \`get_spark_deposit_address\`) into the Spark balance. A deposit becomes claimable only after **${SPARK_STATIC_DEPOSIT_CONFIRMATIONS} on-chain confirmations**. By default this claims **every** currently-claimable deposit; pass \`txid\` to claim one specific deposit. Returns each claimed deposit with its Spark \`transfer_id\` and \`credited_base_units\` (sats). If nothing is claimable yet, returns the \`pending\` deposits with their confirmation progress so you can tell the user how long to wait. Each deposit can only be claimed once.`,
+      inputSchema: {
+        txid: z
+          .string()
+          .min(1)
+          .optional()
+          .describe(
+            "Optional: the on-chain deposit txid to claim (the `transfer_id` from `execute_bitcoin_send`, or a txid from this tool's `pending` list). Omit to claim every claimable deposit. Leading/trailing whitespace is trimmed."
+          ),
+      },
+    },
+    async ({ txid }) => {
+      const wantTxid = txid?.trim();
+      mcpCallLog(`claim_spark_deposit: start${wantTxid ? ` - txid ${wantTxid}` : ' - all claimable'}`);
+      trackMcpCall(deps, 'claim_spark_deposit');
+      try {
+        const w = await backgroundCaller.lazyInitWallet(NETWORK_SPARK, MCP_BALANCE_ACCOUNT_NUMBER);
+        if (!(w instanceof SparkWallet)) {
+          mcpCallLog('claim_spark_deposit: error - wallet does not support Spark deposits');
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Wallet does not support on-chain Spark deposits.', network: NETWORK_SPARK }, null, 2) }],
+          };
+        }
+
+        const swaps = await w.getCommonSwaps();
+        const claimable = swaps.filter((s) => s.status === 'claimable' && (!wantTxid || s.id === wantTxid));
+
+        if (claimable.length === 0) {
+          const pending = swaps
+            .filter((s) => s.status === 'pending' && (!wantTxid || s.id === wantTxid))
+            .map((s) => ({
+              txid: s.id,
+              confirmations: s.confirmations ?? 0,
+              target_confirmations: s.targetConfirmations ?? SPARK_STATIC_DEPOSIT_CONFIRMATIONS,
+              amount_base_units: s.amount != null ? String(s.amount) : null,
+            }));
+          mcpCallLog(`claim_spark_deposit: nothing claimable (${pending.length} pending)`);
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    claimed: [],
+                    pending,
+                    message: wantTxid
+                      ? `Deposit ${wantTxid} is not claimable yet (needs ${SPARK_STATIC_DEPOSIT_CONFIRMATIONS} confirmations) or was not found.`
+                      : `No claimable deposits. Pending deposits (if any) need ${SPARK_STATIC_DEPOSIT_CONFIRMATIONS} confirmations.`,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        const claimed: { txid: string; transfer_id?: string; credited_base_units: string }[] = [];
+        const failed: { txid: string; error: string }[] = [];
+        for (const swap of claimable) {
+          try {
+            const quote = await w.getDepositQuote(swap.id);
+            const transferId = await w.claimDepositSpark(quote);
+            claimed.push({ txid: swap.id, transfer_id: transferId, credited_base_units: String(quote.creditAmountSats) });
+
+            // Count the claim as a completed BTC → Spark swap. This path bypasses the
+            // TransferServiceManager (so `onTransferCompleted` never fires for it), so we emit the
+            // `swap_completed` event ourselves via the platform-injected hook. Provider 'Native' and the
+            // BTC→Spark asset pair mirror what the UI-driven NativeDeposit flow reports.
+            const now = Math.floor(Date.now() / 1000);
+            const creditBtc = new BigNumber(quote.creditAmountSats).div(1e8).toFixed();
+            const completedExecution: NativeClaimExecution = {
+              type: EXECUTION_CLAIM,
+              id: transferId ?? swap.id,
+              status: 'completed',
+              sendAsset: 'native:bitcoin',
+              receiveAsset: 'native:spark',
+              sendAmount: creditBtc,
+              receiveAmount: creditBtc,
+              createdAt: swap.timestamp ? Math.floor(swap.timestamp / 1000) : now,
+              updatedAt: now,
+              accountNumber: MCP_BALANCE_ACCOUNT_NUMBER,
+              serviceName: 'Native',
+              depositTxid: swap.id,
+              receiveTransferId: transferId,
+              autoClaim: false,
+              autoClaimAttempts: 0,
+            };
+            deps.trackSwapCompleted?.(completedExecution);
+          } catch (e) {
+            failed.push({ txid: swap.id, error: e instanceof Error ? e.message : String(e) });
+          }
+        }
+
+        if (claimed.length === 0) {
+          mcpCallLog(`claim_spark_deposit: error - all ${failed.length} claim(s) failed`);
+          return {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ error: 'All claim attempts failed.', network: NETWORK_SPARK, failed }, null, 2) }],
+          };
+        }
+
+        const totalSats = claimed.reduce((acc, c) => acc + Number(c.credited_base_units), 0);
+        mcpCallLog(`claim_spark_deposit: ok - claimed ${claimed.length}, ${totalSats} sats${failed.length ? `, ${failed.length} failed` : ''}`);
+        showMcpSuccess(deps, 'Claimed Spark deposit', `${claimed.length} deposit(s) · ${totalSats} sats`);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  network: NETWORK_SPARK,
+                  claimed,
+                  failed: failed.length ? failed : undefined,
+                  total_credited_base_units: String(totalSats),
+                  fee_ticker: 'BTC',
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        mcpCallLog(`claim_spark_deposit: error - ${message}`);
+        return {
+          isError: true,
+          content: [{ type: 'text', text: JSON.stringify({ error: message, network: NETWORK_SPARK }, null, 2) }],
         };
       }
     }

--- a/shared/features/mcp/modules/mcp-calls.ts
+++ b/shared/features/mcp/modules/mcp-calls.ts
@@ -1688,15 +1688,16 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
     'create_lightning_invoice',
     {
       title: 'Create Lightning invoice (BOLT11)',
-      description: `Creates a BOLT11 receive invoice on \`network\`: ${MCP_LIGHTNING_PAY_NETWORKS.join(',')} (same layers as pay_lightning_invoice). \`sats\` is the amount to request. Optional \`memo\` is the invoice description. Response includes the BOLT11 string in \`invoice\` and the BOLT11 payment hash in \`payment_hash\` (64 hex chars). Track payment status with \`is_invoice_paid\` using the \`payment_hash\`. Handle \`payment_hash\` extra carefully - it must be passed exactly - malformed/mangled strings will not work; dont rely on chat transcription, use EXACT values as returned by MCP.`,
+      description: `Creates a BOLT11 receive invoice on \`network\`: ${MCP_LIGHTNING_PAY_NETWORKS.join(',')} (same layers as pay_lightning_invoice). If \`network\` is omitted it defaults to \`${NETWORK_SPARK}\`. \`sats\` is the amount to request. Optional \`memo\` is the invoice description. Response includes the BOLT11 string in \`invoice\` and the BOLT11 payment hash in \`payment_hash\` (64 hex chars). Track payment status with \`is_invoice_paid\` using the \`payment_hash\`. Handle \`payment_hash\` extra carefully - it must be passed exactly - malformed/mangled strings will not work; dont rely on chat transcription, use EXACT values as returned by MCP.`,
       inputSchema: {
         sats: z.number().int().positive().describe('Requested amount in satoshis.'),
         memo: z.string().optional().describe('Optional description / memo on the invoice.'),
-        network: mcpLightningPayNetworkSchema.describe(`Wallet layer: ${MCP_LIGHTNING_PAY_NETWORKS.join(',')}.`),
+        network: mcpLightningPayNetworkSchema.optional().describe(`Wallet layer: ${MCP_LIGHTNING_PAY_NETWORKS.join(',')}. Defaults to \`${NETWORK_SPARK}\` when omitted.`),
       },
     },
-    async ({ sats, memo, network }) => {
-      mcpCallLog(`create_lightning_invoice: start - ${network}, ${sats} sats${memo?.trim() ? ', memo set' : ''}`);
+    async ({ sats, memo, network: networkRaw }) => {
+      const network = networkRaw ?? NETWORK_SPARK;
+      mcpCallLog(`create_lightning_invoice: start - ${network}, ${sats} sats${memo?.trim() ? ' (' + memo?.trim() + ')' : ''}`);
       trackMcpCall(deps, 'create_lightning_invoice');
       try {
         const w = await backgroundCaller.lazyInitWallet(network, MCP_BALANCE_ACCOUNT_NUMBER);
@@ -1713,7 +1714,7 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
           };
         }
 
-        const { invoice, serviceFeeSat } = await w.createLightningInvoice(sats, memo ?? '');
+        const { invoice, serviceFeeSat } = await w.createLightningInvoice(sats, memo ?? 'Created by Layerz Wallet AI');
         const paymentHash = String(bolt11.decode(invoice).tags.find((t) => t.tagName === 'payment_hash')?.data ?? '');
         if (!paymentHash) throw new Error('payment_hash tag not found in BOLT11 invoice');
         mcpCallLog(`create_lightning_invoice: ok - ${network}, ${sats} sats, service fee ${serviceFeeSat} sats, invoice starts ${bolt11Preview(invoice)}, payment_hash ${paymentHash}`);

--- a/shared/features/mcp/modules/mcp-calls.ts
+++ b/shared/features/mcp/modules/mcp-calls.ts
@@ -1278,6 +1278,101 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
     }
   );
 
+  mcp.registerTool(
+    'get_bitcoin_transaction',
+    {
+      title: 'Look up a Bitcoin transaction by txid',
+      description:
+        'Fetches an on-chain Bitcoin transaction by `txid` (the `transfer_id` returned by `execute_bitcoin_send`, or any other Bitcoin txid). Returns confirmation status, block info, size, and a compact summary of inputs/outputs (output addresses + amounts). Use this to check whether a send has confirmed and how deep, or to inspect any Bitcoin transaction. Read-only; no funds move.\n\n' +
+        'Output amounts are in sats (`value_base_units`) — same scale as `get_network_balance` for bitcoin — and are paired with `value_human_readable` (BTC, with `ticker` on the payload). `status` is `confirmed` when `confirmations >= 1`, otherwise `mempool`. Input prevouts are returned as `{txid, vout}` pointers; input amounts (and therefore the fee) are not reconstructed (would require N+1 lookups). Quote `*_human_readable` to the user; use `*_base_units` only for further programmatic calls.',
+      inputSchema: {
+        txid: z
+          .string()
+          .regex(/^[0-9a-fA-F]{64}$/, 'txid must be a 64-char hex string (as returned by `execute_bitcoin_send` in `transfer_id`).')
+          .describe('Bitcoin transaction id, 64-char hex. Pass exactly as returned by `execute_bitcoin_send` (`transfer_id`) — do not transcribe from chat.'),
+      },
+    },
+    async ({ txid }) => {
+      const txidNorm = txid.trim().toLowerCase();
+      mcpCallLog(`get_bitcoin_transaction: start - ${txidNorm}`);
+      trackMcpCall(deps, 'get_bitcoin_transaction');
+      try {
+        if (!BlueElectrum.mainConnected) await BlueElectrum.connectMain();
+        const result = await BlueElectrum.multiGetTransactionByTxid([txidNorm], true);
+        const tx = result[txidNorm];
+        if (!tx) {
+          mcpCallLog(`get_bitcoin_transaction: not found - ${txidNorm}`);
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    error: 'Transaction not found. The txid may be invalid, not yet broadcast, or evicted from the mempool.',
+                    txid: txidNorm,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        const confirmations = typeof tx.confirmations === 'number' ? tx.confirmations : 0;
+        const status = confirmations >= 1 ? 'confirmed' : 'mempool';
+
+        const btcDecimals = getDecimalsByNetwork(NETWORK_BITCOIN);
+
+        let totalOutputSats = new BigNumber(0);
+        const outputs = (tx.vout ?? []).map((o) => {
+          const sats = new BigNumber(o.value).multipliedBy(1e8).integerValue(BigNumber.ROUND_HALF_UP).toFixed(0);
+          totalOutputSats = totalOutputSats.plus(sats);
+          return {
+            n: o.n,
+            value_base_units: sats,
+            value_human_readable: mcpBaseUnitsToHumanReadable(sats, btcDecimals),
+            address: o.scriptPubKey?.addresses?.[0] ?? null,
+          };
+        });
+
+        const inputs = (tx.vin ?? []).map((i) => ({ txid: i.txid, vout: i.vout }));
+
+        const totalOutput = totalOutputSats.toFixed(0);
+        const payload = {
+          txid: tx.txid,
+          status,
+          confirmations,
+          blockhash: tx.blockhash || null,
+          block_time: tx.blocktime || tx.time || null,
+          size: tx.size,
+          vsize: tx.vsize,
+          input_count: inputs.length,
+          inputs,
+          output_count: outputs.length,
+          outputs,
+          total_output_base_units: totalOutput,
+          total_output_human_readable: mcpBaseUnitsToHumanReadable(totalOutput, btcDecimals),
+          ticker: getTickerByNetwork(NETWORK_BITCOIN),
+        };
+
+        mcpCallLog(`get_bitcoin_transaction: ok - ${txidNorm} ${status} confirmations=${confirmations}`);
+        showMcpSuccess(deps, 'Fetched Bitcoin transaction', `${status} · ${confirmations} conf`);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+        };
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        mcpCallLog(`get_bitcoin_transaction: error - ${message}`);
+        return {
+          isError: true,
+          content: [{ type: 'text', text: JSON.stringify({ error: message, txid: txidNorm }, null, 2) }],
+        };
+      }
+    }
+  );
+
   // ── On-chain BTC → Spark (deposit + claim) ──────────────────────────────────────────────────────
   // Moving native (L1) BTC into the Spark balance is a deposit-address flow, not an instant swap, so
   // it can't ride on get_swap_quote/execute_swap (those are Flashnet's atomic in-wallet trades). It

--- a/shared/features/mcp/modules/mcp-deps.ts
+++ b/shared/features/mcp/modules/mcp-deps.ts
@@ -9,6 +9,7 @@
 
 import type { IBackgroundCaller } from '../../../types/IBackgroundCaller';
 import type { IStorage } from '../../../types/IStorage';
+import type { TransferExecution } from '../../../types/transfer';
 
 /**
  * Wallet-tool dependencies. Supplied once via `configureMcp(...)` (see `./mcp.ts`)
@@ -28,6 +29,14 @@ export type McpCallDeps = {
   showSuccessToast?: (summary: string, detail?: string) => void;
   /** Analytics hook called on every tool invocation (`{ tool_name }` payload at the call site). */
   trackToolCall?: (toolName: string) => void;
+  /**
+   * Fire the `swap_completed` analytics event for an MCP-driven transfer that completes outside the
+   * TransferServiceManager (so `onTransferCompleted` never runs for it) — today, a successful
+   * `claim_spark_deposit` (on-chain BTC → Spark deposit). Platforms wire this to
+   * `trackAnalyticsEvent(SwapCompleted, buildSwapCompletedProperties(execution))`, the same call the
+   * UI/manager path uses, so the event schema stays identical.
+   */
+  trackSwapCompleted?: (execution: TransferExecution) => void;
 };
 
 /**

--- a/shared/features/mcp/modules/mcp-instructions.ts
+++ b/shared/features/mcp/modules/mcp-instructions.ts
@@ -39,9 +39,11 @@ export const MCP_SERVER_INSTRUCTIONS = [
   '3. Present the quote to the user; pass `quote_id` verbatim to `execute_swap`. Quotes expire in ~60s.',
   '4. `get_swap_quote` does not move funds; `execute_swap` is irreversible.',
   '',
-  '**Tokens & IDs:** Copy `token_id`, `quote_id`, and BOLT11 invoices exactly from tool JSON — never from chat summaries.',
+  '**Tokens & IDs:** Copy `token_id`, `quote_id`, BOLT11 invoices, and `payment_hash` exactly from tool JSON — never from chat summaries.',
   '',
-  '**Lightning:** `pay_lightning_invoice` blocks until done (often 15–60s+). Use HTTP read timeout ≥120s. Do not retry the same invoice without checking payment status.',
+  '**Lightning:**',
+  '- `pay_lightning_invoice` blocks until done (often 15–60s+). Use HTTP read timeout ≥120s. Do not retry the same invoice without checking payment status.',
+  '- `create_lightning_invoice` returns both `invoice` (BOLT11) and `payment_hash`. To check if it was paid, call `is_invoice_paid` with the `payment_hash`.',
   '',
   '**Networks:** Call `list_networks` first; use network ids exactly as returned.',
 ].join('\n');

--- a/shared/features/mcp/modules/mcp-instructions.ts
+++ b/shared/features/mcp/modules/mcp-instructions.ts
@@ -36,7 +36,7 @@ export const MCP_SERVER_INSTRUCTIONS = [
   '**Swaps (Spark BTC ↔ USDB):**',
   '1. `get_network_balance` (network `spark`) for selling BTC, or `list_tokens` (network `spark`) for selling USDB.',
   '2. Copy `balance_base_units` verbatim into `get_swap_quote` `send_amount_base_units` (or a smaller integer ≤ balance).',
-  '3. Present the quote to the user; pass `quote_id` verbatim to `execute_swap`. Quotes expire in ~60s.',
+  '3. Present the quote to the user using `send_amount_human_readable` / `receive_amount_human_readable` (already decimal-corrected — never divide base units yourself); pass `quote_id` verbatim to `execute_swap`. Quotes expire in ~60s.',
   '4. `get_swap_quote` does not move funds; `execute_swap` is irreversible.',
   '',
   '**Tokens & IDs:** Copy `token_id`, `quote_id`, BOLT11 invoices, and `payment_hash` exactly from tool JSON — never from chat summaries.',

--- a/shared/tests/unit-vi/mcp-calls-spark-deposit.test.ts
+++ b/shared/tests/unit-vi/mcp-calls-spark-deposit.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests the two on-chain BTC → Spark MCP tools: `get_spark_deposit_address` and `claim_spark_deposit`.
+ *
+ * Moving native (L1) BTC into the Spark balance is a deposit-address flow, not an instant swap, so it
+ * composes the existing Bitcoin send tools: get_spark_deposit_address → get_bitcoin_send_quote →
+ * execute_bitcoin_send → (3 confirmations) → claim_spark_deposit. These tools are thin adapters over
+ * the SparkWallet's `getOnchainDepositAddress` / `getCommonSwaps` / `getDepositQuote` /
+ * `claimDepositSpark`, so we mock `backgroundCaller.lazyInitWallet` to return a fake Spark wallet.
+ *
+ * These tests pin:
+ *  - address: happy path returns the static deposit address + confirmations_required; a non-SparkWallet
+ *    is rejected (instanceof guard).
+ *  - claim: claims every claimable (>=3 conf) deposit and returns transfer_id + credited sats; a `txid`
+ *    arg claims only that one; nothing-claimable returns the pending list with confirmation progress; a
+ *    per-deposit claim failure is collected (partial success) while all-failed surfaces as an MCP error.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { MCP_BALANCE_ACCOUNT_NUMBER } from '../../hooks/AccountNumberContext';
+import { registerWalletMcpCalls } from '../../features/mcp/modules/mcp-calls';
+import type { McpCallDeps } from '../../features/mcp/modules/mcp-deps';
+import { NETWORK_SPARK } from '../../types/networks';
+
+// Heavy module graph pulled in at import time by mcp-calls.ts — stub it so the surface stays cheap and
+// deterministic (mirrors the other mcp-calls unit tests).
+vi.mock('@flashnet/sdk', () => ({ FlashnetClient: vi.fn(), isFlashnetError: vi.fn().mockReturnValue(false) }));
+vi.mock('@buildonspark/spark-sdk', () => ({ isValidSparkAddress: vi.fn().mockReturnValue(true) }));
+vi.mock('../../hooks/useTransferService', () => ({ useTransferService: vi.fn(), getTransferServiceManager: vi.fn(), setFlashnetAccountNumber: vi.fn() }));
+vi.mock('../../hooks/useExchangeRate', () => ({ exchangeRateFetcher: vi.fn() }));
+vi.mock('../../hooks/useBalance', () => ({ balanceFetcher: vi.fn() }));
+vi.mock('../../hooks/useTokenBalance', () => ({ tokenBalanceFetcher: vi.fn() }));
+vi.mock('../../features/mcp/modules/mcp-activity-log', () => ({ pushMcpActivityLog: vi.fn() }));
+vi.mock('../../modules/wallet-utils', () => ({ validateAddress: vi.fn().mockReturnValue(true) }));
+vi.mock('../../blue_modules/BlueElectrum', () => ({ estimateFees: vi.fn(), connectMain: vi.fn(), mainConnected: false }));
+
+// mcp-calls narrows the Spark wallet via `instanceof SparkWallet`, so the fake wallet must be a real
+// instance of the (mocked) class. The deposit/claim methods delegate to hoisted spies we drive per-test.
+const { mockGetOnchainDepositAddress, mockGetCommonSwaps, mockGetDepositQuote, mockClaimDepositSpark, FakeSparkWallet } = vi.hoisted(() => {
+  const mockGetOnchainDepositAddress = vi.fn();
+  const mockGetCommonSwaps = vi.fn();
+  const mockGetDepositQuote = vi.fn();
+  const mockClaimDepositSpark = vi.fn();
+  class FakeSparkWallet {
+    getOnchainDepositAddress = mockGetOnchainDepositAddress;
+    getCommonSwaps = mockGetCommonSwaps;
+    getDepositQuote = mockGetDepositQuote;
+    claimDepositSpark = mockClaimDepositSpark;
+  }
+  return { mockGetOnchainDepositAddress, mockGetCommonSwaps, mockGetDepositQuote, mockClaimDepositSpark, FakeSparkWallet };
+});
+vi.mock('../../class/wallets/spark-wallet', () => ({ SparkWallet: FakeSparkWallet, SPARK_STATIC_DEPOSIT_CONFIRMATIONS: 3 }));
+
+type ToolHandler = (input: any) => Promise<{ content: { text: string }[]; isError?: boolean }>;
+
+function parseToolJson(result: { content: { text: string }[] }): any {
+  return JSON.parse(result.content[0].text);
+}
+
+const DEPOSIT_ADDRESS = 'bc1qsparkdepositaddress000000000000000000';
+
+const mockLazyInitWallet = vi.fn();
+const fakeSparkWallet = new FakeSparkWallet();
+
+function makeFakeDeps(): McpCallDeps {
+  return {
+    storage: {} as any,
+    backgroundCaller: { lazyInitWallet: mockLazyInitWallet, getMasterSeed: vi.fn(), getAddress: vi.fn() } as any,
+    showSuccessToast: vi.fn(),
+    trackToolCall: vi.fn(),
+    trackSwapCompleted: vi.fn(),
+  };
+}
+
+function buildHandlers(deps: McpCallDeps): Map<string, ToolHandler> {
+  const handlers = new Map<string, ToolHandler>();
+  const fakeServer = {
+    registerTool: vi.fn((name: string, _config: unknown, handler: ToolHandler) => {
+      handlers.set(name, handler);
+    }),
+  };
+  registerWalletMcpCalls(fakeServer as any, deps);
+  return handlers;
+}
+
+let deps: McpCallDeps;
+let handlers: Map<string, ToolHandler>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetOnchainDepositAddress.mockResolvedValue(DEPOSIT_ADDRESS);
+  mockGetCommonSwaps.mockResolvedValue([]);
+  mockGetDepositQuote.mockImplementation(async (txid: string) => ({ transactionId: txid, creditAmountSats: 50000, signature: 'sig' }));
+  mockClaimDepositSpark.mockResolvedValue('spark_transfer_1');
+  mockLazyInitWallet.mockResolvedValue(fakeSparkWallet);
+  deps = makeFakeDeps();
+  handlers = buildHandlers(deps);
+});
+
+describe('MCP get_spark_deposit_address', () => {
+  it('returns the static on-chain deposit address + confirmations_required', async () => {
+    const result = await handlers.get('get_spark_deposit_address')!({});
+
+    expect(result.isError).toBeUndefined();
+    const body = parseToolJson(result);
+    expect(body.network).toBe(NETWORK_SPARK);
+    expect(body.deposit_address).toBe(DEPOSIT_ADDRESS);
+    expect(body.deposit_chain).toBe('bitcoin');
+    expect(body.confirmations_required).toBe(3);
+
+    expect(mockLazyInitWallet).toHaveBeenCalledWith(NETWORK_SPARK, MCP_BALANCE_ACCOUNT_NUMBER);
+    expect(mockGetOnchainDepositAddress).toHaveBeenCalledTimes(1);
+    expect(deps.trackToolCall).toHaveBeenCalledWith('get_spark_deposit_address');
+    expect(deps.showSuccessToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a wallet that is not a SparkWallet (instanceof guard)', async () => {
+    mockLazyInitWallet.mockResolvedValueOnce({ getOnchainDepositAddress: vi.fn() }); // not a SparkWallet instance
+
+    const result = await handlers.get('get_spark_deposit_address')!({});
+
+    expect(result.isError).toBe(true);
+    expect(parseToolJson(result).error).toMatch(/does not support on-chain spark deposits/i);
+    expect(mockGetOnchainDepositAddress).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a getOnchainDepositAddress failure as an MCP error (not a throw)', async () => {
+    mockGetOnchainDepositAddress.mockRejectedValueOnce(new Error('spark sdk not ready'));
+
+    const result = await handlers.get('get_spark_deposit_address')!({});
+
+    expect(result.isError).toBe(true);
+    expect(parseToolJson(result).error).toMatch(/spark sdk not ready/i);
+    expect(deps.showSuccessToast).not.toHaveBeenCalled();
+  });
+});
+
+describe('MCP claim_spark_deposit', () => {
+  it('claims every claimable (>=3 conf) deposit and returns transfer_id + credited sats', async () => {
+    mockGetCommonSwaps.mockResolvedValueOnce([
+      { network: NETWORK_SPARK, id: 'txa', status: 'claimable', amount: 50000, direction: 'receive' },
+      { network: NETWORK_SPARK, id: 'txb', status: 'claimable', amount: 70000, direction: 'receive' },
+      { network: NETWORK_SPARK, id: 'txc', status: 'pending', amount: 90000, confirmations: 1, targetConfirmations: 3, direction: 'receive' },
+    ]);
+    mockGetDepositQuote
+      .mockResolvedValueOnce({ transactionId: 'txa', creditAmountSats: 50000, signature: 's' })
+      .mockResolvedValueOnce({ transactionId: 'txb', creditAmountSats: 70000, signature: 's' });
+    mockClaimDepositSpark.mockResolvedValueOnce('spark_a').mockResolvedValueOnce('spark_b');
+
+    const result = await handlers.get('claim_spark_deposit')!({});
+
+    expect(result.isError).toBeUndefined();
+    const body = parseToolJson(result);
+    expect(body.success).toBe(true);
+    expect(body.claimed).toHaveLength(2);
+    expect(body.claimed[0]).toMatchObject({ txid: 'txa', transfer_id: 'spark_a', credited_base_units: '50000' });
+    expect(body.claimed[1]).toMatchObject({ txid: 'txb', transfer_id: 'spark_b', credited_base_units: '70000' });
+    expect(body.total_credited_base_units).toBe('120000');
+    expect(body.failed).toBeUndefined();
+
+    // The pending one (txc) was never claimed.
+    expect(mockGetDepositQuote).toHaveBeenCalledTimes(2);
+    expect(mockGetDepositQuote).not.toHaveBeenCalledWith('txc');
+    expect(deps.trackToolCall).toHaveBeenCalledWith('claim_spark_deposit');
+
+    // Each claimed deposit is counted as a completed BTC → Spark swap (swap_completed analytics).
+    expect(deps.trackSwapCompleted).toHaveBeenCalledTimes(2);
+    expect(deps.trackSwapCompleted).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ id: 'spark_a', serviceName: 'Native', sendAsset: 'native:bitcoin', receiveAsset: 'native:spark', sendAmount: '0.0005', receiveAmount: '0.0005' })
+    );
+    expect(deps.trackSwapCompleted).toHaveBeenNthCalledWith(2, expect.objectContaining({ id: 'spark_b', sendAmount: '0.0007', receiveAmount: '0.0007' }));
+  });
+
+  it('claims only the deposit matching the supplied txid', async () => {
+    mockGetCommonSwaps.mockResolvedValueOnce([
+      { network: NETWORK_SPARK, id: 'txa', status: 'claimable', amount: 50000, direction: 'receive' },
+      { network: NETWORK_SPARK, id: 'txb', status: 'claimable', amount: 70000, direction: 'receive' },
+    ]);
+
+    const result = await handlers.get('claim_spark_deposit')!({ txid: ' txb ' });
+
+    expect(result.isError).toBeUndefined();
+    const body = parseToolJson(result);
+    expect(body.claimed).toHaveLength(1);
+    expect(body.claimed[0].txid).toBe('txb');
+    expect(mockGetDepositQuote).toHaveBeenCalledTimes(1);
+    expect(mockGetDepositQuote).toHaveBeenCalledWith('txb');
+  });
+
+  it('returns the pending list with confirmation progress when nothing is claimable', async () => {
+    mockGetCommonSwaps.mockResolvedValueOnce([{ network: NETWORK_SPARK, id: 'txp', status: 'pending', amount: 90000, confirmations: 2, targetConfirmations: 3, direction: 'receive' }]);
+
+    const result = await handlers.get('claim_spark_deposit')!({});
+
+    expect(result.isError).toBeUndefined();
+    const body = parseToolJson(result);
+    expect(body.claimed).toEqual([]);
+    expect(body.pending).toHaveLength(1);
+    expect(body.pending[0]).toMatchObject({ txid: 'txp', confirmations: 2, target_confirmations: 3, amount_base_units: '90000' });
+    expect(mockClaimDepositSpark).not.toHaveBeenCalled();
+  });
+
+  it('collects per-deposit failures as partial success', async () => {
+    mockGetCommonSwaps.mockResolvedValueOnce([
+      { network: NETWORK_SPARK, id: 'txa', status: 'claimable', amount: 50000, direction: 'receive' },
+      { network: NETWORK_SPARK, id: 'txb', status: 'claimable', amount: 70000, direction: 'receive' },
+    ]);
+    mockGetDepositQuote.mockResolvedValueOnce({ transactionId: 'txa', creditAmountSats: 50000, signature: 's' }).mockRejectedValueOnce(new Error('quote expired'));
+    mockClaimDepositSpark.mockResolvedValueOnce('spark_a');
+
+    const result = await handlers.get('claim_spark_deposit')!({});
+
+    expect(result.isError).toBeUndefined();
+    const body = parseToolJson(result);
+    expect(body.success).toBe(true);
+    expect(body.claimed).toHaveLength(1);
+    expect(body.claimed[0].txid).toBe('txa');
+    expect(body.failed).toHaveLength(1);
+    expect(body.failed[0]).toMatchObject({ txid: 'txb' });
+    expect(body.failed[0].error).toMatch(/quote expired/i);
+
+    // Only the successful claim (txa) counts as a completed swap.
+    expect(deps.trackSwapCompleted).toHaveBeenCalledTimes(1);
+    expect(deps.trackSwapCompleted).toHaveBeenCalledWith(expect.objectContaining({ id: 'spark_a' }));
+  });
+
+  it('surfaces an MCP error when every claim fails', async () => {
+    mockGetCommonSwaps.mockResolvedValueOnce([{ network: NETWORK_SPARK, id: 'txa', status: 'claimable', amount: 50000, direction: 'receive' }]);
+    mockGetDepositQuote.mockRejectedValueOnce(new Error('sdk down'));
+
+    const result = await handlers.get('claim_spark_deposit')!({});
+
+    expect(result.isError).toBe(true);
+    const body = parseToolJson(result);
+    expect(body.error).toMatch(/all claim attempts failed/i);
+    expect(body.failed[0].error).toMatch(/sdk down/i);
+    expect(deps.showSuccessToast).not.toHaveBeenCalled();
+    expect(deps.trackSwapCompleted).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wallet that is not a SparkWallet (instanceof guard)', async () => {
+    mockLazyInitWallet.mockResolvedValueOnce({ getCommonSwaps: vi.fn() }); // not a SparkWallet instance
+
+    const result = await handlers.get('claim_spark_deposit')!({});
+
+    expect(result.isError).toBe(true);
+    expect(parseToolJson(result).error).toMatch(/does not support on-chain spark deposits/i);
+    expect(mockGetCommonSwaps).not.toHaveBeenCalled();
+  });
+});

--- a/shared/tests/unit-vi/mcp-calls-swap.test.ts
+++ b/shared/tests/unit-vi/mcp-calls-swap.test.ts
@@ -168,6 +168,10 @@ describe('MCP swap tools', () => {
       const body = parseToolJson(result);
       // Real conversion: 99.500000 (human) × 10^6 = 99,500,000 base units USDB.
       expect(body.receive_amount_base_units).toBe('99500000');
+      // Human-readable strings are derived from the exact base-unit values above so the agent
+      // never has to divide by 10^decimals. 100,000 sats = 0.001 BTC; 99,500,000 = 99.5 USDB.
+      expect(body.send_amount_human_readable).toBe('0.001');
+      expect(body.receive_amount_human_readable).toBe('99.5');
       // Fee derived from pool bps: 100,000 sats × 40 bps / 10,000 = 400 sats.
       // Crucially, this is computed from `pool.lpFeeBps + hostFeeBps`, NOT from
       // `simulation.feePaidAssetIn` (49750 in the mock) — if a regression went back to
@@ -211,6 +215,9 @@ describe('MCP swap tools', () => {
       const body = parseToolJson(result);
       // 50000 sats from the AMM converts back to '50000' sats base units (no rounding).
       expect(body.receive_amount_base_units).toBe('50000');
+      // 50,000,000 USDB units = 50 USDB; 50,000 sats = 0.0005 BTC. Decimal math is done in-wallet.
+      expect(body.send_amount_human_readable).toBe('50');
+      expect(body.receive_amount_human_readable).toBe('0.0005');
       // Fee derived from pool bps: 50,000,000 USDB units × 40 bps / 10,000 = 200,000 USDB units.
       // This is in the INPUT asset's smallest units (USDB) — direction-asymmetric vs the BTC→USDB
       // case which yielded 400 sats. A regression that hardcoded sats or forgot to use the input
@@ -400,6 +407,10 @@ describe('MCP swap tools', () => {
       // wrapper reports realized (not quoted) amounts to the agent.
       expect(body.receive_amount_base_units).toBe('99400000');
       expect(body.send_amount_base_units).toBe('100000');
+      // Human-readable strings mirror the realized base-unit amounts: 100,000 sats = 0.001 BTC,
+      // 99,400,000 USDB units = 99.4 USDB.
+      expect(body.send_amount_human_readable).toBe('0.001');
+      expect(body.receive_amount_human_readable).toBe('99.4');
       expect(body.service).toBe('Flashnet');
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds MCP paths that claim Spark deposits and move credited BTC on the dedicated MCP account; Lightning API change (`is_invoice_paid` input) could break existing agent integrations that still pass BOLT11.
> 
> **Overview**
> Expands the **MCP wallet surface** for agents: on-chain BTC → Spark deposit/claim, Bitcoin tx inspection, safer Lightning receive tracking, and clearer swap quoting—plus platform analytics for MCP-driven claims.
> 
> **On-chain BTC → Spark:** New read-only `get_spark_deposit_address` and `claim_spark_deposit` (optional `txid`) on the MCP balance account, wired to `SparkWallet` static deposit flow instead of instant `execute_swap`. Claim responses include pending confirmation progress; successful claims call optional `trackSwapCompleted` so `SwapCompleted` analytics match the UI Native path. `SPARK_STATIC_DEPOSIT_CONFIRMATIONS` (3) is centralized in `spark-wallet.ts`.
> 
> **Bitcoin:** `get_bitcoin_transaction` looks up a txid via Electrum (confirmations, outputs in sats, compact I/O summary).
> 
> **Lightning:** `create_lightning_invoice` defaults network to Spark, returns `payment_hash`, and `is_invoice_paid` now takes that hash instead of the full BOLT11. Wallets implement `isInvoicePaidByHash` on Ark, Breez, and Spark.
> 
> **Swaps:** `get_swap_quote` / `execute_swap` add `*_human_readable` amount fields; server instructions tell agents not to do decimal math on base units.
> 
> **Platform:** Mobile and desktop `McpCallDeps` gain `trackSwapCompleted` via `buildSwapCompletedProperties`. Docs and `mcp-calls-spark-deposit.test.ts` cover the deposit tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222cd1db91dd714328cda32cf2af48149a443357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->