### PR TITLE
Fix arkade

### DIFF
--- a/desktop/bun.lock
+++ b/desktop/bun.lock
@@ -6,8 +6,8 @@
       "name": "layerzwallet-desktop",
       "dependencies": {
         "@aptabase/web": "^0.5.0",
-        "@arkade-os/boltz-swap": "0.3.44",
-        "@arkade-os/sdk": "0.4.39",
+        "@arkade-os/boltz-swap": "0.3.47",
+        "@arkade-os/sdk": "0.4.42",
         "@atomiqlabs/chain-evm": "2.4.5",
         "@atomiqlabs/sdk": "8.8.4",
         "@bitcoinerlab/secp256k1": "1.2.0",
@@ -85,9 +85,9 @@
 
     "@aptabase/web": ["@aptabase/web@0.5.0", "", {}, "sha512-+RFdaS0bLJtqTZyB1uG32S7tuTfJTGbG2bkdVMs3AT7yG7DP2yb6JY5rZoBf3UyW9sigFHGRkbXoAXdCMZibWA=="],
 
-    "@arkade-os/boltz-swap": ["@arkade-os/boltz-swap@0.3.44", "", { "dependencies": { "@arkade-os/sdk": "0.4.39", "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0", "@scure/btc-signer": "2.0.1", "bip68": "1.0.4", "light-bolt11-decoder": "3.2.0" }, "peerDependencies": { "expo-background-task": ">=0.1.0", "expo-task-manager": ">=3.0.0" }, "optionalPeers": ["expo-background-task", "expo-task-manager"] }, "sha512-18Vsgv286hsbrp/ICdAlP0XkVQBxcVh6KV3BC+MgD90+9S4GpogFO9Tlb35jpkDYbYLjyPa7quscMOE79Ff1CA=="],
+    "@arkade-os/boltz-swap": ["@arkade-os/boltz-swap@0.3.47", "", { "dependencies": { "@arkade-os/sdk": "0.4.42", "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0", "@scure/btc-signer": "2.0.1", "bip68": "1.0.4", "light-bolt11-decoder": "3.2.0" }, "peerDependencies": { "expo-background-task": ">=0.1.0", "expo-task-manager": ">=3.0.0" }, "optionalPeers": ["expo-background-task", "expo-task-manager"] }, "sha512-Q9BpIhZNLc2MLRua4LhzbhUIQavUtqt4WSVxfr1or7q0gjcqWlZGF5W0ONYJFMq/JWOSUiHsnoiLihvX6Vl7rQ=="],
 
-    "@arkade-os/sdk": ["@arkade-os/sdk@0.4.39", "", { "dependencies": { "@bitcoinerlab/descriptors-scure": "3.1.7", "@marcbachmann/cel-js": "7.3.1", "@noble/curves": "2.0.1", "@noble/secp256k1": "3.0.0", "@scure/base": "2.0.0", "@scure/bip39": "2.0.1", "@scure/btc-signer": "2.0.1", "bip68": "1.0.4", "ws-electrumx-client": "1.0.5" }, "peerDependencies": { "@react-native-async-storage/async-storage": ">=1.0.0", "expo": ">=54.0.0", "expo-background-task": "~1.0.10 || >=55.0.0", "expo-sqlite": "~16.0.10 || >=55.0.0", "expo-task-manager": "~14.0.9 || >=55.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo", "expo-background-task", "expo-sqlite", "expo-task-manager"] }, "sha512-Pmj1NMKK6eV9z+XGUs+S0zK14MFnasfLxmmSYhcG9A0dn/d8KLSMxhpxHc6d6mNTpAiVEzS4u/VvSngYbtUgbA=="],
+    "@arkade-os/sdk": ["@arkade-os/sdk@0.4.42", "", { "dependencies": { "@bitcoinerlab/descriptors-scure": "3.1.7", "@marcbachmann/cel-js": "7.3.1", "@noble/curves": "2.0.1", "@noble/secp256k1": "3.0.0", "@scure/base": "2.0.0", "@scure/bip39": "2.0.1", "@scure/btc-signer": "2.0.1", "bip68": "1.0.4", "ws-electrumx-client": "1.0.5" }, "peerDependencies": { "@react-native-async-storage/async-storage": ">=1.0.0", "expo": ">=54.0.0", "expo-background-task": "~1.0.10 || >=55.0.0", "expo-sqlite": "~16.0.10 || >=55.0.0", "expo-task-manager": "~14.0.9 || >=55.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo", "expo-background-task", "expo-sqlite", "expo-task-manager"] }, "sha512-yv9v4IRGV5n2wQSAocZwn8owwJ7rghcLZd/7F5X8EcaYa4DknWSMa0iRAvT62Nc2k440sk0XILw3Z5wICdYT6w=="],
 
     "@atomiqlabs/base": ["@atomiqlabs/base@13.5.2", "", { "dependencies": { "buffer": "6.0.3" } }, "sha512-+lhUWntOjbeqVDsWhz8j5FmPNVJr0WcOqACNci6XF8PrYzgdrt/tBGWWkYs03HlIldKwX3463rzN23ByQVAq0Q=="],
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@aptabase/web": "^0.5.0",
-    "@arkade-os/boltz-swap": "0.3.44",
-    "@arkade-os/sdk": "0.4.39",
+    "@arkade-os/boltz-swap": "0.3.47",
+    "@arkade-os/sdk": "0.4.42",
     "@atomiqlabs/chain-evm": "2.4.5",
     "@atomiqlabs/sdk": "8.8.4",
     "@bitcoinerlab/secp256k1": "1.2.0",

--- a/ext/package-lock.json
+++ b/ext/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.6.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.3.44",
-        "@arkade-os/sdk": "0.4.39",
+        "@arkade-os/boltz-swap": "0.3.47",
+        "@arkade-os/sdk": "0.4.42",
         "@atomiqlabs/chain-evm": "2.4.5",
         "@atomiqlabs/sdk": "8.8.4",
         "@bitcoinerlab/secp256k1": "1.2.0",
@@ -109,12 +109,12 @@
       "license": "MIT"
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.3.44",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.3.44.tgz",
-      "integrity": "sha512-18Vsgv286hsbrp/ICdAlP0XkVQBxcVh6KV3BC+MgD90+9S4GpogFO9Tlb35jpkDYbYLjyPa7quscMOE79Ff1CA==",
+      "version": "0.3.47",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.3.47.tgz",
+      "integrity": "sha512-Q9BpIhZNLc2MLRua4LhzbhUIQavUtqt4WSVxfr1or7q0gjcqWlZGF5W0ONYJFMq/JWOSUiHsnoiLihvX6Vl7rQ==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.4.39",
+        "@arkade-os/sdk": "0.4.42",
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.4.39",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.4.39.tgz",
-      "integrity": "sha512-Pmj1NMKK6eV9z+XGUs+S0zK14MFnasfLxmmSYhcG9A0dn/d8KLSMxhpxHc6d6mNTpAiVEzS4u/VvSngYbtUgbA==",
+      "version": "0.4.42",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.4.42.tgz",
+      "integrity": "sha512-yv9v4IRGV5n2wQSAocZwn8owwJ7rghcLZd/7F5X8EcaYa4DknWSMa0iRAvT62Nc2k440sk0XILw3Z5wICdYT6w==",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors-scure": "3.1.7",

--- a/ext/package.json
+++ b/ext/package.json
@@ -21,8 +21,8 @@
     "prepare": "cd .. && husky ext/.husky"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.3.44",
-    "@arkade-os/sdk": "0.4.39",
+    "@arkade-os/boltz-swap": "0.3.47",
+    "@arkade-os/sdk": "0.4.42",
     "@atomiqlabs/chain-evm": "2.4.5",
     "@atomiqlabs/sdk": "8.8.4",
     "@bitcoinerlab/secp256k1": "1.2.0",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@aptabase/react-native": "^0.4.0",
-        "@arkade-os/boltz-swap": "0.3.44",
-        "@arkade-os/sdk": "0.4.39",
+        "@arkade-os/boltz-swap": "0.3.47",
+        "@arkade-os/sdk": "0.4.42",
         "@atomiqlabs/chain-evm": "2.4.5",
         "@atomiqlabs/sdk": "8.8.4",
         "@bitcoinerlab/secp256k1": "1.2.0",
@@ -164,12 +164,12 @@
       }
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.3.44",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.3.44.tgz",
-      "integrity": "sha512-18Vsgv286hsbrp/ICdAlP0XkVQBxcVh6KV3BC+MgD90+9S4GpogFO9Tlb35jpkDYbYLjyPa7quscMOE79Ff1CA==",
+      "version": "0.3.47",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.3.47.tgz",
+      "integrity": "sha512-Q9BpIhZNLc2MLRua4LhzbhUIQavUtqt4WSVxfr1or7q0gjcqWlZGF5W0ONYJFMq/JWOSUiHsnoiLihvX6Vl7rQ==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.4.39",
+        "@arkade-os/sdk": "0.4.42",
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.4.39",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.4.39.tgz",
-      "integrity": "sha512-Pmj1NMKK6eV9z+XGUs+S0zK14MFnasfLxmmSYhcG9A0dn/d8KLSMxhpxHc6d6mNTpAiVEzS4u/VvSngYbtUgbA==",
+      "version": "0.4.42",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.4.42.tgz",
+      "integrity": "sha512-yv9v4IRGV5n2wQSAocZwn8owwJ7rghcLZd/7F5X8EcaYa4DknWSMa0iRAvT62Nc2k440sk0XILw3Z5wICdYT6w==",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors-scure": "3.1.7",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "@aptabase/react-native": "^0.4.0",
-    "@arkade-os/boltz-swap": "0.3.44",
-    "@arkade-os/sdk": "0.4.39",
+    "@arkade-os/boltz-swap": "0.3.47",
+    "@arkade-os/sdk": "0.4.42",
     "@atomiqlabs/chain-evm": "2.4.5",
     "@atomiqlabs/sdk": "8.8.4",
     "@bitcoinerlab/secp256k1": "1.2.0",

--- a/shared/class/wallets/ark-wallet.ts
+++ b/shared/class/wallets/ark-wallet.ts
@@ -458,7 +458,6 @@ export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLigh
   private _wallet: Wallet | undefined = undefined;
   private _arkadeLightning: ArkadeSwaps | undefined = undefined;
   private _arkServerUrl: string = 'https://mutinynet.arkade.sh';
-  private _arkServerPublicKey: string = '03fa73c6e4876ffb2dfc961d763cca9abc73d4b88efcb8f5e7ff92dc55e9aa553d';
   private _boltzApiUrl: string = '';
   protected _accountNumber: number = 0;
   private _manager: VtxoManager | undefined = undefined;
@@ -478,11 +477,6 @@ export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLigh
   setBoltzApiUrl(url: string) {
     assert(!this._arkadeLightning, 'Already initialized');
     this._boltzApiUrl = url;
-  }
-
-  setArkServerPublicKey(key: string) {
-    assert(!this._wallet, 'Wallet already initialized');
-    this._arkServerPublicKey = key;
   }
 
   _getIdentity() {
@@ -542,12 +536,40 @@ export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLigh
     try {
       await this._wallet.restore();
       const report = await this._manager.migrateDeprecatedSignerVtxos();
-      if (report.vtxos?.txid || report.boarding?.txid) {
+      if (report.rotated || report.vtxos?.txid || report.boarding?.txid) {
         console.log('ARK deprecated-signer migration:', report);
       }
+      await this._resyncIfDeprecatedSignerContracts();
     } catch (error) {
       globalThis.handleError?.(error, 'ark-wallet.ts');
       console.log('ARK deprecated-signer migration error:', error);
+    }
+  }
+
+  /** Drop the incremental sync cursor when this wallet still has contracts under a deprecated server signer. */
+  private async _resyncIfDeprecatedSignerContracts(): Promise<void> {
+    assert(this._wallet, 'Ark wallet not initialized');
+
+    const info = await this._wallet.arkProvider.getInfo();
+    if (!info.deprecatedSigners?.length) return;
+
+    const deprecatedKeys = new Set(
+      info.deprecatedSigners.map((s) => {
+        const hex = s.pubkey.toLowerCase();
+        return hex.length === 66 ? hex.slice(2) : hex;
+      })
+    );
+
+    const contracts = await (await this._wallet.getContractManager()).getContracts({});
+    const hasDeprecatedContract = contracts.some((c) => {
+      const pk = c.params?.serverPubKey;
+      if (typeof pk !== 'string') return false;
+      const hex = pk.toLowerCase();
+      return deprecatedKeys.has(hex.length === 66 ? hex.slice(2) : hex);
+    });
+
+    if (hasDeprecatedContract) {
+      await this._wallet.clearSyncCursor();
     }
   }
 

--- a/shared/class/wallets/ark-wallet.ts
+++ b/shared/class/wallets/ark-wallet.ts
@@ -539,37 +539,45 @@ export class ArkWallet extends AbstractHDElectrumWallet implements InterfaceLigh
       if (report.rotated || report.vtxos?.txid || report.boarding?.txid) {
         console.log('ARK deprecated-signer migration:', report);
       }
-      await this._resyncIfDeprecatedSignerContracts();
     } catch (error) {
       globalThis.handleError?.(error, 'ark-wallet.ts');
       console.log('ARK deprecated-signer migration error:', error);
     }
+
+    // Runs regardless of migration success: a failed/partial migration is exactly
+    // when the wallet is most likely to still hold funds under a rotated signer.
+    await this._resyncIfDeprecatedSignerContracts();
   }
 
-  /** Drop the incremental sync cursor when this wallet still has contracts under a deprecated server signer. */
+  /** Drop the incremental sync cursor when this wallet still has active contracts under a deprecated server signer. */
   private async _resyncIfDeprecatedSignerContracts(): Promise<void> {
     assert(this._wallet, 'Ark wallet not initialized');
 
-    const info = await this._wallet.arkProvider.getInfo();
-    if (!info.deprecatedSigners?.length) return;
+    try {
+      const info = await this._wallet.arkProvider.getInfo();
+      if (!info.deprecatedSigners?.length) return;
 
-    const deprecatedKeys = new Set(
-      info.deprecatedSigners.map((s) => {
-        const hex = s.pubkey.toLowerCase();
+      const normalizeKey = (pubkey: string) => {
+        const hex = pubkey.toLowerCase();
         return hex.length === 66 ? hex.slice(2) : hex;
-      })
-    );
+      };
 
-    const contracts = await (await this._wallet.getContractManager()).getContracts({});
-    const hasDeprecatedContract = contracts.some((c) => {
-      const pk = c.params?.serverPubKey;
-      if (typeof pk !== 'string') return false;
-      const hex = pk.toLowerCase();
-      return deprecatedKeys.has(hex.length === 66 ? hex.slice(2) : hex);
-    });
+      const deprecatedKeys = new Set(info.deprecatedSigners.map((s) => normalizeKey(s.pubkey)));
 
-    if (hasDeprecatedContract) {
-      await this._wallet.clearSyncCursor();
+      // Only active contracts can still hold spendable funds; inactive/completed
+      // ones lingering in storage must not force a re-bootstrap on every init.
+      const contracts = await (await this._wallet.getContractManager()).getContracts({ state: 'active' });
+      const hasDeprecatedContract = contracts.some((c) => {
+        const pk = c.params?.serverPubKey;
+        return typeof pk === 'string' && deprecatedKeys.has(normalizeKey(pk));
+      });
+
+      if (hasDeprecatedContract) {
+        await this._wallet.clearSyncCursor();
+      }
+    } catch (error) {
+      globalThis.handleError?.(error, 'ark-wallet.ts');
+      console.log('ARK deprecated-signer resync check error:', error);
     }
   }
 

--- a/shared/modules/wallet-utils.ts
+++ b/shared/modules/wallet-utils.ts
@@ -184,7 +184,6 @@ export async function lazyInitWallet(network: TSupportedLazyInitWalletNetworks, 
       aw.setSecret(masterSeed);
       aw.setAccountNumber(accountNumber);
       aw.setArkServerUrl('https://arkade.computer');
-      aw.setArkServerPublicKey('022b74c2011af089c849383ee527c72325de52df6a788428b68d49e9174053aaba');
       aw.setBoltzApiUrl('https://api.ark.boltz.exchange');
       await aw.init(storage);
       await aw.initLightningSwaps();

--- a/shared/tests/integration-vi/ark-wallet.test.ts
+++ b/shared/tests/integration-vi/ark-wallet.test.ts
@@ -1,22 +1,26 @@
 import assert from 'assert';
-import { test } from 'vitest';
+import { beforeEach, test } from 'vitest';
 import { ArkWallet } from '../../class/wallets/ark-wallet';
 import { IStorage } from '../../types/IStorage';
-import fs from 'fs';
 
+// In-memory storage — do not persist under /tmp; stale VTXO caches survive CI/local
+// reruns and block incremental sync after Arkade server signer rotation.
+const storageCache: Record<string, string> = {};
 const storageMock: IStorage = {
   async setItem(key: string, value: string) {
-    fs.writeFileSync('/tmp/ark-swap-storage' + key, value);
+    storageCache[key] = value;
   },
 
   async getItem(key: string) {
-    try {
-      return fs.readFileSync('/tmp/ark-swap-storage' + key).toString('utf8');
-    } catch {
-      return '';
-    }
+    return storageCache[key] ?? '';
   },
 };
+
+beforeEach(() => {
+  for (const key of Object.keys(storageCache)) {
+    delete storageCache[key];
+  }
+});
 
 test.skip('ark mutinynet can check balance', async (context) => {
   if (!process.env.TEST_MNEMONIC) {
@@ -44,7 +48,6 @@ test('ark mainnet can check balance', async (context) => {
   const w = new ArkWallet();
   w.setSecret(process.env.TEST_MNEMONIC);
   w.setArkServerUrl('https://arkade.computer');
-  w.setArkServerPublicKey('022b74c2011af089c849383ee527c72325de52df6a788428b68d49e9174053aaba');
   w.setBoltzApiUrl('https://api.ark.boltz.exchange');
   await w.init(storageMock);
 
@@ -64,7 +67,6 @@ test.skip('ark mainnet can check if our invoice is paid', async (context) => {
   const w = new ArkWallet();
   w.setSecret(process.env.TEST_MNEMONIC);
   w.setArkServerUrl('https://arkade.computer');
-  w.setArkServerPublicKey('022b74c2011af089c849383ee527c72325de52df6a788428b68d49e9174053aaba');
   w.setBoltzApiUrl('https://api.ark.boltz.exchange');
   await w.init(storageMock);
 
@@ -89,7 +91,6 @@ test('ark mainnet switch accounts', async (context) => {
   const w = new ArkWallet();
   w.setSecret(process.env.TEST_MNEMONIC);
   w.setArkServerUrl('https://arkade.computer');
-  w.setArkServerPublicKey('022b74c2011af089c849383ee527c72325de52df6a788428b68d49e9174053aaba');
   w.setBoltzApiUrl('https://api.ark.boltz.exchange');
   await w.init(storageMock);
 
@@ -119,7 +120,6 @@ test.skip('ark mainnet can create lightning invoice', async (context) => {
   const w = new ArkWallet();
   w.setSecret(process.env.TEST_MNEMONIC);
   w.setArkServerUrl('https://arkade.computer');
-  w.setArkServerPublicKey('022b74c2011af089c849383ee527c72325de52df6a788428b68d49e9174053aaba');
   w.setBoltzApiUrl('https://api.ark.boltz.exchange');
 
   await w.init(storageMock);
@@ -141,7 +141,6 @@ test.skip('ark mainnet can pay lightning invoice', async (context) => {
   const w = new ArkWallet();
   w.setSecret(process.env.TEST_MNEMONIC);
   w.setArkServerUrl('https://arkade.computer');
-  w.setArkServerPublicKey('022b74c2011af089c849383ee527c72325de52df6a788428b68d49e9174053aaba');
   w.setBoltzApiUrl('https://api.ark.boltz.exchange');
   await w.init(storageMock);
 

--- a/shared/tests/unit-vi/ark-wallet.test.ts
+++ b/shared/tests/unit-vi/ark-wallet.test.ts
@@ -128,7 +128,6 @@ test('ark mainnet can getCommonTransactions', async (context) => {
   const w = new ArkWallet();
   w.setSecret(process.env.TEST_MNEMONIC);
   w.setArkServerUrl('https://arkade.computer');
-  w.setArkServerPublicKey('022b74c2011af089c849383ee527c72325de52df6a788428b68d49e9174053aaba');
   w.setBoltzApiUrl('https://api.ark.boltz.exchange');
   await w.init(storageMock);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Ark off-chain balance sync and signer-migration paths where incorrect cursor clearing could cause extra indexer load or missed edge cases, but scope is limited to deprecated-signer recovery and dependency bumps.
> 
> **Overview**
> Bumps **`@arkade-os/sdk`** (0.4.39 → 0.4.42) and **`@arkade-os/boltz-swap`** (0.3.44 → 0.3.47) across desktop, extension, and mobile, and drops the hardcoded Ark server public key (`setArkServerPublicKey` / mainnet wiring) so trust comes from the updated SDK/server flow.
> 
> **`ArkWallet`** now runs **`_resyncIfDeprecatedSignerContracts`** after deprecated-signer migration: if the Ark provider reports rotated signers and the wallet still has **active** contracts tied to those keys, it clears the incremental sync cursor so the next sync can re-bootstrap and surface funds correctly. Migration logging also treats **`report.rotated`** as a signal to log.
> 
> Integration tests switch Ark storage to an in-memory mock cleared in **`beforeEach`** instead of persisting under `/tmp`, avoiding stale VTXO caches across runs after signer rotation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af40c48a239b61d3def322de082a2187db9cd952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->