### PR TITLE
build: macos codesign

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,16 @@ jobs:
         working-directory: desktop
         run: bun install --frozen-lockfile
 
+      # Imports the Developer ID Application cert (.p12) into a temporary keychain so
+      # `codesign --sign "$ELECTROBUN_DEVELOPER_ID"` can resolve the identity. Skipped when
+      # the secret is absent so forks/unconfigured repos still produce unsigned builds.
+      - name: Import code signing certificate
+        if: ${{ secrets.MACOS_CERTIFICATE_BASE64 != '' }}
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+          p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+
       # notarytool needs the App Store Connect API key as a file on disk. Written to $HOME
       # (not the configured `~/AuthKey.p8` literal) because Electrobun checks the path with
       # existsSync, which does not expand `~`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,9 @@ jobs:
       ELECTROBUN_TEAMID: ${{ secrets.ELECTROBUN_TEAMID }}
       ELECTROBUN_APPLEAPIKEY: ${{ secrets.ELECTROBUN_APPLEAPIKEY }}
       ELECTROBUN_APPLEAPIISSUER: ${{ secrets.ELECTROBUN_APPLEAPIISSUER }}
-      # `secrets` is not usable in step-level `if`, so surface cert presence as an env flag.
+      # `secrets` is not usable in step-level `if`, so surface secret presence as env flags.
       HAS_CODESIGN_CERT: ${{ secrets.MACOS_CERTIFICATE_BASE64 != '' }}
+      HAS_NOTARY_KEY: ${{ secrets.AUTHKEY_P8 != '' }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -112,6 +113,7 @@ jobs:
       # (not the configured `~/AuthKey.p8` literal) because Electrobun checks the path with
       # existsSync, which does not expand `~`.
       - name: Write App Store Connect API key
+        if: ${{ env.HAS_NOTARY_KEY == 'true' }}
         run: |
           echo "${{ secrets.AUTHKEY_P8 }}" > "$HOME/AuthKey.p8"
           chmod 600 "$HOME/AuthKey.p8"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,8 @@ jobs:
 
   # Electrobun always builds for the host platform/arch, so we need one runner per target OS.
   # `bun run build` => `vite build && electrobun build --env=stable`; the distributable output
-  # lands in desktop/artifacts/ (flat, {channel}-{os}-{arch}- prefixed). The mac config sets
-  # neither codesign nor notarize, so unsigned stable builds succeed without Apple credentials.
+  # lands in desktop/artifacts/ (flat, {channel}-{os}-{arch}- prefixed). The mac config enables
+  # codesign/notarize only when the ELECTROBUN_* Apple credentials are present in the env.
   # Electrobun builds for the host arch only, so each macOS arch needs its own runner.
   # Both pin macOS 15 (avoids macos-latest drift): macos-15 = arm64, macos-15-intel = x64
   # (the last Intel image GitHub offers, supported until ~Aug 2027).
@@ -73,6 +73,11 @@ jobs:
       EXPO_PUBLIC_BREEZ_API_KEY: ${{ secrets.EXPO_PUBLIC_BREEZ_API_KEY }}
       EXPO_PUBLIC_GARDEN_APP_ID: ${{ secrets.EXPO_PUBLIC_GARDEN_APP_ID }}
       EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
+      # Apple code signing + notarization (https://framework.blackboard.sh/electrobun/guides/code-signing/)
+      ELECTROBUN_DEVELOPER_ID: ${{ secrets.ELECTROBUN_DEVELOPER_ID }}
+      ELECTROBUN_TEAMID: ${{ secrets.ELECTROBUN_TEAMID }}
+      ELECTROBUN_APPLEAPIKEY: ${{ secrets.ELECTROBUN_APPLEAPIKEY }}
+      ELECTROBUN_APPLEAPIISSUER: ${{ secrets.ELECTROBUN_APPLEAPIISSUER }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -91,9 +96,22 @@ jobs:
         working-directory: desktop
         run: bun install --frozen-lockfile
 
+      # notarytool needs the App Store Connect API key as a file on disk. Written to $HOME
+      # (not the configured `~/AuthKey.p8` literal) because Electrobun checks the path with
+      # existsSync, which does not expand `~`.
+      - name: Write App Store Connect API key
+        run: |
+          echo "${{ secrets.AUTHKEY_P8 }}" > "$HOME/AuthKey.p8"
+          chmod 600 "$HOME/AuthKey.p8"
+          echo "ELECTROBUN_APPLEAPIKEYPATH=$HOME/AuthKey.p8" >> "$GITHUB_ENV"
+
       - name: Build
         working-directory: desktop
         run: bun run build
+
+      - name: Cleanup App Store Connect API key
+        if: always()
+        run: rm -f "$HOME/AuthKey.p8"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,8 @@ jobs:
       ELECTROBUN_TEAMID: ${{ secrets.ELECTROBUN_TEAMID }}
       ELECTROBUN_APPLEAPIKEY: ${{ secrets.ELECTROBUN_APPLEAPIKEY }}
       ELECTROBUN_APPLEAPIISSUER: ${{ secrets.ELECTROBUN_APPLEAPIISSUER }}
+      # `secrets` is not usable in step-level `if`, so surface cert presence as an env flag.
+      HAS_CODESIGN_CERT: ${{ secrets.MACOS_CERTIFICATE_BASE64 != '' }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -100,7 +102,7 @@ jobs:
       # `codesign --sign "$ELECTROBUN_DEVELOPER_ID"` can resolve the identity. Skipped when
       # the secret is absent so forks/unconfigured repos still produce unsigned builds.
       - name: Import code signing certificate
-        if: ${{ secrets.MACOS_CERTIFICATE_BASE64 != '' }}
+        if: ${{ env.HAS_CODESIGN_CERT == 'true' }}
         uses: apple-actions/import-codesign-certs@v3
         with:
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}

--- a/desktop/electrobun.config.ts
+++ b/desktop/electrobun.config.ts
@@ -27,6 +27,12 @@ export default {
       bundleCEF: false,
       // Same Icon Composer asset as mobile iOS (see mobile/app.json).
       icons: '../mobile/assets/appicon.icon',
+      // Signing needs ELECTROBUN_DEVELOPER_ID (+ cert in keychain), notarization needs
+      // ELECTROBUN_APPLEAPIKEYPATH/ELECTROBUN_APPLEAPIKEY/ELECTROBUN_APPLEAPIISSUER.
+      // Gated on env so local/unconfigured builds stay unsigned instead of failing.
+      // Wired up in .github/workflows/build.yml; see https://framework.blackboard.sh/electrobun/guides/code-signing/
+      codesign: !!process.env.ELECTROBUN_DEVELOPER_ID,
+      notarize: !!process.env.ELECTROBUN_APPLEAPIKEYPATH,
     },
     linux: {
       // WebKitGTK is weak for WASM-heavy wallet UI; CEF is recommended on Linux.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches release pipeline and handling of signing certificates/API keys; behavior is gated on secrets but misconfiguration could break macOS desktop builds or leak credentials if cleanup failed.
> 
> **Overview**
> **macOS desktop CI** can now produce **signed and notarized** Electrobun artifacts when Apple secrets are configured, while forks and repos without credentials still get **unsigned** builds.
> 
> The `desktop-build-macos` job wires in `ELECTROBUN_*` signing/notary env vars, uses `HAS_CODESIGN_CERT` / `HAS_NOTARY_KEY` flags (because `secrets` cannot drive step `if`), conditionally imports the `.p12` via `apple-actions/import-codesign-certs`, writes the App Store Connect API key to `$HOME/AuthKey.p8` (not `~/…` because Electrobun uses `existsSync`), and always removes that key after the build.
> 
> In `desktop/electrobun.config.ts`, **`codesign`** and **`notarize`** are turned on only when `ELECTROBUN_DEVELOPER_ID` and `ELECTROBUN_APPLEAPIKEYPATH` are set, replacing the previous always-unsigned mac behavior described in workflow comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b5499c5ade1b34540f4e6a19acca17e4d62bfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->