### PR TITLE
Feat ln address refund and refactoring

### DIFF
--- a/desktop/src/mainview/pages/ReceiveOnLightningAddress.tsx
+++ b/desktop/src/mainview/pages/ReceiveOnLightningAddress.tsx
@@ -8,8 +8,7 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-utils';
-import { createClient } from '@shared/openapi/generated/layerzme/client';
-import { getApiUsersBySparkAddressBySparkAddress } from '@shared/openapi/generated/layerzme';
+import { formatLayerzLightningAddress, LAYERZ_ME_DOMAIN, lookupLayerzLightningAddress } from '@shared/modules/layerz-lightning-address';
 import { NETWORK_LIGHTNING_TESTNET, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_SPARK } from '@shared/types/networks';
 import { StringNumber } from '@shared/types/string-number';
 
@@ -21,11 +20,6 @@ import { BackgroundCaller } from '../modules/background-caller';
 import { WideButton } from './DesignSystem';
 import './Home.css';
 import './ReceiveOnLightningAddress.css';
-
-const layerzClient = createClient({
-  baseUrl: 'https://layerz.me',
-  responseStyle: 'data',
-});
 
 const qrGifDataUrl = (text: string) => {
   const gifBytes = writeQR(text, 'gif', { scale: text.length > 43 ? 4 : 7 });
@@ -71,11 +65,18 @@ const ReceiveOnLightningAddress: React.FC = () => {
       const addressResponse = await BackgroundCaller.getAddress(network, accountNumber);
       setSparkAddress(addressResponse);
       setResolvedUsername('');
-      const lightningAddr = `${addressResponse}@layerz.me`;
-      setLightningAddress(lightningAddr);
-      const [local, domain] = lightningAddr.split('@');
+      const defaultAddr = formatLayerzLightningAddress(addressResponse);
+      setLightningAddress(defaultAddr);
+      const [local, domain] = defaultAddr.split('@');
       setLightningAddressParts({ local, domain });
-      setImgSrc(qrGifDataUrl(lightningAddr));
+      setImgSrc(qrGifDataUrl(defaultAddr));
+
+      const resolved = await lookupLayerzLightningAddress(addressResponse);
+      if (resolved.username) {
+        setResolvedUsername(resolved.username);
+        setLightningAddress(resolved.lightningAddress);
+        setImgSrc(qrGifDataUrl(resolved.lightningAddress));
+      }
     } catch (error) {
       console.error('Error fetching address:', error);
     } finally {
@@ -90,16 +91,11 @@ const ReceiveOnLightningAddress: React.FC = () => {
   const refreshResolvedUsername = useCallback(async () => {
     if (!sparkAddress || resolvedUsername) return;
     try {
-      const { data } = await getApiUsersBySparkAddressBySparkAddress({
-        client: layerzClient,
-        path: { sparkAddress },
-        responseStyle: 'fields',
-        throwOnError: false,
-      });
-      if (data?.username) {
-        setResolvedUsername(data.username);
-        setLightningAddress(`${data.username}@layerz.me`);
-        setImgSrc(qrGifDataUrl(`${data.username}@layerz.me`));
+      const resolved = await lookupLayerzLightningAddress(sparkAddress);
+      if (resolved.username) {
+        setResolvedUsername(resolved.username);
+        setLightningAddress(resolved.lightningAddress);
+        setImgSrc(qrGifDataUrl(resolved.lightningAddress));
       }
     } catch (error) {
       console.error('Error fetching username for spark address', error);
@@ -181,7 +177,7 @@ const ReceiveOnLightningAddress: React.FC = () => {
                   </div>
                   <div className="receive-lightning-address" data-testid="LightningAddressButton">
                     <span>{(resolvedUsername || lightningAddressParts?.local) ?? ''}</span>
-                    {(resolvedUsername || lightningAddressParts?.domain) && <span className="receive-lightning-domain">@{resolvedUsername ? 'layerz.me' : lightningAddressParts?.domain}</span>}
+                    {(resolvedUsername || lightningAddressParts?.domain) && <span className="receive-lightning-domain">@{resolvedUsername ? LAYERZ_ME_DOMAIN : lightningAddressParts?.domain}</span>}
                   </div>
                 </>
               ) : (

--- a/mobile/app/ClaimUsernameModal.tsx
+++ b/mobile/app/ClaimUsernameModal.tsx
@@ -3,18 +3,13 @@ import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import { ActivityIndicator, GestureResponderEvent, Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, View } from 'react-native';
 import Pressable from '../components/Pressable';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
-import { createClient } from '@shared/openapi/generated/layerzme/client';
-import { getApiUsersByUsername, postApiUsers } from '@shared/openapi/generated/layerzme';
+import { claimLayerzLightningAddressUsername, LAYERZ_ME_DOMAIN } from '@shared/modules/layerz-lightning-address';
 import { getGradientColors } from '@/utils/gradientUtils';
 import { ThemedText } from '@/components/ThemedText';
 
 export type ClaimUsernameModalParams = {
   sparkAddress: string;
 };
-
-const layerzClient = createClient({
-  baseUrl: 'https://layerz.me',
-});
 
 export default function ClaimUsernameModalScreen() {
   const router = useRouter();
@@ -68,32 +63,20 @@ export default function ClaimUsernameModalScreen() {
 
     setIsSubmitting(true);
     try {
-      const { data: existing } = await getApiUsersByUsername({
-        client: layerzClient,
-        path: { username: u },
-        responseStyle: 'fields',
-        throwOnError: false,
-      });
-
-      if (existing?.username) {
-        setErrorMessage('Username is unavailable');
-        return;
-      }
-
-      const { data: claim } = await postApiUsers({
-        client: layerzClient,
-        body: { username: u, sparkAddress: sparkAddressString },
-        responseStyle: 'fields',
-        throwOnError: true,
-      });
-
-      if (claim?.username) {
+      const result = await claimLayerzLightningAddressUsername(sparkAddressString, u);
+      if (result.ok) {
         router.back();
         return;
       }
 
-      setErrorMessage('Unable to claim username');
-    } catch (e) {
+      if (result.reason === 'empty') {
+        setErrorMessage('Please enter a username');
+      } else if (result.reason === 'taken') {
+        setErrorMessage('Username is unavailable');
+      } else {
+        setErrorMessage('Unable to claim username');
+      }
+    } catch {
       setErrorMessage('Unable to claim username');
     } finally {
       setIsSubmitting(false);
@@ -120,7 +103,7 @@ export default function ClaimUsernameModalScreen() {
                   editable={!isSubmitting}
                 />
                 <View style={styles.suffixContainer}>
-                  <ThemedText style={styles.suffixText}>@layerz.me</ThemedText>
+                  <ThemedText style={styles.suffixText}>@{LAYERZ_ME_DOMAIN}</ThemedText>
                 </View>
               </View>
 

--- a/mobile/app/PosMerchant.tsx
+++ b/mobile/app/PosMerchant.tsx
@@ -10,6 +10,7 @@ import GradientScreen from '@/components/GradientScreen';
 import ScreenHeader from '@/components/navigation/ScreenHeader';
 import { ThemedText } from '@/components/ThemedText';
 import { initiateScan, PosMetadata, queryForMetadata, ScanRequest } from '@shared/modules/merchants';
+import { resolveLayerzLightningAddress } from '@shared/modules/layerz-lightning-address';
 import { getDeviceID } from '@shared/modules/device-id';
 import { SecureStorage } from '@/src/class/secure-storage';
 import { Csprng } from '@/src/class/rng';
@@ -266,6 +267,8 @@ const PosMerchant: React.FC = () => {
     try {
       // Get the device ID
       const deviceId = await getDeviceID(SecureStorage, Csprng);
+      const sparkAddress = await BackgroundExecutor.getAddress(NETWORK_SPARK, accountNumber);
+      const refundLightningAddress = await resolveLayerzLightningAddress(sparkAddress);
 
       // Hash device ID with different salts for device_id and user_id
       const hashedDeviceId = await hashToUUID(deviceId, 'device-salt-cryptoqr');
@@ -284,6 +287,10 @@ const PosMerchant: React.FC = () => {
         user_id: hashedUserId,
         scan_data: rawParam,
         allowed_payment_methods: ['lightning'], // FIXME: should be changed to 'layerzwallet' eventually
+        refund_address: {
+          address_type: 'lightning',
+          address: refundLightningAddress,
+        },
         requested_payment_amount: {
           currency: metadata.currencyISOCode,
           denomination: metadata.denomination,

--- a/mobile/app/ReceiveOnLightningAddress.tsx
+++ b/mobile/app/ReceiveOnLightningAddress.tsx
@@ -19,17 +19,11 @@ import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { useBalance } from '@shared/hooks/useBalance';
 import { getDecimalsByNetwork, getTickerByNetwork } from '@shared/models/network-getters';
 import { capitalizeFirstLetter, formatBalance } from '@shared/modules/string-utils';
+import { formatLayerzLightningAddress, LAYERZ_ME_DOMAIN, lookupLayerzLightningAddress } from '@shared/modules/layerz-lightning-address';
 import { NETWORK_ARK, NETWORK_LIGHTNING_TESTNET, NETWORK_LIQUID, NETWORK_LIQUID_TESTNET, NETWORK_SPARK, Networks } from '@shared/types/networks';
 import { StringNumber } from '@shared/types/string-number';
-import { getApiUsersBySparkAddressBySparkAddress } from '@shared/openapi/generated/layerzme';
 
-import { createClient } from '@shared/openapi/generated/layerzme/client';
 import { ClaimUsernameModalParams } from './ClaimUsernameModal';
-
-const layerzClient = createClient({
-  baseUrl: 'https://layerz.me',
-  responseStyle: 'data',
-});
 
 const Action = ({ network, text, testID }: { network?: Networks; text: string; testID?: string }) => {
   const networkImage = network ? getNetworkImageAsset(network) : null;
@@ -82,11 +76,18 @@ export default function ReceiveOnLightningAddressScreen() {
       const addressResponse = await BackgroundExecutor.getAddress(network, accountNumber);
       setSparkAddress(addressResponse);
       setResolvedUsername('');
-      // Format as Lightning address: address@layerz.me
-      const lightningAddr = `${addressResponse}@layerz.me`;
-      setLightningAddress(lightningAddr);
-      const [local, domain] = lightningAddr.split('@');
+      const defaultAddr = formatLayerzLightningAddress(addressResponse);
+      setLightningAddress(defaultAddr);
+      const [local, domain] = defaultAddr.split('@');
       setLightningAddressParts({ local, domain });
+
+      const resolved = await lookupLayerzLightningAddress(addressResponse);
+      if (resolved.username) {
+        setResolvedUsername(resolved.username);
+        setLightningAddress(resolved.lightningAddress);
+        const [resolvedLocal, resolvedDomain] = resolved.lightningAddress.split('@');
+        setLightningAddressParts({ local: resolvedLocal, domain: resolvedDomain });
+      }
     } catch (error) {
       console.error('Error fetching address:', error);
     } finally {
@@ -101,16 +102,10 @@ export default function ReceiveOnLightningAddressScreen() {
   const refreshResolvedUsername = useCallback(async () => {
     if (!sparkAddress) return;
     try {
-      const { data } = await getApiUsersBySparkAddressBySparkAddress({
-        client: layerzClient,
-        path: { sparkAddress },
-        responseStyle: 'fields',
-        throwOnError: false,
-      });
-
-      if (data?.username) {
-        setResolvedUsername(data.username);
-        setLightningAddress(`${data.username}@layerz.me`);
+      const resolved = await lookupLayerzLightningAddress(sparkAddress);
+      if (resolved.username) {
+        setResolvedUsername(resolved.username);
+        setLightningAddress(resolved.lightningAddress);
       }
     } catch (error) {
       console.error('Error fetching username for spark address', error);
@@ -242,7 +237,9 @@ export default function ReceiveOnLightningAddressScreen() {
                   <Animated.View style={[styles.addressContainer, { transform: [{ scale: pressScaleAnim }] }]}>
                     <ThemedText style={styles.addressDisplay}>
                       {(resolvedUsername || lightningAddressParts?.local) ?? ''}
-                      {(resolvedUsername || lightningAddressParts?.domain) && <ThemedText style={styles.domainDisplay}>@{resolvedUsername ? 'layerz.me' : lightningAddressParts?.domain}</ThemedText>}
+                      {(resolvedUsername || lightningAddressParts?.domain) && (
+                        <ThemedText style={styles.domainDisplay}>@{resolvedUsername ? LAYERZ_ME_DOMAIN : lightningAddressParts?.domain}</ThemedText>
+                      )}
                     </ThemedText>
                   </Animated.View>
                 </Pressable>

--- a/shared/features/mcp/modules/mcp-calls.ts
+++ b/shared/features/mcp/modules/mcp-calls.ts
@@ -31,9 +31,7 @@ import { getAssetInfo } from '../../../models/asset-info';
 import { getDecimalsByNetwork, getIsEVM, getIsTestnet, getTickerByNetwork } from '../../../models/network-getters';
 import { getTokenInfo, getTokenList } from '../../../models/token-list';
 import { validateAddress, type TSupportedLazyInitWalletNetworks } from '../../../modules/wallet-utils';
-import { getApiUsersByUsername, postApiUsers } from '../../../openapi/generated/layerzme';
-import { createClient } from '../../../openapi/generated/layerzme/client';
-import { formatLayerzLightningAddress, LAYERZ_ME_DOMAIN, lookupLayerzLightningAddress } from '../../../modules/layerz-lightning-address';
+import { claimLayerzLightningAddressUsername, LAYERZ_ME_DOMAIN, lookupLayerzLightningAddress } from '../../../modules/layerz-lightning-address';
 import { AssetId } from '../../../types/asset';
 import type { SendQuote } from '../../../types/send-quote';
 import {
@@ -190,17 +188,6 @@ function showMcpSuccess(deps: McpCallDeps, actionSummary: string, detail?: strin
 
 function trackMcpCall(deps: McpCallDeps, toolName: string): void {
   deps.trackToolCall?.(toolName);
-}
-
-/**
- * Layerz Lightning Addresses are served by the layerz.me SparkHub (Spark-backed). Usernames are
- * registered/looked up over plain HTTP via the generated client — there is no wallet/SDK method for
- * this; see `lookupLayerzLightningAddress()` in `modules/layerz-lightning-address.ts`.
- */
-const LAYERZ_ME_BASE_URL = 'https://layerz.me';
-
-function layerzMeClient() {
-  return createClient({ baseUrl: LAYERZ_ME_BASE_URL });
 }
 
 export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void {
@@ -2019,41 +2006,40 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
       },
     },
     async ({ username: usernameRaw }) => {
-      const username = usernameRaw.trim().toLowerCase();
-      mcpCallLog(`claim_lightning_address: start - "${username}"`);
+      mcpCallLog(`claim_lightning_address: start - "${usernameRaw.trim()}"`);
       trackMcpCall(deps, 'claim_lightning_address');
       try {
-        if (!username) {
-          return {
-            isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: 'Username must not be empty.' }, null, 2) }],
-          };
-        }
-
-        const client = layerzMeClient();
         const sparkAddress = await backgroundCaller.getAddress(NETWORK_SPARK, MCP_BALANCE_ACCOUNT_NUMBER);
-
-        const { data: existing } = await getApiUsersByUsername({ client, path: { username }, responseStyle: 'fields', throwOnError: false });
-        if (existing?.username) {
-          mcpCallLog(`claim_lightning_address: error - "${username}" already taken`);
+        const claim = await claimLayerzLightningAddressUsername(sparkAddress, usernameRaw);
+        if (!claim.ok) {
+          let error: string;
+          switch (claim.reason) {
+            case 'empty':
+              error = 'Username must not be empty.';
+              break;
+            case 'taken': {
+              const username = usernameRaw.trim().toLowerCase();
+              mcpCallLog(`claim_lightning_address: error - "${username}" already taken`);
+              error = `Username "${username}" is unavailable.`;
+              break;
+            }
+            case 'unconfirmed':
+              mcpCallLog('claim_lightning_address: error - layerz.me did not confirm the claim');
+              error = 'Unable to claim username.';
+              break;
+            case 'api_error':
+              mcpCallLog(`claim_lightning_address: error - ${claim.message ?? 'layerz.me request failed'}`);
+              error = claim.message ?? 'Unable to claim username.';
+              break;
+          }
           return {
             isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: `Username "${username}" is unavailable.` }, null, 2) }],
+            content: [{ type: 'text', text: JSON.stringify({ error }, null, 2) }],
           };
         }
 
-        const { data: claim } = await postApiUsers({ client, body: { username, sparkAddress }, responseStyle: 'fields', throwOnError: true });
-        if (!claim?.username) {
-          mcpCallLog('claim_lightning_address: error - layerz.me did not confirm the claim');
-          return {
-            isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: 'Unable to claim username.' }, null, 2) }],
-          };
-        }
-
-        const lightningAddress = formatLayerzLightningAddress(claim.username);
-        mcpCallLog(`claim_lightning_address: ok - ${lightningAddress}`);
-        showMcpSuccess(deps, `Claimed Lightning Address ${lightningAddress}`);
+        mcpCallLog(`claim_lightning_address: ok - ${claim.lightningAddress}`);
+        showMcpSuccess(deps, `Claimed Lightning Address ${claim.lightningAddress}`);
         return {
           content: [
             {
@@ -2061,7 +2047,7 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
               text: JSON.stringify(
                 {
                   success: true,
-                  lightning_address: lightningAddress,
+                  lightning_address: claim.lightningAddress,
                   username: claim.username,
                   spark_address: sparkAddress,
                   domain: LAYERZ_ME_DOMAIN,

--- a/shared/features/mcp/modules/mcp-calls.ts
+++ b/shared/features/mcp/modules/mcp-calls.ts
@@ -31,8 +31,9 @@ import { getAssetInfo } from '../../../models/asset-info';
 import { getDecimalsByNetwork, getIsEVM, getIsTestnet, getTickerByNetwork } from '../../../models/network-getters';
 import { getTokenInfo, getTokenList } from '../../../models/token-list';
 import { validateAddress, type TSupportedLazyInitWalletNetworks } from '../../../modules/wallet-utils';
-import { getApiUsersByUsername, getApiUsersBySparkAddressBySparkAddress, postApiUsers } from '../../../openapi/generated/layerzme';
+import { getApiUsersByUsername, postApiUsers } from '../../../openapi/generated/layerzme';
 import { createClient } from '../../../openapi/generated/layerzme/client';
+import { formatLayerzLightningAddress, LAYERZ_ME_DOMAIN, lookupLayerzLightningAddress } from '../../../modules/layerz-lightning-address';
 import { AssetId } from '../../../types/asset';
 import type { SendQuote } from '../../../types/send-quote';
 import {
@@ -194,9 +195,8 @@ function trackMcpCall(deps: McpCallDeps, toolName: string): void {
 /**
  * Layerz Lightning Addresses are served by the layerz.me SparkHub (Spark-backed). Usernames are
  * registered/looked up over plain HTTP via the generated client — there is no wallet/SDK method for
- * this; the mobile claim/receive screens hit the same endpoints.
+ * this; see `lookupLayerzLightningAddress()` in `modules/layerz-lightning-address.ts`.
  */
-const LAYERZ_ME_DOMAIN = 'layerz.me';
 const LAYERZ_ME_BASE_URL = 'https://layerz.me';
 
 function layerzMeClient() {
@@ -1977,19 +1977,7 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
       trackMcpCall(deps, 'get_lightning_address');
       try {
         const sparkAddress = await backgroundCaller.getAddress(NETWORK_SPARK, MCP_BALANCE_ACCOUNT_NUMBER);
-
-        let username: string | null = null;
-        try {
-          const { data } = await getApiUsersBySparkAddressBySparkAddress({ client: layerzMeClient(), path: { sparkAddress }, responseStyle: 'fields', throwOnError: false });
-          if (data?.username) username = data.username;
-        } catch (e) {
-          // The default `<spark-address>@layerz.me` is always valid, so a username lookup failure is
-          // non-fatal — fall back to it rather than failing the whole call.
-          const message = e instanceof Error ? e.message : String(e);
-          mcpCallLog(`get_lightning_address: username lookup failed, using default address - ${message}`);
-        }
-
-        const lightningAddress = `${username ?? sparkAddress}@${LAYERZ_ME_DOMAIN}`;
+        const { lightningAddress, username, claimed } = await lookupLayerzLightningAddress(sparkAddress);
         mcpCallLog(`get_lightning_address: ok - ${lightningAddress}`);
         showMcpSuccess(deps, 'Lightning Address', lightningAddress);
         return {
@@ -2001,7 +1989,7 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
                   lightning_address: lightningAddress,
                   spark_address: sparkAddress,
                   username,
-                  claimed: username !== null,
+                  claimed,
                   domain: LAYERZ_ME_DOMAIN,
                 },
                 null,
@@ -2063,7 +2051,7 @@ export function registerWalletMcpCalls(mcp: McpServer, deps: McpCallDeps): void 
           };
         }
 
-        const lightningAddress = `${claim.username}@${LAYERZ_ME_DOMAIN}`;
+        const lightningAddress = formatLayerzLightningAddress(claim.username);
         mcpCallLog(`claim_lightning_address: ok - ${lightningAddress}`);
         showMcpSuccess(deps, `Claimed Lightning Address ${lightningAddress}`);
         return {

--- a/shared/modules/layerz-lightning-address.ts
+++ b/shared/modules/layerz-lightning-address.ts
@@ -1,0 +1,49 @@
+import { createClient } from '../openapi/generated/layerzme/client';
+import { getApiUsersBySparkAddressBySparkAddress } from '../openapi/generated/layerzme';
+
+export const LAYERZ_ME_DOMAIN = 'layerz.me';
+const LAYERZ_ME_BASE_URL = 'https://layerz.me';
+
+let layerzMeClient: ReturnType<typeof createClient> | undefined;
+
+function getLayerzMeClient() {
+  layerzMeClient ??= createClient({ baseUrl: LAYERZ_ME_BASE_URL });
+  return layerzMeClient;
+}
+
+export type LayerzLightningAddressLookup = {
+  lightningAddress: string;
+  username: string | null;
+  claimed: boolean;
+};
+
+export function formatLayerzLightningAddress(localPart: string): string {
+  return `${localPart}@${LAYERZ_ME_DOMAIN}`;
+}
+
+/** Looks up a claimed username; falls back to `<spark-address>@layerz.me`. */
+export async function lookupLayerzLightningAddress(sparkAddress: string): Promise<LayerzLightningAddressLookup> {
+  let username: string | null = null;
+  try {
+    const { data } = await getApiUsersBySparkAddressBySparkAddress({
+      client: getLayerzMeClient(),
+      path: { sparkAddress },
+      responseStyle: 'fields',
+      throwOnError: false,
+    });
+    if (data?.username) username = data.username;
+  } catch {
+    // The default `<spark-address>@layerz.me` is always valid.
+  }
+
+  return {
+    lightningAddress: formatLayerzLightningAddress(username ?? sparkAddress),
+    username,
+    claimed: username !== null,
+  };
+}
+
+/** Returns the wallet's Layerz Lightning Address (claimed username or spark-address fallback). */
+export async function resolveLayerzLightningAddress(sparkAddress: string): Promise<string> {
+  return (await lookupLayerzLightningAddress(sparkAddress)).lightningAddress;
+}

--- a/shared/modules/layerz-lightning-address.ts
+++ b/shared/modules/layerz-lightning-address.ts
@@ -1,5 +1,5 @@
+import { getApiUsersBySparkAddressBySparkAddress, getApiUsersByUsername, postApiUsers } from '../openapi/generated/layerzme';
 import { createClient } from '../openapi/generated/layerzme/client';
-import { getApiUsersBySparkAddressBySparkAddress } from '../openapi/generated/layerzme';
 
 export const LAYERZ_ME_DOMAIN = 'layerz.me';
 const LAYERZ_ME_BASE_URL = 'https://layerz.me';
@@ -16,6 +16,10 @@ export type LayerzLightningAddressLookup = {
   username: string | null;
   claimed: boolean;
 };
+
+export type ClaimLayerzUsernameFailureReason = 'empty' | 'taken' | 'unconfirmed' | 'api_error';
+
+export type ClaimLayerzUsernameResult = { ok: true; username: string; lightningAddress: string } | { ok: false; reason: ClaimLayerzUsernameFailureReason; message?: string };
 
 export function formatLayerzLightningAddress(localPart: string): string {
   return `${localPart}@${LAYERZ_ME_DOMAIN}`;
@@ -46,4 +50,45 @@ export async function lookupLayerzLightningAddress(sparkAddress: string): Promis
 /** Returns the wallet's Layerz Lightning Address (claimed username or spark-address fallback). */
 export async function resolveLayerzLightningAddress(sparkAddress: string): Promise<string> {
   return (await lookupLayerzLightningAddress(sparkAddress)).lightningAddress;
+}
+
+/** Registers a human-readable username for a Spark address on layerz.me. */
+export async function claimLayerzLightningAddressUsername(sparkAddress: string, usernameRaw: string): Promise<ClaimLayerzUsernameResult> {
+  const username = usernameRaw.trim().toLowerCase();
+  if (!username) {
+    return { ok: false, reason: 'empty' };
+  }
+
+  const { data: existing } = await getApiUsersByUsername({
+    client: getLayerzMeClient(),
+    path: { username },
+    responseStyle: 'fields',
+    throwOnError: false,
+  });
+  if (existing?.username) {
+    return { ok: false, reason: 'taken' };
+  }
+
+  try {
+    const { data: claim } = await postApiUsers({
+      client: getLayerzMeClient(),
+      body: { username, sparkAddress },
+      responseStyle: 'fields',
+      throwOnError: true,
+    });
+    if (!claim?.username) {
+      return { ok: false, reason: 'unconfirmed' };
+    }
+    return {
+      ok: true,
+      username: claim.username,
+      lightningAddress: formatLayerzLightningAddress(claim.username),
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      reason: 'api_error',
+      message: e instanceof Error ? e.message : String(e),
+    };
+  }
 }

--- a/shared/modules/merchants.ts
+++ b/shared/modules/merchants.ts
@@ -184,8 +184,15 @@ export const queryForMetadata = async (payload: string): Promise<PosMetadata> =>
   return data;
 };
 
+/** @see https://api.cryptoqr.net/scanner/v1/swagger.yaml */
+export type ScanRefundAddress = {
+  address_type: 'lightning';
+  address: string;
+};
+
 /**
  * @see https://moneybadger-qr-scanner.readme.io/reference/scan
+ * @see https://api.cryptoqr.net/scanner/v1/swagger.yaml
  */
 export type ScanRequest = {
   scan_id: string;
@@ -197,6 +204,7 @@ export type ScanRequest = {
   allowed_payment_methods?: string[];
   payment_currencies?: string[];
   payment_reference?: string;
+  refund_address: ScanRefundAddress;
   requested_payment_amount?: {
     currency: string;
     denomination: string;

--- a/shared/tests/unit-vi/layerz-lightning-address.test.ts
+++ b/shared/tests/unit-vi/layerz-lightning-address.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { claimLayerzLightningAddressUsername, formatLayerzLightningAddress, lookupLayerzLightningAddress, resolveLayerzLightningAddress } from '../../modules/layerz-lightning-address';
+
 const { mockGetBySparkAddress, mockGetByUsername, mockPostUsers, mockCreateClient } = vi.hoisted(() => ({
   mockGetBySparkAddress: vi.fn(),
   mockGetByUsername: vi.fn(),
@@ -16,8 +18,6 @@ vi.mock('../../openapi/generated/layerzme', () => ({
 vi.mock('../../openapi/generated/layerzme/client', () => ({
   createClient: mockCreateClient,
 }));
-
-import { claimLayerzLightningAddressUsername, formatLayerzLightningAddress, lookupLayerzLightningAddress, resolveLayerzLightningAddress } from '../../modules/layerz-lightning-address';
 
 const SPARK_ADDRESS = 'spark1testaddress';
 

--- a/shared/tests/unit-vi/layerz-lightning-address.test.ts
+++ b/shared/tests/unit-vi/layerz-lightning-address.test.ts
@@ -1,48 +1,125 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetBySparkAddress, mockCreateClient } = vi.hoisted(() => ({
+const { mockGetBySparkAddress, mockGetByUsername, mockPostUsers, mockCreateClient } = vi.hoisted(() => ({
   mockGetBySparkAddress: vi.fn(),
+  mockGetByUsername: vi.fn(),
+  mockPostUsers: vi.fn(),
   mockCreateClient: vi.fn(() => ({})),
 }));
 
 vi.mock('../../openapi/generated/layerzme', () => ({
   getApiUsersBySparkAddressBySparkAddress: mockGetBySparkAddress,
+  getApiUsersByUsername: mockGetByUsername,
+  postApiUsers: mockPostUsers,
 }));
 
 vi.mock('../../openapi/generated/layerzme/client', () => ({
   createClient: mockCreateClient,
 }));
 
-import { LAYERZ_ME_DOMAIN, lookupLayerzLightningAddress, resolveLayerzLightningAddress } from '../../modules/layerz-lightning-address';
+import { claimLayerzLightningAddressUsername, formatLayerzLightningAddress, lookupLayerzLightningAddress, resolveLayerzLightningAddress } from '../../modules/layerz-lightning-address';
 
 const SPARK_ADDRESS = 'spark1testaddress';
 
-describe('resolveLayerzLightningAddress', () => {
+describe('formatLayerzLightningAddress', () => {
+  it('appends @layerz.me', () => {
+    expect(formatLayerzLightningAddress('alice')).toBe('alice@layerz.me');
+    expect(formatLayerzLightningAddress(SPARK_ADDRESS)).toBe(`${SPARK_ADDRESS}@layerz.me`);
+  });
+});
+
+describe('lookupLayerzLightningAddress', () => {
   beforeEach(() => {
     mockGetBySparkAddress.mockReset();
   });
 
-  it('returns claimed username@layerz.me when registered', async () => {
+  it('uses the registered username instead of the spark address', async () => {
     mockGetBySparkAddress.mockResolvedValueOnce({ data: { username: 'alice' } });
-    await expect(resolveLayerzLightningAddress(SPARK_ADDRESS)).resolves.toBe(`alice@${LAYERZ_ME_DOMAIN}`);
+
+    const result = await lookupLayerzLightningAddress(SPARK_ADDRESS);
+
+    expect(result.lightningAddress).toBe('alice@layerz.me');
+    expect(result.username).toBe('alice');
+    expect(result.claimed).toBe(true);
+    expect(mockGetBySparkAddress).toHaveBeenCalledWith(expect.objectContaining({ path: { sparkAddress: SPARK_ADDRESS }, throwOnError: false }));
   });
 
-  it('falls back to spark-address@layerz.me when no username is claimed', async () => {
-    mockGetBySparkAddress.mockResolvedValueOnce({ data: {} });
-    await expect(resolveLayerzLightningAddress(SPARK_ADDRESS)).resolves.toBe(`${SPARK_ADDRESS}@${LAYERZ_ME_DOMAIN}`);
+  it('falls back to the spark address when no username is registered', async () => {
+    mockGetBySparkAddress.mockResolvedValueOnce({ data: { status: 'not_found' } });
+
+    const result = await lookupLayerzLightningAddress(SPARK_ADDRESS);
+
+    expect(result.lightningAddress).toBe(`${SPARK_ADDRESS}@layerz.me`);
+    expect(result.username).toBeNull();
+    expect(result.claimed).toBe(false);
   });
 
-  it('falls back to spark-address@layerz.me when lookup throws', async () => {
+  it('falls back when the lookup request fails', async () => {
     mockGetBySparkAddress.mockRejectedValueOnce(new Error('layerz.me 500'));
-    await expect(resolveLayerzLightningAddress(SPARK_ADDRESS)).resolves.toBe(`${SPARK_ADDRESS}@${LAYERZ_ME_DOMAIN}`);
+
+    const result = await lookupLayerzLightningAddress(SPARK_ADDRESS);
+
+    expect(result.lightningAddress).toBe(`${SPARK_ADDRESS}@layerz.me`);
+    expect(result.claimed).toBe(false);
+  });
+});
+
+describe('resolveLayerzLightningAddress', () => {
+  it('returns the lightningAddress field from lookup', async () => {
+    mockGetBySparkAddress.mockResolvedValueOnce({ data: { username: 'bob' } });
+    await expect(resolveLayerzLightningAddress(SPARK_ADDRESS)).resolves.toBe('bob@layerz.me');
+  });
+});
+
+describe('claimLayerzLightningAddressUsername', () => {
+  beforeEach(() => {
+    mockGetByUsername.mockReset();
+    mockPostUsers.mockReset();
   });
 
-  it('lookupLayerzLightningAddress returns structured result', async () => {
-    mockGetBySparkAddress.mockResolvedValueOnce({ data: { username: 'alice' } });
-    await expect(lookupLayerzLightningAddress(SPARK_ADDRESS)).resolves.toEqual({
-      lightningAddress: `alice@${LAYERZ_ME_DOMAIN}`,
-      username: 'alice',
-      claimed: true,
-    });
+  it('rejects whitespace-only input before calling the API', async () => {
+    const result = await claimLayerzLightningAddressUsername(SPARK_ADDRESS, '   ');
+
+    expect(result).toEqual({ ok: false, reason: 'empty' });
+    expect(mockGetByUsername).not.toHaveBeenCalled();
+    expect(mockPostUsers).not.toHaveBeenCalled();
+  });
+
+  it('normalizes input and posts the spark address', async () => {
+    mockGetByUsername.mockResolvedValueOnce({ data: { status: 'not_found' } });
+    mockPostUsers.mockResolvedValueOnce({ data: { username: 'alice', sparkAddress: SPARK_ADDRESS } });
+
+    const result = await claimLayerzLightningAddressUsername(SPARK_ADDRESS, '  Alice ');
+
+    expect(result).toEqual({ ok: true, username: 'alice', lightningAddress: 'alice@layerz.me' });
+    expect(mockGetByUsername).toHaveBeenCalledWith(expect.objectContaining({ path: { username: 'alice' } }));
+    expect(mockPostUsers).toHaveBeenCalledWith(expect.objectContaining({ body: { username: 'alice', sparkAddress: SPARK_ADDRESS } }));
+  });
+
+  it('does not POST when the username is already taken', async () => {
+    mockGetByUsername.mockResolvedValueOnce({ data: { username: 'alice', sparkAddress: 'spark1other' } });
+
+    const result = await claimLayerzLightningAddressUsername(SPARK_ADDRESS, 'alice');
+
+    expect(result).toEqual({ ok: false, reason: 'taken' });
+    expect(mockPostUsers).not.toHaveBeenCalled();
+  });
+
+  it('treats a POST body without username as unconfirmed', async () => {
+    mockGetByUsername.mockResolvedValueOnce({ data: { status: 'not_found' } });
+    mockPostUsers.mockResolvedValueOnce({ data: { status: 'error', message: 'nope' } });
+
+    const result = await claimLayerzLightningAddressUsername(SPARK_ADDRESS, 'alice');
+
+    expect(result).toEqual({ ok: false, reason: 'unconfirmed' });
+  });
+
+  it('surfaces POST failures as api_error', async () => {
+    mockGetByUsername.mockResolvedValueOnce({ data: { status: 'not_found' } });
+    mockPostUsers.mockRejectedValueOnce(new Error('layerz.me unavailable'));
+
+    const result = await claimLayerzLightningAddressUsername(SPARK_ADDRESS, 'alice');
+
+    expect(result).toEqual({ ok: false, reason: 'api_error', message: 'layerz.me unavailable' });
   });
 });

--- a/shared/tests/unit-vi/layerz-lightning-address.test.ts
+++ b/shared/tests/unit-vi/layerz-lightning-address.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetBySparkAddress, mockCreateClient } = vi.hoisted(() => ({
+  mockGetBySparkAddress: vi.fn(),
+  mockCreateClient: vi.fn(() => ({})),
+}));
+
+vi.mock('../../openapi/generated/layerzme', () => ({
+  getApiUsersBySparkAddressBySparkAddress: mockGetBySparkAddress,
+}));
+
+vi.mock('../../openapi/generated/layerzme/client', () => ({
+  createClient: mockCreateClient,
+}));
+
+import { LAYERZ_ME_DOMAIN, lookupLayerzLightningAddress, resolveLayerzLightningAddress } from '../../modules/layerz-lightning-address';
+
+const SPARK_ADDRESS = 'spark1testaddress';
+
+describe('resolveLayerzLightningAddress', () => {
+  beforeEach(() => {
+    mockGetBySparkAddress.mockReset();
+  });
+
+  it('returns claimed username@layerz.me when registered', async () => {
+    mockGetBySparkAddress.mockResolvedValueOnce({ data: { username: 'alice' } });
+    await expect(resolveLayerzLightningAddress(SPARK_ADDRESS)).resolves.toBe(`alice@${LAYERZ_ME_DOMAIN}`);
+  });
+
+  it('falls back to spark-address@layerz.me when no username is claimed', async () => {
+    mockGetBySparkAddress.mockResolvedValueOnce({ data: {} });
+    await expect(resolveLayerzLightningAddress(SPARK_ADDRESS)).resolves.toBe(`${SPARK_ADDRESS}@${LAYERZ_ME_DOMAIN}`);
+  });
+
+  it('falls back to spark-address@layerz.me when lookup throws', async () => {
+    mockGetBySparkAddress.mockRejectedValueOnce(new Error('layerz.me 500'));
+    await expect(resolveLayerzLightningAddress(SPARK_ADDRESS)).resolves.toBe(`${SPARK_ADDRESS}@${LAYERZ_ME_DOMAIN}`);
+  });
+
+  it('lookupLayerzLightningAddress returns structured result', async () => {
+    mockGetBySparkAddress.mockResolvedValueOnce({ data: { username: 'alice' } });
+    await expect(lookupLayerzLightningAddress(SPARK_ADDRESS)).resolves.toEqual({
+      lightningAddress: `alice@${LAYERZ_ME_DOMAIN}`,
+      username: 'alice',
+      claimed: true,
+    });
+  });
+});

--- a/shared/tests/unit-vi/mcp-calls-lightning-address.test.ts
+++ b/shared/tests/unit-vi/mcp-calls-lightning-address.test.ts
@@ -1,21 +1,6 @@
 /**
- * Tests the two Lightning-Address MCP tools: `get_lightning_address` and `claim_lightning_address`.
- *
- * A Layerz Lightning Address is Spark + layerz.me only. The default address is always
- * `<spark-address>@layerz.me` (payable immediately, no claim). "Claiming" registers a human
- * username via the layerz.me SparkHub HTTP API (`GET /api/users/{username}` availability check →
- * `POST /api/users {username, sparkAddress}`), after which the address becomes `<username>@layerz.me`.
- * This is exactly what the mobile `ClaimUsernameModal` / `ReceiveOnLightningAddress` screens do — no
- * new wallet/SDK method is involved, so we mock the generated layerz.me client + `getAddress`.
- *
- * These tests pin:
- *  - get: claimed-username address, default fallback when no username is claimed, SOFT fallback to
- *    the default address when the layerz.me lookup throws (must NOT error), and a hard error when
- *    `getAddress` itself fails.
- *  - claim: trim+lowercase of the username, availability check then POST with the wallet's spark
- *    address, success toast/tracking, "already taken" rejection (without POSTing), empty-after-trim
- *    rejection (without hitting the API), a POST response lacking a username, and an API failure
- *    surfacing as an MCP error (not a throw) with no success toast.
+ * MCP wiring for lightning-address tools only. Business logic lives in
+ * `modules/layerz-lightning-address.ts` — tested there, not re-tested here.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -25,8 +10,6 @@ import { registerWalletMcpCalls } from '../../features/mcp/modules/mcp-calls';
 import type { McpCallDeps } from '../../features/mcp/modules/mcp-deps';
 import { NETWORK_SPARK } from '../../types/networks';
 
-// Heavy module graph pulled in at import time by mcp-calls.ts — stub it so the surface stays
-// cheap and deterministic (mirrors the other mcp-calls unit tests).
 vi.mock('@flashnet/sdk', () => ({ FlashnetClient: vi.fn(), isFlashnetError: vi.fn().mockReturnValue(false) }));
 vi.mock('@buildonspark/spark-sdk', () => ({ isValidSparkAddress: vi.fn().mockReturnValue(true) }));
 vi.mock('../../hooks/useTransferService', () => ({ useTransferService: vi.fn(), getTransferServiceManager: vi.fn(), setFlashnetAccountNumber: vi.fn() }));
@@ -36,7 +19,6 @@ vi.mock('../../hooks/useTokenBalance', () => ({ tokenBalanceFetcher: vi.fn() }))
 vi.mock('../../features/mcp/modules/mcp-activity-log', () => ({ pushMcpActivityLog: vi.fn() }));
 vi.mock('../../modules/wallet-utils', () => ({ validateAddress: vi.fn().mockReturnValue(true) }));
 
-// The layerz.me SparkHub client — the only thing the two tools talk to (besides `getAddress`).
 const { mockGetByUsername, mockGetBySparkAddress, mockPostUsers, mockCreateClient } = vi.hoisted(() => ({
   mockGetByUsername: vi.fn(),
   mockGetBySparkAddress: vi.fn(),
@@ -57,7 +39,6 @@ function parseToolJson(result: { content: { text: string }[] }): any {
 }
 
 const SPARK_ADDRESS = 'spark1exampleownaddress000000000000000000';
-
 const mockGetAddress = vi.fn();
 
 function makeFakeDeps(): McpCallDeps {
@@ -71,12 +52,7 @@ function makeFakeDeps(): McpCallDeps {
 
 function buildHandlers(deps: McpCallDeps): Map<string, ToolHandler> {
   const handlers = new Map<string, ToolHandler>();
-  const fakeServer = {
-    registerTool: vi.fn((name: string, _config: unknown, handler: ToolHandler) => {
-      handlers.set(name, handler);
-    }),
-  };
-  registerWalletMcpCalls(fakeServer as any, deps);
+  registerWalletMcpCalls({ registerTool: vi.fn((name: string, _config: unknown, handler: ToolHandler) => handlers.set(name, handler)) } as any, deps);
   return handlers;
 }
 
@@ -86,58 +62,28 @@ describe('MCP get_lightning_address', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateClient.mockReturnValue({ __client: true });
+    mockCreateClient.mockReturnValue({});
     mockGetAddress.mockResolvedValue(SPARK_ADDRESS);
+    mockGetBySparkAddress.mockResolvedValue({ data: { username: 'alice' } });
     deps = makeFakeDeps();
     handlers = buildHandlers(deps);
   });
 
-  it('returns the claimed username address when a username is registered for this spark address', async () => {
-    mockGetBySparkAddress.mockResolvedValueOnce({ data: { status: 'ok', username: 'alice', sparkAddress: SPARK_ADDRESS } });
-
+  it('loads the spark address from the wallet and returns MCP JSON', async () => {
     const result = await handlers.get('get_lightning_address')!({});
 
     expect(result.isError).toBeUndefined();
-    const body = parseToolJson(result);
-    expect(body.lightning_address).toBe('alice@layerz.me');
-    expect(body.spark_address).toBe(SPARK_ADDRESS);
-    expect(body.username).toBe('alice');
-    expect(body.claimed).toBe(true);
-    expect(body.domain).toBe('layerz.me');
-
+    expect(parseToolJson(result)).toMatchObject({
+      lightning_address: 'alice@layerz.me',
+      spark_address: SPARK_ADDRESS,
+      domain: 'layerz.me',
+    });
     expect(mockGetAddress).toHaveBeenCalledWith(NETWORK_SPARK, MCP_BALANCE_ACCOUNT_NUMBER);
-    expect(mockGetBySparkAddress).toHaveBeenCalledTimes(1);
     expect(deps.trackToolCall).toHaveBeenCalledWith('get_lightning_address');
-    // Like every other read tool (get_network_balance / get_receive_address / …), a successful read
-    // pushes to the activity log and fires the toast so it shows up in the calls-log component.
     expect(deps.showSuccessToast).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to the default <spark-address>@layerz.me when no username is claimed', async () => {
-    mockGetBySparkAddress.mockResolvedValueOnce({ data: { status: 'not_found' } });
-
-    const result = await handlers.get('get_lightning_address')!({});
-
-    expect(result.isError).toBeUndefined();
-    const body = parseToolJson(result);
-    expect(body.lightning_address).toBe(`${SPARK_ADDRESS}@layerz.me`);
-    expect(body.username).toBeNull();
-    expect(body.claimed).toBe(false);
-  });
-
-  it('SOFT-falls back to the default address when the layerz.me lookup throws (does not error)', async () => {
-    mockGetBySparkAddress.mockRejectedValueOnce(new Error('layerz.me 500'));
-
-    const result = await handlers.get('get_lightning_address')!({});
-
-    expect(result.isError).toBeUndefined();
-    const body = parseToolJson(result);
-    expect(body.lightning_address).toBe(`${SPARK_ADDRESS}@layerz.me`);
-    expect(body.username).toBeNull();
-    expect(body.claimed).toBe(false);
-  });
-
-  it('surfaces a getAddress failure as an MCP error (not a throw)', async () => {
+  it('does not call layerz.me when getAddress fails', async () => {
     mockGetAddress.mockRejectedValueOnce(new Error('wallet not ready'));
 
     const result = await handlers.get('get_lightning_address')!({});
@@ -154,70 +100,30 @@ describe('MCP claim_lightning_address', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateClient.mockReturnValue({ __client: true });
+    mockCreateClient.mockReturnValue({});
     mockGetAddress.mockResolvedValue(SPARK_ADDRESS);
-    // Default: username is available.
     mockGetByUsername.mockResolvedValue({ data: { status: 'not_found' } });
-    mockPostUsers.mockResolvedValue({ data: { status: 'ok', message: 'created', username: 'alice', sparkAddress: SPARK_ADDRESS } });
+    mockPostUsers.mockResolvedValue({ data: { username: 'alice', sparkAddress: SPARK_ADDRESS } });
     deps = makeFakeDeps();
     handlers = buildHandlers(deps);
   });
 
-  it('claims an available username (trim+lowercase) and binds it to the wallet spark address', async () => {
-    const result = await handlers.get('claim_lightning_address')!({ username: '  Alice ' });
+  it('returns success JSON and toast after a successful claim', async () => {
+    const result = await handlers.get('claim_lightning_address')!({ username: 'alice' });
 
     expect(result.isError).toBeUndefined();
-    const body = parseToolJson(result);
-    expect(body.success).toBe(true);
-    expect(body.lightning_address).toBe('alice@layerz.me');
-    expect(body.username).toBe('alice');
-    expect(body.spark_address).toBe(SPARK_ADDRESS);
-    expect(body.domain).toBe('layerz.me');
-
-    expect(mockGetByUsername).toHaveBeenCalledWith(expect.objectContaining({ path: { username: 'alice' } }));
-    expect(mockPostUsers).toHaveBeenCalledWith(expect.objectContaining({ body: { username: 'alice', sparkAddress: SPARK_ADDRESS } }));
-
+    expect(parseToolJson(result)).toMatchObject({ success: true, username: 'alice', spark_address: SPARK_ADDRESS });
+    expect(mockGetAddress).toHaveBeenCalledWith(NETWORK_SPARK, MCP_BALANCE_ACCOUNT_NUMBER);
     expect(deps.trackToolCall).toHaveBeenCalledWith('claim_lightning_address');
     expect(deps.showSuccessToast).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects a username that is already taken, without POSTing', async () => {
-    mockGetByUsername.mockResolvedValueOnce({ data: { status: 'ok', username: 'alice', sparkAddress: 'spark1someoneelse00000000000000000000000' } });
-
-    const result = await handlers.get('claim_lightning_address')!({ username: 'alice' });
-
-    expect(result.isError).toBe(true);
-    expect(parseToolJson(result).error).toMatch(/unavailable|taken/i);
-    expect(mockPostUsers).not.toHaveBeenCalled();
-    expect(deps.showSuccessToast).not.toHaveBeenCalled();
-  });
-
-  it('rejects an empty/whitespace username without hitting the API', async () => {
+  it('maps module empty-input failure to an MCP error without calling the API', async () => {
     const result = await handlers.get('claim_lightning_address')!({ username: '   ' });
 
     expect(result.isError).toBe(true);
-    expect(parseToolJson(result).error).toMatch(/username/i);
+    expect(parseToolJson(result).error).toMatch(/empty/i);
     expect(mockGetByUsername).not.toHaveBeenCalled();
-    expect(mockPostUsers).not.toHaveBeenCalled();
-  });
-
-  it('treats a POST response without a username as an error', async () => {
-    mockPostUsers.mockResolvedValueOnce({ data: { status: 'error', message: 'something' } });
-
-    const result = await handlers.get('claim_lightning_address')!({ username: 'alice' });
-
-    expect(result.isError).toBe(true);
-    expect(parseToolJson(result).error).toMatch(/unable to claim/i);
-    expect(deps.showSuccessToast).not.toHaveBeenCalled();
-  });
-
-  it('surfaces a layerz.me POST failure as an MCP error (not a throw)', async () => {
-    mockPostUsers.mockRejectedValueOnce(new Error('layerz.me unavailable'));
-
-    const result = await handlers.get('claim_lightning_address')!({ username: 'alice' });
-
-    expect(result.isError).toBe(true);
-    expect(parseToolJson(result).error).toMatch(/layerz\.me unavailable/i);
     expect(deps.showSuccessToast).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> POS scan payloads now require a Lightning refund address tied to the payer’s Layerz address; a wrong or missing resolution could break merchant payments or misroute refunds.
> 
> **Overview**
> Introduces **`shared/modules/layerz-lightning-address`** so layerz.me username lookup, claiming, formatting, and resolution live in one place instead of duplicated OpenAPI clients across desktop, mobile, and MCP.
> 
> **Receive / claim UX** on desktop and mobile now uses `formatLayerzLightningAddress`, `lookupLayerzLightningAddress`, and `claimLayerzLightningAddressUsername` (with shared `LAYERZ_ME_DOMAIN`). MCP `get_lightning_address` / `claim_lightning_address` delegate to the same helpers; detailed behavior is covered by new Vitest tests on the module, with slimmer MCP wiring tests.
> 
> **POS (CryptoQR) scans** now send a required **`refund_address`** on `ScanRequest` (`address_type: 'lightning'`, address from `resolveLayerzLightningAddress` after loading the wallet Spark address). `merchants.ts` types reflect the scanner swagger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aed73b6a3b834768d1213c1c1bd9bfeb33b1001a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->