### PR TITLE
feat: local mcp server

### DIFF
--- a/desktop/src/bun/background-message-controller.ts
+++ b/desktop/src/bun/background-message-controller.ts
@@ -2,6 +2,7 @@ import { Utils } from 'electrobun/bun';
 
 import { DesktopMessageType, type DesktopMessage } from '../shared/desktop-messages';
 import { desktopStorage } from './desktop-storage';
+import { startLocalMcpServer, stopLocalMcpServer } from './local-mcp-server';
 
 /**
  * Bun-side dispatcher for renderer messages — the desktop analog of ext's
@@ -23,6 +24,13 @@ export async function handleMessage(message: DesktopMessage): Promise<unknown> {
 
     case DesktopMessageType.SHOW_NOTIFICATION:
       Utils.showNotification(message.params[0]);
+      return null;
+
+    case DesktopMessageType.MCP_LOCAL_SERVER_START:
+      return startLocalMcpServer();
+
+    case DesktopMessageType.MCP_LOCAL_SERVER_STOP:
+      stopLocalMcpServer();
       return null;
 
     default: {

--- a/desktop/src/bun/index.ts
+++ b/desktop/src/bun/index.ts
@@ -2,6 +2,7 @@ import Electrobun, { BrowserView, BrowserWindow, GlobalShortcut, Updater, Utils 
 
 import { handleMessage } from './background-message-controller';
 import { applyLinuxWindowIcon } from './linux-window-icon';
+import { configureLocalMcpServer } from './local-mcp-server';
 import type { DesktopAppRPC } from '../shared/desktop-messages';
 
 const DEV_SERVER_PORT = 5173;
@@ -43,6 +44,9 @@ async function getMainViewUrl(): Promise<string> {
 const url = await getMainViewUrl();
 
 const rpc = BrowserView.defineRPC<DesktopAppRPC>({
+  // Bun → renderer MCP calls (`mcpHandleHttp`) can be slow — a `pay_lightning_invoice`
+  // may take minutes. Raise the default 1s RPC timeout so they aren't cut off mid-flight.
+  maxRequestTime: 190_000,
   handlers: {
     requests: {
       processMessage: (message) => handleMessage(message),
@@ -64,6 +68,10 @@ const mainWindow = new BrowserWindow({
 });
 
 applyLinuxWindowIcon(mainWindow.ptr);
+
+// Bridge the local MCP listener (Bun) to the wallet's MCP handler (renderer). The
+// listener itself is started/stopped on demand via MCP_LOCAL_SERVER_START/STOP.
+configureLocalMcpServer((req) => mainWindow.webview.rpc!.request.mcpHandleHttp(req));
 
 // Open http(s) links from the webview in the system browser (e.g. Terms of Service).
 // BrowserView.on() does not expose new-window-open; use the global emitter with a webview id suffix.

--- a/desktop/src/bun/local-mcp-server.ts
+++ b/desktop/src/bun/local-mcp-server.ts
@@ -1,0 +1,189 @@
+/**
+ * Local MCP HTTP listener — the "closed circuit" alternative to the public tunnel.
+ *
+ * Runs in the Bun main process (the only context that can open a listening socket)
+ * and forwards every request to the renderer's existing `handleMcpRequest` over the
+ * Electrobun RPC channel. No traffic leaves the machine/LAN. This is the local analog
+ * of `mcp-websocket-tunnel/server.ts`, minus sessions (a single in-process "device"
+ * needs none of that).
+ *
+ * Security mirrors the tunnel: the URL carries an unguessable token (`/mcp/<token>`)
+ * that acts as the bearer credential. The token is persisted so the URL is stable
+ * across restarts, exactly like the tunnel's persisted session id.
+ */
+
+import { isIPv4 } from 'node:net';
+import { networkInterfaces } from 'node:os';
+
+import { desktopStorage } from './desktop-storage';
+import type { LocalMcpServerInfo } from '../shared/desktop-messages';
+import type { TunnelHttpRequest, TunnelHttpResponse } from '@shared/features/mcp/modules/tunnel-types';
+
+type Forwarder = (req: TunnelHttpRequest) => Promise<TunnelHttpResponse>;
+
+const HOST = '0.0.0.0';
+const DEFAULT_PORT = 4435;
+const PORT_SCAN_ATTEMPTS = 10;
+/** Persisted bearer token so the local URL survives restarts (parallels the tunnel's session id). */
+const TOKEN_STORAGE_KEY = '@layerz/mcp-local-token';
+
+/** CORS so browser-based agents / MCP Inspector can reach the listener (mirrors the tunnel server). */
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, HEAD, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Accept, Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Authorization',
+};
+
+let forward: Forwarder | null = null;
+let server: ReturnType<typeof Bun.serve> | null = null;
+let serverPort = 0;
+let serverToken = '';
+
+/** Wire the renderer bridge once at boot (from index.ts, where the window/RPC exists). */
+export function configureLocalMcpServer(forwarder: Forwarder): void {
+  forward = forwarder;
+}
+
+/** 24 random bytes, base64url — same shape/strength as the tunnel server's session id. */
+function randomToken(bytes = 24): string {
+  return Buffer.from(crypto.getRandomValues(new Uint8Array(bytes))).toString('base64url');
+}
+
+async function getOrCreateToken(): Promise<string> {
+  const existing = await desktopStorage.getItem(TOKEN_STORAGE_KEY);
+  if (existing) return existing;
+  const token = randomToken();
+  await desktopStorage.setItem(TOKEN_STORAGE_KEY, token);
+  return token;
+}
+
+function buildUrl(port: number, token: string): string {
+  return `http://${lanAddress()}:${port}/mcp/${token}`;
+}
+
+/** First non-internal IPv4 so other machines on the LAN get a reachable URL; loopback otherwise. */
+function lanAddress(): string {
+  for (const addrs of Object.values(networkInterfaces())) {
+    for (const addr of addrs ?? []) {
+      // Detect IPv4 from the address itself: `addr.family` is `'IPv4'` on Bun but has been a
+      // numeric `4` on some Node releases, so don't depend on its representation.
+      if (!addr.internal && isIPv4(addr.address)) return addr.address;
+    }
+  }
+  return '127.0.0.1';
+}
+
+function isAddrInUse(err: unknown): boolean {
+  return (err as { code?: string } | null)?.code === 'EADDRINUSE';
+}
+
+/** Idempotent: returns the existing listener's URL if running. The renderer serializes start/stop. */
+export async function startLocalMcpServer(): Promise<LocalMcpServerInfo> {
+  if (server) {
+    return { url: buildUrl(serverPort, serverToken), port: serverPort };
+  }
+  const dispatch = forward;
+  if (!dispatch) {
+    throw new Error('[local-mcp] not configured: call configureLocalMcpServer() first');
+  }
+
+  const token = await getOrCreateToken();
+
+  let lastErr: unknown;
+  for (let i = 0; i < PORT_SCAN_ATTEMPTS; i++) {
+    const port = DEFAULT_PORT + i;
+    try {
+      server = Bun.serve({
+        hostname: HOST,
+        port,
+        async fetch(req, srv) {
+          const url = new URL(req.url);
+
+          // The token in the path is the bearer credential. Reject anything else
+          // (404, not 401, so we don't confirm the endpoint exists to scanners).
+          const match = url.pathname.match(/^\/mcp\/([^/]+)\/?$/);
+          if (!match || match[1] !== token) {
+            return new Response(JSON.stringify({ error: 'NOT_FOUND' }), {
+              status: 404,
+              headers: { 'content-type': 'application/json', ...CORS_HEADERS },
+            });
+          }
+
+          if (req.method === 'OPTIONS') {
+            return new Response(null, { status: 204, headers: { ...CORS_HEADERS, 'Access-Control-Max-Age': '86400' } });
+          }
+
+          // A slow tool (e.g. pay_lightning_invoice) can take minutes; don't let Bun's
+          // idle cutoff kill the request while the renderer is working.
+          srv.timeout(req, 0);
+
+          const headers: Record<string, string> = {};
+          req.headers.forEach((value, key) => {
+            headers[key] = value;
+          });
+
+          const tunnelReq: TunnelHttpRequest = {
+            type: 'http_request',
+            requestId: crypto.randomUUID(),
+            method: req.method,
+            // Strip the token before handing to the MCP layer (it routes by method +
+            // Mcp-Session-Id, not path) so the credential never reaches renderer logs.
+            path: `/mcp${url.search}`,
+            headers,
+            bodyBase64: Buffer.from(await req.arrayBuffer()).toString('base64'),
+          };
+
+          let tunnelRes: TunnelHttpResponse;
+          try {
+            tunnelRes = await dispatch(tunnelReq);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return new Response(JSON.stringify({ error: message }), {
+              status: 504,
+              headers: { 'content-type': 'application/json', ...CORS_HEADERS },
+            });
+          }
+
+          const responseHeaders = new Headers();
+          for (const [key, value] of Object.entries(tunnelRes.headers)) {
+            const lower = key.toLowerCase();
+            if (lower === 'content-length' || lower === 'transfer-encoding' || lower === 'connection') continue;
+            responseHeaders.set(key, value);
+          }
+          for (const [key, value] of Object.entries(CORS_HEADERS)) {
+            responseHeaders.set(key, value);
+          }
+
+          return new Response(Buffer.from(tunnelRes.bodyBase64, 'base64'), {
+            status: tunnelRes.status ?? 200,
+            headers: responseHeaders,
+          });
+        },
+      });
+
+      serverPort = port;
+      serverToken = token;
+      console.log(`[local-mcp] listening on ${HOST}:${port}`);
+      return { url: buildUrl(port, token), port };
+    } catch (err) {
+      lastErr = err;
+      if (isAddrInUse(err)) continue;
+      throw err;
+    }
+  }
+
+  throw new Error(`[local-mcp] no free port in ${DEFAULT_PORT}-${DEFAULT_PORT + PORT_SCAN_ATTEMPTS - 1}: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`);
+}
+
+export function stopLocalMcpServer(): void {
+  if (!server) return;
+  console.log('[local-mcp] stopping');
+  try {
+    server.stop(true);
+  } catch {
+    // already torn down
+  }
+  server = null;
+  serverPort = 0;
+  serverToken = '';
+}

--- a/desktop/src/mainview/components/mcp/McpAgentActivateModal.tsx
+++ b/desktop/src/mainview/components/mcp/McpAgentActivateModal.tsx
@@ -3,9 +3,10 @@ import React, { useContext } from 'react';
 import { useNavigate } from 'react-router';
 
 import { NetworkContext } from '@shared/hooks/NetworkContext';
-import { connectTunnel } from '../../features/mcp/tunnel-desktop';
+import { activateMcp } from '../../features/mcp/tunnel-desktop';
 
 import { DetachedSheet } from '../DetachedSheet';
+import { McpLocalModeToggle } from './McpLocalModeToggle';
 import '../../pages/McpAgentActivateModal.css';
 
 type McpAgentActivateModalProps = {
@@ -19,7 +20,7 @@ export const McpAgentActivateModal: React.FC<McpAgentActivateModalProps> = ({ on
 
   const handleActivate = () => {
     onClose();
-    void connectTunnel();
+    void activateMcp();
     navigate('/mcp-tunnel-url-modal');
   };
 
@@ -32,6 +33,7 @@ export const McpAgentActivateModal: React.FC<McpAgentActivateModalProps> = ({ on
         <Bot className="mcp-agent-activate-icon" size={52} strokeWidth={1.5} aria-hidden />
         <h2 className="mcp-agent-activate-title">Agent</h2>
         <p className="mcp-agent-activate-subtitle">Automate payments, trade and control your wallet from your messaging or AI provider.</p>
+        <McpLocalModeToggle />
         <button type="button" className="mcp-agent-activate-btn" onClick={handleActivate} aria-label="Activate agent" data-testid="McpAgentActivateButton">
           Activate
         </button>

--- a/desktop/src/mainview/components/mcp/McpLocalModeToggle.css
+++ b/desktop/src/mainview/components/mcp/McpLocalModeToggle.css
@@ -1,0 +1,36 @@
+.mcp-local-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  margin: 0 0 20px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.mcp-local-toggle-input {
+  margin: 2px 0 0;
+  width: 18px;
+  height: 18px;
+  accent-color: #ffffff;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.mcp-local-toggle-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mcp-local-toggle-title {
+  font-size: 14px;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.mcp-local-toggle-subtitle {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+  line-height: 16px;
+}

--- a/desktop/src/mainview/components/mcp/McpLocalModeToggle.tsx
+++ b/desktop/src/mainview/components/mcp/McpLocalModeToggle.tsx
@@ -1,0 +1,24 @@
+import React, { useSyncExternalStore } from 'react';
+
+import { getMcpLocalMode, setMcpLocalMode, subscribeMcp } from '../../features/mcp/tunnel-desktop';
+
+import './McpLocalModeToggle.css';
+
+/**
+ * Switches the MCP transport between the public tunnel and the local closed-circuit
+ * listener. Toggling is live: turning it on disconnects the tunnel and starts the local
+ * server; turning it off does the reverse. Shared by the activate and URL modals.
+ */
+export const McpLocalModeToggle: React.FC = () => {
+  const localMode = useSyncExternalStore(subscribeMcp, getMcpLocalMode, getMcpLocalMode);
+
+  return (
+    <label className="mcp-local-toggle">
+      <input type="checkbox" className="mcp-local-toggle-input" checked={localMode} onChange={(e) => void setMcpLocalMode(e.target.checked)} data-testid="McpLocalModeToggle" />
+      <span className="mcp-local-toggle-text">
+        <span className="mcp-local-toggle-title">Local only (closed circuit)</span>
+        <span className="mcp-local-toggle-subtitle">Expose on your local network with no tunnel — nothing leaves this machine.</span>
+      </span>
+    </label>
+  );
+};

--- a/desktop/src/mainview/components/mcp/McpTunnelStatusRow.tsx
+++ b/desktop/src/mainview/components/mcp/McpTunnelStatusRow.tsx
@@ -2,7 +2,7 @@ import { Pause, Play } from 'lucide-react';
 import React, { useSyncExternalStore } from 'react';
 import { useNavigate } from 'react-router';
 
-import { connectTunnel, disconnectTunnel, getTunnelConnectionStatus, subscribeTunnelConnection } from '../../features/mcp/tunnel-desktop';
+import { activateMcp, getMcpStatus, pauseMcp, subscribeMcp } from '../../features/mcp/tunnel-desktop';
 
 import { McpActivityLog } from './McpActivityLog';
 import './McpTunnelStatusRow.css';
@@ -10,7 +10,7 @@ import './McpTunnelStatusRow.css';
 /** Desktop port of mobile `McpTunnelStatusRow`. */
 export const McpTunnelStatusRow: React.FC = () => {
   const navigate = useNavigate();
-  const status = useSyncExternalStore(subscribeTunnelConnection, getTunnelConnectionStatus, getTunnelConnectionStatus);
+  const status = useSyncExternalStore(subscribeMcp, getMcpStatus, getMcpStatus);
   const connecting = status === 'connecting';
 
   const pill = status === 'connected' ? 'Active' : status === 'connecting' ? 'Connecting...' : 'Inactive';
@@ -31,9 +31,9 @@ export const McpTunnelStatusRow: React.FC = () => {
           type="button"
           className={`mcp-tunnel-circle-btn${connecting ? ' mcp-tunnel-circle-btn--dimmed' : ''}`}
           onClick={() => {
-            if (status === 'connected') void disconnectTunnel();
+            if (status === 'connected') void pauseMcp();
             else if (status === 'disconnected') {
-              void connectTunnel().then(() => navigate('/mcp-tunnel-url-modal'));
+              void activateMcp().then(() => navigate('/mcp-tunnel-url-modal'));
             }
           }}
           disabled={connecting}

--- a/desktop/src/mainview/components/mcp/TunnelBootstrap.tsx
+++ b/desktop/src/mainview/components/mcp/TunnelBootstrap.tsx
@@ -1,11 +1,14 @@
 import { useEffect } from 'react';
 
-import { ensureTunnelBootstrapped } from '../../features/mcp/tunnel-desktop';
+import { ensureMcpBootstrapped, teardownMcpTransport } from '../../features/mcp/tunnel-desktop';
 
-/** One-shot tunnel bootstrap when wallet shell is ready. */
+/** One-shot MCP bootstrap when wallet shell is ready (tunnel client + restore local mode). */
 export function TunnelBootstrap() {
   useEffect(() => {
-    void ensureTunnelBootstrapped();
+    void ensureMcpBootstrapped();
+    return () => {
+      void teardownMcpTransport();
+    };
   }, []);
 
   return null;

--- a/desktop/src/mainview/features/mcp/mcp-desktop.ts
+++ b/desktop/src/mainview/features/mcp/mcp-desktop.ts
@@ -1,0 +1,55 @@
+/**
+ * Single desktop entry for `@shared/features/mcp/modules/mcp`.
+ *
+ * Both transports (public tunnel + local listener) reach the MCP handler through here,
+ * so Vite can't duplicate the module and split the `configureMcp` singleton. Mirrors the
+ * rationale in `tunnel-desktop.ts` / `mcp-activity-log-desktop.ts`. The shared module is
+ * imported lazily so wallet/MCP code stays out of the boot bundle until MCP is used.
+ */
+
+import { ensureWalletAdapters } from '../../modules/load-adapters';
+
+import { desktopMcpDeps } from './modules/mcp-platform';
+
+import type { RequestHandler, TunnelHttpRequest, TunnelHttpResponse } from '@shared/features/mcp/modules/tunnel-types';
+
+type McpModule = typeof import('@shared/features/mcp/modules/mcp');
+
+let mcpModulePromise: Promise<McpModule> | null = null;
+let configurePromise: Promise<void> | null = null;
+
+function loadMcp(): Promise<McpModule> {
+  if (!mcpModulePromise) mcpModulePromise = import('@shared/features/mcp/modules/mcp');
+  return mcpModulePromise;
+}
+
+/** Idempotent: load wallet adapters and wire platform deps before any MCP request. */
+export function ensureMcpConfigured(): Promise<void> {
+  if (!configurePromise) {
+    configurePromise = (async () => {
+      await ensureWalletAdapters();
+      const { configureMcp } = await loadMcp();
+      configureMcp(desktopMcpDeps, { name: 'layerz-wallet-desktop' });
+    })().catch((err) => {
+      configurePromise = null;
+      throw err;
+    });
+  }
+  return configurePromise;
+}
+
+/** The request handler the public tunnel feeds (after deps are wired). */
+export async function getMcpRequestHandler(): Promise<RequestHandler> {
+  await ensureMcpConfigured();
+  return (await loadMcp()).handleMcpRequest;
+}
+
+/** Renderer-side entry for the local listener — Bun calls this via the `mcpHandleHttp` RPC. */
+export async function handleLocalMcpHttp(req: TunnelHttpRequest): Promise<TunnelHttpResponse> {
+  await ensureMcpConfigured();
+  return (await loadMcp()).handleMcpRequest(req);
+}
+
+export async function resetMcpSessions(): Promise<void> {
+  (await loadMcp()).resetMcpSessions();
+}

--- a/desktop/src/mainview/features/mcp/tunnel-desktop.ts
+++ b/desktop/src/mainview/features/mcp/tunnel-desktop.ts
@@ -1,14 +1,32 @@
 /**
- * Single desktop entry for `@shared/features/mcp/modules/tunnel`.
+ * Single desktop entry for the MCP transport (public tunnel + local listener).
  *
- * Vite can duplicate that module when one caller uses `import()` and another
- * uses a static import — then `startTunnel` and `connectTunnel` see different
- * singleton state. All desktop code must import tunnel APIs from this file.
+ * Vite can duplicate `@shared/.../tunnel` when one caller uses `import()` and another a
+ * static import — then `startTunnel` and the connection state diverge. All desktop code
+ * must reach tunnel/MCP-mode APIs through this file.
+ *
+ * Two concepts, kept separate to avoid surprises:
+ *   - PREFERENCE (`getMcpLocalMode` / `setMcpLocalMode`): which transport the user wants —
+ *     local closed-circuit listener vs public tunnel. Toggling preserves the on/off state:
+ *     if the agent is OFF it only records the choice (nothing starts until the user activates);
+ *     if the agent is already RUNNING it switches transports live — drops the old one and
+ *     starts the new one instantly. Either way the tunnel is never left running while local
+ *     is selected (closed circuit).
+ *   - ACTIVATION (`activateMcp` / `pauseMcp`): explicitly start/stop the preferred transport
+ *     from the off state. The two transports are mutually exclusive.
+ *
+ * `getMcpStatus` / `getMcpPublicUrl` track the transport that is *actually live* (`activeLocal`),
+ * not the preference: during a live switch they keep reporting the old transport until it is torn
+ * down, so the API never claims local-only while the public tunnel is still up.
  */
 
 import { LayerzStorage } from '../../class/layerz-storage';
+import { Messenger } from '../../modules/messenger';
+import { showDesktopNotification } from '../../modules/notifications';
+import { DesktopMessageType } from '../../../shared/desktop-messages';
 
-import { desktopAppLifecycle, desktopMcpDeps } from './modules/mcp-platform';
+import { ensureMcpConfigured, getMcpRequestHandler, resetMcpSessions } from './mcp-desktop';
+import { desktopAppLifecycle } from './modules/mcp-platform';
 
 import {
   connectTunnel as connectTunnelShared,
@@ -17,42 +35,244 @@ import {
   getTunnelConnectionStatus,
   getTunnelPublicUrl,
   startTunnel,
+  stopTunnel,
   subscribeTunnelConnection,
+  type TunnelConnectionStatus,
 } from '@shared/features/mcp/modules/tunnel';
 
-export { disconnectTunnel, getTunnelAutostartOnLaunch, getTunnelConnectionStatus, getTunnelPublicUrl, subscribeTunnelConnection };
+/** `'local'` selects the closed-circuit listener; anything else (default) selects the public tunnel. */
+const MODE_KEY = '@layerz/mcp-mode';
+/** Whether the local listener should be running (its "autostart on launch" flag; the tunnel has its own). */
+const LOCAL_ACTIVE_KEY = '@layerz/mcp-local-active';
 
-let bootstrapPromise: Promise<void> | null = null;
+let mcpBootstrapPromise: Promise<void> | null = null;
+/** Bumped by teardown so an in-flight `ensureMcpBootstrapped` body cannot reopen transports after reset. */
+let bootstrapEpoch = 0;
+/** Desired transport (the checkbox): flips immediately so the UI + dedup react at once. */
+let localPreference = false;
+/** Transport currently authoritative for status/URL: flips only after the old one is torn down. */
+let activeLocal = false;
+let localUrl: string | null = null; // non-null iff the local listener is running
+const localListeners = new Set<() => void>();
 
-/** Idempotent: wires MCP + calls `startTunnel` once per app session. */
-export function ensureTunnelBootstrapped(): Promise<void> {
-  if (!bootstrapPromise) {
-    bootstrapPromise = (async () => {
-      const adapters = await import('../../modules/load-adapters');
-      await adapters.ensureWalletAdapters();
+function notifyLocal(): void {
+  localListeners.forEach((fn) => fn());
+}
 
-      const { configureMcp, handleMcpRequest, resetMcpSessions } = await import('@shared/features/mcp/modules/mcp');
-      configureMcp(desktopMcpDeps, { name: 'layerz-wallet-desktop' });
+/**
+ * Serialize transport mutations. The UI fires `activateMcp` / `pauseMcp` / `setMcpLocalMode`
+ * without awaiting, so without a queue a stop could run while a start's RPC is still in flight:
+ * Bun's stop would no-op (socket not bound yet) and the late start would then re-mark the listener
+ * active — leaving it running after the user paused/switched off. Queuing makes the last action win
+ * and keeps `localUrl` + storage consistent with the actual socket.
+ */
+let opChain: Promise<void> = Promise.resolve();
+function enqueueTransportOp(op: () => Promise<void>): Promise<void> {
+  const run = opChain.then(op, op);
+  opChain = run.catch(() => {}); // keep the chain alive even if one op throws
+  return run;
+}
+
+/** Start the local listener (Bun process) and record its URL. */
+async function startLocalServer(): Promise<void> {
+  try {
+    const info = await Messenger.send(DesktopMessageType.MCP_LOCAL_SERVER_START, []);
+    localUrl = info.url;
+    activeLocal = true; // status/URL getters key off this, not just localPreference
+    await LayerzStorage.setItem(LOCAL_ACTIVE_KEY, '1');
+    notifyLocal();
+  } catch (err) {
+    localUrl = null;
+    try {
+      await LayerzStorage.setItem(LOCAL_ACTIVE_KEY, '0');
+    } catch {
+      // ignore — best-effort cleanup
+    }
+    notifyLocal();
+    const message = err instanceof Error ? err.message : String(err);
+    void showDesktopNotification({ title: 'Agent failed to start', body: message });
+    throw err;
+  }
+}
+
+/** Stop the local listener and clear its "should run" flag. No-op on the Bun side if not running. */
+async function stopLocalServer(): Promise<void> {
+  await Messenger.send(DesktopMessageType.MCP_LOCAL_SERVER_STOP, []);
+  localUrl = null;
+  await LayerzStorage.setItem(LOCAL_ACTIVE_KEY, '0');
+  notifyLocal();
+}
+
+async function stopAllTransports(): Promise<void> {
+  await disconnectTunnel();
+  await stopLocalServer();
+}
+
+/** If teardown bumped the epoch, undo any partial bootstrap work and abandon the run. */
+async function abortBootstrapIfStale(epoch: number): Promise<boolean> {
+  if (epoch === bootstrapEpoch) return false;
+  await stopAllTransports();
+  stopTunnel();
+  return true;
+}
+
+/**
+ * Boot entry (called once from `<TunnelBootstrap/>` and `Home`): wire MCP deps + the tunnel
+ * client, then restore whichever transport was last active. In local mode `startTunnel` is told
+ * not to auto-connect (`allowAutoConnect: false`), so the public tunnel can't open at launch.
+ */
+export function ensureMcpBootstrapped(): Promise<void> {
+  if (!mcpBootstrapPromise) {
+    const epoch = bootstrapEpoch;
+    mcpBootstrapPromise = (async () => {
+      localPreference = (await LayerzStorage.getItem(MODE_KEY)) === 'local';
+      activeLocal = localPreference;
+      if (await abortBootstrapIfStale(epoch)) return;
+
+      await ensureMcpConfigured();
+      if (await abortBootstrapIfStale(epoch)) return;
+
+      // Re-read: a toggle during ensureMcpConfigured may have persisted a new MODE_KEY.
+      localPreference = (await LayerzStorage.getItem(MODE_KEY)) === 'local';
+      activeLocal = localPreference;
+      if (await abortBootstrapIfStale(epoch)) return;
 
       await startTunnel({
-        handleRequest: handleMcpRequest,
+        handleRequest: await getMcpRequestHandler(),
         storage: LayerzStorage,
         appLifecycle: desktopAppLifecycle,
+        // Closed circuit: in local mode the public tunnel must never open on launch — not even for
+        // one tick — even if its autostart flag was left at '1' by a crash mid-switch.
+        allowAutoConnect: !localPreference,
         onSessionChange: ({ publicUrl, idChanged }) => {
           if (__DEV__) console.log('[mcp] PUBLIC URL:', publicUrl);
-          if (idChanged) resetMcpSessions();
+          if (idChanged) void resetMcpSessions();
         },
       });
+      if (await abortBootstrapIfStale(epoch)) return;
+
+      if (localPreference) {
+        await disconnectTunnel(); // keep the tunnel's autostart flag at '0' so persisted state stays consistent
+        if (await abortBootstrapIfStale(epoch)) return;
+        if ((await LayerzStorage.getItem(LOCAL_ACTIVE_KEY)) === '1') await startLocalServer();
+      }
+      if (await abortBootstrapIfStale(epoch)) return;
+      notifyLocal();
     })().catch((err) => {
-      bootstrapPromise = null;
+      if (bootstrapEpoch === epoch) mcpBootstrapPromise = null;
       throw err;
     });
   }
-  return bootstrapPromise;
+  return mcpBootstrapPromise;
 }
 
-/** Waits for bootstrap, then connects (play / Activate). */
-export async function connectTunnel(): Promise<void> {
-  await ensureTunnelBootstrapped();
-  return connectTunnelShared();
+/**
+ * Change the transport preference (the checkbox), preserving the agent's on/off state:
+ *   - OFF  → only record the choice; nothing starts (the user activates explicitly).
+ *   - ON   → switch transports live: drop the old one and start the new one instantly.
+ * The contradicting transport is always torn down, so "Local only" can't leave the tunnel exposed.
+ */
+export async function setMcpLocalMode(local: boolean): Promise<void> {
+  if (local === localPreference) return;
+
+  // Capture (sync) whether the current transport is live, then flip the *preference* immediately —
+  // so the checkbox responds at once and rapid re-toggles dedupe against the guard above. Status/URL
+  // stay on the old transport (via `activeLocal`) until the queued op actually tears it down.
+  const wasActive = getMcpStatus() !== 'disconnected';
+  localPreference = local;
+  notifyLocal();
+
+  await enqueueTransportOp(async () => {
+    await LayerzStorage.setItem(MODE_KEY, local ? 'local' : 'tunnel');
+    await ensureMcpBootstrapped();
+    // Re-assert: a first-run bootstrap racing this toggle reads the pre-toggle MODE_KEY and would
+    // clobber `localPreference` back. We persisted the new value above, so our intent is authoritative.
+    localPreference = local;
+    if (local) {
+      await disconnectTunnel(); // closed circuit: tear the tunnel down BEFORE reporting local
+      activeLocal = true;
+      notifyLocal();
+      if (wasActive) {
+        await startLocalServer();
+      } else {
+        // Preference-only switch: clear a stale autostart flag so isMcpActivated stays honest.
+        await LayerzStorage.setItem(LOCAL_ACTIVE_KEY, '0');
+      }
+    } else {
+      await stopLocalServer(); // stop the local listener BEFORE reporting tunnel
+      activeLocal = false;
+      notifyLocal();
+      if (wasActive) await connectTunnelShared();
+    }
+  });
+}
+
+/** Explicitly start the preferred transport (Activate button / play), stopping the other. */
+export async function activateMcp(): Promise<void> {
+  await enqueueTransportOp(async () => {
+    await ensureMcpBootstrapped();
+    // Re-read MODE_KEY: bootstrap's first run can clobber in-memory preference from storage.
+    localPreference = (await LayerzStorage.getItem(MODE_KEY)) === 'local';
+    if (localPreference) {
+      await disconnectTunnel(); // closed circuit: no public tunnel at all
+      await startLocalServer();
+    } else {
+      await stopLocalServer();
+      activeLocal = false;
+      notifyLocal();
+      await connectTunnelShared();
+    }
+  });
+}
+
+/** Explicitly stop the agent (pause). Tears down both transports so a pause can never leave one up. */
+export async function pauseMcp(): Promise<void> {
+  await enqueueTransportOp(stopAllTransports);
+}
+
+/**
+ * Full transport teardown — stops listeners/tunnel, clears in-memory state, and drops the
+ * bootstrap latch so a future READY session can re-initialize. Used on wallet reset and when
+ * leaving the unlocked shell.
+ */
+export function teardownMcpTransport(): Promise<void> {
+  return enqueueTransportOp(async () => {
+    bootstrapEpoch++; // invalidate any in-flight bootstrap before stopping sockets
+    await stopAllTransports();
+    stopTunnel();
+    mcpBootstrapPromise = null;
+    localPreference = false;
+    activeLocal = false;
+    localUrl = null;
+    notifyLocal();
+  });
+}
+
+/** True if the preferred transport is actually running (used to skip the activate prompt). */
+export async function isMcpActivated(): Promise<boolean> {
+  return localPreference ? localUrl !== null : getTunnelAutostartOnLaunch();
+}
+
+export function getMcpLocalMode(): boolean {
+  return localPreference;
+}
+
+/** Active public URL for the transport that is *actually live* (null until it's been activated). */
+export function getMcpPublicUrl(): string | null {
+  return activeLocal ? localUrl : getTunnelPublicUrl();
+}
+
+export function getMcpStatus(): TunnelConnectionStatus {
+  if (activeLocal) return localUrl ? 'connected' : 'disconnected';
+  return getTunnelConnectionStatus();
+}
+
+/** Subscribe to either transport's changes (status / URL / preference). */
+export function subscribeMcp(onChange: () => void): () => void {
+  const unsubscribeTunnel = subscribeTunnelConnection(onChange);
+  localListeners.add(onChange);
+  return () => {
+    unsubscribeTunnel();
+    localListeners.delete(onChange);
+  };
 }

--- a/desktop/src/mainview/modules/messenger.ts
+++ b/desktop/src/mainview/modules/messenger.ts
@@ -21,7 +21,17 @@ class DesktopMessenger implements IMessenger {
   private getRpc(): DesktopRpc {
     if (!this.rpc) {
       const rpc = Electroview.defineRPC<DesktopAppRPC>({
-        handlers: { requests: {}, messages: {} },
+        handlers: {
+          requests: {
+            // Bun's local MCP listener forwards each HTTP request here. Lazy-import the
+            // MCP handler so wallet/MCP code stays out of the boot bundle until used.
+            mcpHandleHttp: async (req) => {
+              const { handleLocalMcpHttp } = await import('../features/mcp/mcp-desktop');
+              return handleLocalMcpHttp(req);
+            },
+          },
+          messages: {},
+        },
       });
       new Electroview({ rpc });
       this.rpc = rpc;

--- a/desktop/src/mainview/modules/reset-app-state.ts
+++ b/desktop/src/mainview/modules/reset-app-state.ts
@@ -1,11 +1,13 @@
 import { setMasterSeed } from '@shared/modules/wallet-utils';
 
 import { DesktopMessageType } from '../../shared/desktop-messages';
+import { teardownMcpTransport } from '../features/mcp/tunnel-desktop';
 import { BackgroundCaller } from './background-caller';
 import { Messenger } from './messenger';
 
 /** Wipes persisted storage and in-memory wallet cache. Caller must navigate to onboarding. */
 export async function resetAppState(): Promise<void> {
+  await teardownMcpTransport();
   await BackgroundCaller.clear();
   setMasterSeed('');
 

--- a/desktop/src/mainview/pages/Home.tsx
+++ b/desktop/src/mainview/pages/Home.tsx
@@ -2,7 +2,7 @@ import { ArrowDownLeft, ChevronDown, Settings } from 'lucide-react';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 
-import { ensureTunnelBootstrapped, getTunnelAutostartOnLaunch } from '../features/mcp/tunnel-desktop';
+import { ensureMcpBootstrapped, isMcpActivated } from '../features/mcp/tunnel-desktop';
 
 import { accountItems, AccountNumberContext, getAccountItem, MCP_BALANCE_ACCOUNT_NUMBER } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
@@ -48,10 +48,10 @@ const Home: React.FC = () => {
 
     let cancelled = false;
     void (async () => {
-      await ensureTunnelBootstrapped();
+      await ensureMcpBootstrapped();
       if (cancelled) return;
-      const wantsTunnelOn = await getTunnelAutostartOnLaunch();
-      if (cancelled || wantsTunnelOn) return;
+      const activated = await isMcpActivated();
+      if (cancelled || activated) return;
       setShowActivateModal(true);
     })();
     return () => {

--- a/desktop/src/mainview/pages/McpTunnelUrlModal.tsx
+++ b/desktop/src/mainview/pages/McpTunnelUrlModal.tsx
@@ -3,17 +3,19 @@ import React, { useContext, useEffect, useState, useSyncExternalStore } from 're
 import { useNavigate } from 'react-router';
 
 import { NetworkContext } from '@shared/hooks/NetworkContext';
-import { getTunnelConnectionStatus, getTunnelPublicUrl, subscribeTunnelConnection } from '../features/mcp/tunnel-desktop';
+import { getMcpLocalMode, getMcpPublicUrl, getMcpStatus, subscribeMcp } from '../features/mcp/tunnel-desktop';
 
 import { DetachedSheet } from '../components/DetachedSheet';
+import { McpLocalModeToggle } from '../components/mcp/McpLocalModeToggle';
 import './McpTunnelUrlModal.css';
 
 /** Web port of mobile `McpTunnelUrlModal`. */
 const McpTunnelUrlModal: React.FC = () => {
   const navigate = useNavigate();
   const { network } = useContext(NetworkContext);
-  const publicUrl = useSyncExternalStore(subscribeTunnelConnection, getTunnelPublicUrl, getTunnelPublicUrl);
-  const status = useSyncExternalStore(subscribeTunnelConnection, getTunnelConnectionStatus, getTunnelConnectionStatus);
+  const publicUrl = useSyncExternalStore(subscribeMcp, getMcpPublicUrl, getMcpPublicUrl);
+  const status = useSyncExternalStore(subscribeMcp, getMcpStatus, getMcpStatus);
+  const localMode = useSyncExternalStore(subscribeMcp, getMcpLocalMode, getMcpLocalMode);
 
   const urlLine = publicUrl ?? (status === 'connecting' ? 'Connecting…' : 'Not available yet');
   const [copied, setCopied] = useState(false);
@@ -60,7 +62,15 @@ const McpTunnelUrlModal: React.FC = () => {
           </button>
         </div>
 
-        <p className="mcp-tunnel-url-hint">Copy this URL for your AI provider. Anyone with the link can run MCP actions on this wallet — keep it secret.</p>
+        <McpLocalModeToggle />
+
+        <p className="mcp-tunnel-url-hint">
+          {!publicUrl
+            ? 'Inactive — press play on the Agent screen to start it, then the URL appears here.'
+            : localMode
+              ? 'Copy this URL for a local AI agent. The token in the link is its key: anyone on your network who has it can run wallet actions, so only share it on a network you trust.'
+              : 'Copy this URL for your AI provider. The token in the link is its key: anyone with it can run MCP actions on this wallet — keep it secret.'}
+        </p>
       </div>
     </DetachedSheet>
   );

--- a/desktop/src/shared/desktop-messages.ts
+++ b/desktop/src/shared/desktop-messages.ts
@@ -1,20 +1,33 @@
 import type { RPCSchema } from 'electrobun/bun';
 
+import type { TunnelHttpRequest, TunnelHttpResponse } from '@shared/features/mcp/modules/tunnel-types';
+
 /**
  * Renderer ↔ Bun message contract for desktop-native operations.
  *
  * Mirrors ext's `MessageType` / `MessageTypeMap`: the renderer (CEF) sends a generic
  * `(type, params)` message over the Electrobun RPC channel, and the Bun-side
- * `background-message-controller` dispatches it. Currently only storage crosses the
- * boundary (CEF does not persist `views://` localStorage on Linux); add new message
- * types here to extend the bus (e.g. file dialogs, deep links).
+ * `background-message-controller` dispatches it. Currently storage, notifications, and
+ * the local MCP server toggle cross the boundary; add new message types here to extend
+ * the bus (e.g. file dialogs, deep links).
  */
 export enum DesktopMessageType {
   STORAGE_GET_ITEM,
   STORAGE_SET_ITEM,
   STORAGE_CLEAR,
   SHOW_NOTIFICATION,
+  /** Start the loopback/LAN MCP HTTP listener (local "closed circuit" mode). */
+  MCP_LOCAL_SERVER_START,
+  /** Stop the local MCP HTTP listener. */
+  MCP_LOCAL_SERVER_STOP,
 }
+
+/** What the Bun side reports back after starting the local MCP server. */
+export type LocalMcpServerInfo = {
+  /** Address to paste into a local agent, e.g. `http://192.168.1.10:4435/mcp`. */
+  url: string;
+  port: number;
+};
 
 /** Native OS notification options (subset of Electrobun's `Utils.NotificationOptions`). */
 export type DesktopNotificationOptions = {
@@ -38,6 +51,8 @@ export type DesktopMessageTypeMap = {
     params: [options: DesktopNotificationOptions];
     response: null;
   };
+  [DesktopMessageType.MCP_LOCAL_SERVER_START]: { params: []; response: LocalMcpServerInfo };
+  [DesktopMessageType.MCP_LOCAL_SERVER_STOP]: { params: []; response: null };
 };
 
 /** Discriminated envelope crossing the RPC channel. */
@@ -60,7 +75,10 @@ export type DesktopAppRPC = {
     messages: Record<string, never>;
   }>;
   webview: RPCSchema<{
-    requests: Record<string, never>;
+    requests: {
+      /** Bun → renderer: hand an HTTP request from the local MCP listener to the wallet's MCP handler. */
+      mcpHandleHttp: { params: TunnelHttpRequest; response: TunnelHttpResponse };
+    };
     messages: Record<string, never>;
   }>;
 };

--- a/shared/features/mcp/modules/tunnel.ts
+++ b/shared/features/mcp/modules/tunnel.ts
@@ -43,6 +43,12 @@ export type StartTunnelOptions = {
   /** Override the default tunnel URL (e.g. for tests). */
   url?: string;
   /**
+   * When `false`, never auto-connect on launch even if the persisted autostart flag is `'1'`.
+   * Desktop local-only mode passes `false` so a stale flag (e.g. left by a crash mid-switch)
+   * can't open the public socket. Defaults to honoring the stored flag.
+   */
+  allowAutoConnect?: boolean;
+  /**
    * Called whenever the tunnel session id changes. The first time it fires
    * delivers the initial public URL; on resume the same URL is returned so
    * external agents don't need to reconfigure.
@@ -203,7 +209,7 @@ export async function startTunnel(opts: StartTunnelOptions): Promise<void> {
     });
   }
 
-  const autostart = await getTunnelAutostartOnLaunch();
+  const autostart = opts.allowAutoConnect === false ? false : await getTunnelAutostartOnLaunch();
 
   try {
     // IStorage returns '' on miss (no `null`); coerce to null so we don't pass `?sessionId=`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Exposes wallet MCP on the LAN with token-in-URL auth and adds complex transport switching; mistakes could leave the public tunnel active in “local only” mode or allow unauthorized MCP actions on untrusted networks.
> 
> **Overview**
> Adds a **local-only MCP path** on desktop: Bun hosts an HTTP listener on LAN/loopback with a persisted bearer token in the URL, forwards requests to the wallet MCP handler via **`mcpHandleHttp` RPC**, and exposes start/stop through new desktop message types. Electrobun RPC **`maxRequestTime`** is raised so long-running MCP tools are not cut off.
> 
> Desktop MCP transport is unified in **`tunnel-desktop`**: users pick **public tunnel vs local closed circuit** (`McpLocalModeToggle`), with **`activateMcp` / `pauseMcp`**, serialized transport ops, mutual exclusion (local mode never leaves the public tunnel up), restore on bootstrap, and teardown on wallet reset / shell unmount. UI and home flow use **`subscribeMcp`**, **`isMcpActivated`**, and mode-specific URL copy hints. Shared **`startTunnel`** gains **`allowAutoConnect: false`** so local preference cannot auto-open the public socket after a stale autostart flag. **`mcp-desktop.ts`** centralizes lazy MCP configuration for both transports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fde52cae54d110097a9fb20a67c3a184d14cc24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->