### PR TITLE
fix: prevent zero-fee btc estimate

### DIFF
--- a/shared/blue_modules/BlueElectrum.ts
+++ b/shared/blue_modules/BlueElectrum.ts
@@ -895,7 +895,9 @@ export const estimateFee = async function (numberOfBlocks: number): Promise<numb
   numberOfBlocks = numberOfBlocks || 1;
   const coinUnitsPerKilobyte = await mainClient.blockchainEstimatefee(numberOfBlocks);
   if (coinUnitsPerKilobyte === -1) return 1;
-  return Math.round(new BigNumber(coinUnitsPerKilobyte).dividedBy(1024).multipliedBy(100000000).toNumber());
+  // ceil (not round) so a sub-1 sat/vB estimate never floors to 0, which would build an
+  // unbroadcastable (below min-relay-fee) transaction when the mempool is near-empty
+  return Math.ceil(new BigNumber(coinUnitsPerKilobyte).dividedBy(1024).multipliedBy(100000000).toNumber());
 };
 
 export const serverFeatures = async function () {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line rounding change in fee estimation with clear intent; no auth or data-model impact, though fee UX may show 1 sat/vB slightly more often when estimates are fractional.
> 
> **Overview**
> **Electrum fee conversion** in `estimateFee` now uses **`Math.ceil`** instead of **`Math.round`** when turning `blockchain.estimatefee` (coin per KB) into satoshis per virtual byte.
> 
> When the mempool is nearly empty, the raw estimate can be **below 1 sat/vB**; rounding could produce **0**, which leads to transactions **below the minimum relay fee** and failed broadcasts. Ceil guarantees at least **1 sat/vB** in those edge cases (the existing `-1` server response still returns `1` unchanged).
> 
> This path feeds **`estimateFees`** and BTC send flows that load network fee presets from Electrum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897672381fe011fac28a8c89d9be2327d09edc7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->